### PR TITLE
feat: prevent re-emission of already emitted DAR

### DIFF
--- a/src/api/botRoutes.js
+++ b/src/api/botRoutes.js
@@ -463,6 +463,7 @@ router.get('/dars/:darId/pdf', botAuthMiddleware, async (req, res) => {
  * POST /api/bot/dars/:darId/emit
  * Body opcional: { msisdn: "55..." } — valida posse.
  * Emite na SEFAZ usando o mesmo builder do sistema.
+ * Retorna 409 se o DAR já estiver "Emitido" ou "Reemitido".
  */
 router.post('/dars/:darId/emit', botAuthMiddleware, async (req, res) => {
   const darId = Number(req.params.darId);
@@ -475,6 +476,14 @@ router.post('/dars/:darId/emit', botAuthMiddleware, async (req, res) => {
 
     if (msisdn && !phoneMatches(msisdn, ctx.tels)) {
       return res.status(403).json({ error: 'Este telefone não está autorizado a emitir este DAR.' });
+    }
+
+    if (['Emitido', 'Reemitido'].includes(ctx.dar.status)) {
+      return res.status(409).json({
+        error: `DAR já ${ctx.dar.status.toLowerCase()}.`,
+        status: ctx.dar.status,
+        hint: 'Se precisar gerar novamente, utilize /api/bot/dars/:darId/reemit.'
+      });
     }
 
     let payload;


### PR DESCRIPTION
## Summary
- add status check in `/dars/:darId/emit` to avoid re-emitting guides already marked as Emitido or Reemitido
- return HTTP 409 with a hint to use `/reemit` when applicable

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d7b157008333a185c7975f0868a0