### PR TITLE
feat: responsividade da logo

### DIFF
--- a/public/admin/login.html
+++ b/public/admin/login.html
@@ -43,7 +43,7 @@
       background-position: center;
       padding: 4rem 1rem;
     }
-    .portal-logo { max-width: 400px; height: auto; display: block; margin: 0 auto; }
+    .portal-logo { max-width: 420px; height: auto; display: block; margin: 0 auto; }
     .login-card {
       background-color: white; color: var(--cor-texto); border-radius: var(--raio-borda);
       box-shadow: 0 0.5rem 1.5rem rgba(0,0,0,0.2); padding: 2.5rem; width: 100%; max-width: 420px;

--- a/public/css/app-shell.css
+++ b/public/css/app-shell.css
@@ -105,11 +105,12 @@ body{
 
 @media (max-width: 768px){
   .portal-logo,
-  .navbar-brand img{
-    height: clamp(56px, 18vw, 96px);
-    display:block;
-    margin:0 auto;
-    width:auto;
+  .navbar-brand img {
+    width: 100%;
+    max-width: 420px; /* mesma largura máxima do box de login */
+    height: auto;
+    display: block;
+    margin: 0 auto;
   }
 }
 

--- a/public/eventos/login-eventos.html
+++ b/public/eventos/login-eventos.html
@@ -25,7 +25,7 @@
     .navbar > .container { justify-content: center !important; }
     .navbar-brand img { filter: brightness(0) invert(1); max-width: 602px; height: 55px; object-fit: contain; }
     .main-container { flex-grow: 1; display: flex; align-items: center; background-image: linear-gradient(rgba(0, 0, 0, 0.45), rgba(0, 0, 0, 0.45)), url('/images/background-login.jpg'); background-size: cover; background-position: center; padding: 4rem 1rem; }
-    .portal-logo { max-width: 400px; height: auto; display: block; margin: 0 auto; }
+    .portal-logo { max-width: 420px; height: auto; display: block; margin: 0 auto; }
     .login-card { background-color: white; color: var(--cor-texto); border-radius: var(--raio-borda); box-shadow: 0 0.5rem 1.5rem rgba(0,0,0,0.2); padding: 2.5rem; width: 100%; max-width: 420px; }
     .btn-primary { background-color: var(--cor-primaria); border-color: var(--cor-primaria); border-radius: var(--raio-borda); }
     /* Ajustes para o botão dentro do input */

--- a/public/login.html
+++ b/public/login.html
@@ -44,7 +44,7 @@
       padding: 4rem 1rem;
     }
     .portal-logo {
-      max-width: 400px;
+      max-width: 420px;
       height: auto;
       display: block;
       margin: 0 auto;


### PR DESCRIPTION
## Summary
- garante que a logo seja exibida com largura máxima de 420px em telas menores
- alinha estilos inline das páginas de login com a regra global

## Testing
- `npm test` *(erro: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689e281286088333816784dd9fb4464e