### PR TITLE
Log detalhado do erro da SEFAZ

### DIFF
--- a/src/services/sefazService.js
+++ b/src/services/sefazService.js
@@ -249,11 +249,13 @@ async function _postEmitir(payload) {
     if (err.response) {
       const status = err.response.status;
       const body = err.response.data;
+      // log raw body for troubleshooting
+      console.error(body);
       const msg = (body && (body.message || body.detail || body.title)) || `Erro HTTP ${status}`;
       if (/Data Limite Pagamento.*menor que a data atual/i.test(JSON.stringify(body))) {
         throw new Error('Data Limite Pagamento não pode ser menor que hoje. (Ajuste automático recomendado no payload)');
       }
-      throw new Error(`Erro ${status}: ${msg}`);
+      throw new Error(`Erro ${status}: ${msg} - ${JSON.stringify(body)}`);
     }
     if (err.request) {
       const reason = (err.code === 'ECONNABORTED') ? 'timeout' : 'sem resposta';


### PR DESCRIPTION
## Summary
- loga `err.response.data` em `_postEmitir`
- inclui detalhes do body na mensagem de erro

## Testing
- `npm test` *(falha: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d7b4c5188333ad93cb3978a585df