### PR TITLE
Adjust portal and navbar logo sizing on mobile logins

### DIFF
--- a/public/css/app-shell.css
+++ b/public/css/app-shell.css
@@ -103,6 +103,17 @@ body{
   font-size: clamp(.95rem, 3.4vw, 1.15rem);
 }
 
+@media (max-width: 768px){
+  .portal-logo,
+  .navbar-brand img{
+    max-height:48px;
+    height:auto;
+    display:block;
+    margin:0 auto;
+    width:auto;
+  }
+}
+
 /* cartão de login */
 .login-card{
   margin: clamp(12px, 3vw, 24px) auto;

--- a/public/js/mobile-adapter.js
+++ b/public/js/mobile-adapter.js
@@ -139,7 +139,7 @@ function compatLoginBrandAndHero() {
   }
 
   // 2) Hero/Logo central — reduz a logo “grande”
-  const heroLogo = document.querySelector('.login-hero img, .hero img, .banner img');
+  const heroLogo = document.querySelector('.login-hero img, .hero img, .banner img, .portal-logo');
   if (heroLogo && !heroLogo.classList.contains('hero-logo')) {
     heroLogo.classList.add('hero-logo');
   }


### PR DESCRIPTION
## Summary
- include `.portal-logo` in mobile hero/logo detection so portal logos shrink appropriately
- constrain portal and navbar logos to ~48px height on mobile and center them

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689e1c47c0708333847d024e620f5117