### PR TITLE
Add billing phone to permissionário admin endpoints and UI

### DIFF
--- a/public/admin/permissionario-form.html
+++ b/public/admin/permissionario-form.html
@@ -108,6 +108,10 @@
                                     <input type="text" readonly class="form-control" id="telefone">
                                 </div>
                                 <div class="col-md-6 mb-3">
+                                    <label for="telefone_cobranca" class="form-label">Telefone Cobrança</label>
+                                    <input type="text" readonly class="form-control" id="telefone_cobranca">
+                                </div>
+                                <div class="col-md-6 mb-3">
                                     <label for="numero_sala" class="form-label">Sala(s)</label>
                                     <input type="text" readonly class="form-control" id="numero_sala" required>
                                 </div>
@@ -215,6 +219,12 @@
                 { mask: '(00) 0 0000-0000' }
             ]
         });
+        IMask(document.getElementById('telefone_cobranca'), {
+            mask: [
+                { mask: '(00) 0000-0000' },
+                { mask: '(00) 0 0000-0000' }
+            ]
+        });
 
         if (isEditMode) {
             pageTitle.innerText = 'Editar Permissionário - Painel de Gestão';
@@ -233,6 +243,7 @@
                 document.getElementById('cnpj').value = formatarCNPJ(data.cnpj);
                 document.getElementById('email').value = data.email;
                 document.getElementById('telefone').value = data.telefone || '';
+                document.getElementById('telefone_cobranca').value = data.telefone_cobranca || '';
                 document.getElementById('numero_sala').value = data.numero_sala;
                 document.getElementById('valor_aluguel').value = data.valor_aluguel;
                 toggleEditMode(false);
@@ -264,6 +275,7 @@
                 cnpj: document.getElementById('cnpj').value,
                 email: document.getElementById('email').value,
                 telefone: document.getElementById('telefone').value,
+                telefone_cobranca: document.getElementById('telefone_cobranca').value,
                 numero_sala: document.getElementById('numero_sala').value,
                 valor_aluguel: parseFloat(document.getElementById('valor_aluguel').value)
             };

--- a/public/admin/permissionarios.html
+++ b/public/admin/permissionarios.html
@@ -110,7 +110,7 @@
                             <table class="table table-hover align-middle">
                                 <thead>
                                     <tr>
-                                        <th>Nome da Empresa</th><th>CNPJ</th><th>E-mail</th><th>Telefone</th><th>Ações</th>
+                                        <th>Nome da Empresa</th><th>CNPJ</th><th>E-mail</th><th>Telefone</th><th>Tel. Cobrança</th><th>Ações</th>
                                     </tr>
                                 </thead>
                                 <tbody id="permissionarios-table-body"></tbody>
@@ -197,7 +197,7 @@
         let currentPage = 1, currentSearch = '', currentLimit = 10, searchTimeout;
         
         async function fetchPermissionarios() {
-            tableBody.innerHTML = '<tr><td colspan="5" class="text-center">Carregando...</td></tr>';
+            tableBody.innerHTML = '<tr><td colspan="6" class="text-center">Carregando...</td></tr>';
             try {
                 const response = await fetch(`/api/admin/permissionarios?search=${encodeURIComponent(currentSearch)}&page=${currentPage}&limit=${currentLimit}`, {
                     headers: { 'Authorization': `Bearer ${token}` }
@@ -207,13 +207,13 @@
                 renderTable(data.permissionarios);
                 renderPagination(data.totalPages, data.currentPage);
             } catch (error) {
-                tableBody.innerHTML = `<tr><td colspan="5" class="text-center text-danger">${error.message}</td></tr>`;
+                tableBody.innerHTML = `<tr><td colspan="6" class="text-center text-danger">${error.message}</td></tr>`;
             }
         }
 
         function renderTable(permissionarios) {
             if (!permissionarios || permissionarios.length === 0) {
-                tableBody.innerHTML = '<tr><td colspan="5" class="text-center">Nenhum permissionário encontrado.</td></tr>';
+                tableBody.innerHTML = '<tr><td colspan="6" class="text-center">Nenhum permissionário encontrado.</td></tr>';
                 return;
             }
             tableBody.innerHTML = permissionarios.map(p => `
@@ -222,6 +222,7 @@
                     <td>${formatarCNPJ(p.cnpj)}</td>
                     <td>${p.email}</td>
                     <td>${p.telefone || 'Não informado'}</td>
+                    <td>${p.telefone_cobranca || 'Não informado'}</td>
                     <td>
                         <a href="/admin/permissionario-form.html?id=${p.id}" class="btn btn-sm btn-outline-primary me-2">Ver/Editar</a>
                         <button class="btn btn-sm btn-outline-secondary gerar-oficio-btn" data-id="${p.id}">Gerar Ofício</button>

--- a/src/api/adminRoutes.js
+++ b/src/api/adminRoutes.js
@@ -156,7 +156,7 @@ router.get(
       const totalPermissionarios = totalResult.count;
 
       const dataSql = `
-        SELECT id, nome_empresa, cnpj, email, telefone, numero_sala
+        SELECT id, nome_empresa, cnpj, email, telefone, telefone_cobranca, numero_sala
         FROM permissionarios
         ${whereClause}
         ORDER BY nome_empresa ASC
@@ -206,17 +206,30 @@ router.put(
   async (req, res) => {
     const { id } = req.params;
     const {
-      nome_empresa, cnpj, email, telefone, numero_sala, valor_aluguel,
+      nome_empresa,
+      cnpj,
+      email,
+      telefone,
+      telefone_cobranca,
+      numero_sala,
+      valor_aluguel,
     } = req.body;
 
     try {
       const sql = `
         UPDATE permissionarios SET
-          nome_empresa = ?, cnpj = ?, email = ?, telefone = ?, numero_sala = ?, valor_aluguel = ?
+          nome_empresa = ?, cnpj = ?, email = ?, telefone = ?, telefone_cobranca = ?, numero_sala = ?, valor_aluguel = ?
         WHERE id = ?
       `;
       const params = [
-        nome_empresa, cnpj, email, telefone, numero_sala, valor_aluguel, id,
+        nome_empresa,
+        cnpj,
+        email,
+        telefone,
+        telefone_cobranca,
+        numero_sala,
+        valor_aluguel,
+        id,
       ];
 
       await new Promise((resolve, reject) => {
@@ -242,17 +255,29 @@ router.post(
   [authMiddleware, authorizeRole(['SUPER_ADMIN', 'FINANCE_ADMIN'])],
   async (req, res) => {
     const {
-      nome_empresa, cnpj, email, telefone, numero_sala, valor_aluguel,
+      nome_empresa,
+      cnpj,
+      email,
+      telefone,
+      telefone_cobranca,
+      numero_sala,
+      valor_aluguel,
     } = req.body;
 
     try {
       const sql = `
         INSERT INTO permissionarios
-          (nome_empresa, cnpj, email, telefone, numero_sala, valor_aluguel)
-        VALUES (?, ?, ?, ?, ?, ?)
+          (nome_empresa, cnpj, email, telefone, telefone_cobranca, numero_sala, valor_aluguel)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
       `;
       const params = [
-        nome_empresa, cnpj, email, telefone, numero_sala, valor_aluguel,
+        nome_empresa,
+        cnpj,
+        email,
+        telefone,
+        telefone_cobranca,
+        numero_sala,
+        valor_aluguel,
       ];
 
       const result = await new Promise((resolve, reject) => {
@@ -301,7 +326,7 @@ router.get(
 
       const permissionarios = await dbAll(
         `
-        SELECT nome_empresa, cnpj, email, telefone, numero_sala
+        SELECT nome_empresa, cnpj, email, telefone, telefone_cobranca, numero_sala
         FROM permissionarios
         ${whereClause}
         ORDER BY nome_empresa ASC
@@ -459,13 +484,14 @@ function generateTable(doc, data) {
   const rowHeight = 30;
   const availableWidth = doc.page.width - doc.page.margins.left - doc.page.margins.right;
   const colWidths = {
-    nome: availableWidth * 0.3,
-    cnpj: availableWidth * 0.2,
-    email: availableWidth * 0.25,
-    telefone: availableWidth * 0.15,
+    nome: availableWidth * 0.25,
+    cnpj: availableWidth * 0.18,
+    email: availableWidth * 0.22,
+    telefone: availableWidth * 0.12,
+    telefone_cobranca: availableWidth * 0.13,
     sala: availableWidth * 0.1,
   };
-  const headers = ['Razão Social', 'CNPJ', 'E-mail', 'Telefone', 'Sala(s)'];
+  const headers = ['Razão Social', 'CNPJ', 'E-mail', 'Telefone', 'Tel. Cobrança', 'Sala(s)'];
 
   const drawRow = (row, currentY, isHeader = false) => {
     let x = doc.page.margins.left;
@@ -497,6 +523,7 @@ function generateTable(doc, data) {
       item.cnpj,
       item.email,
       item.telefone || 'N/A',
+      item.telefone_cobranca || 'N/A',
       item.numero_sala,
     ];
     drawRow(row, y);


### PR DESCRIPTION
## Summary
- allow updating and creating permissionários with `telefone_cobranca`
- include billing phone in admin listing and exports
- expose billing phone field in admin interface

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d6559d9c8333aa010aa2e43b960d