### PR TITLE
Propagate SEFAZ error details

### DIFF
--- a/src/api/botRoutes.js
+++ b/src/api/botRoutes.js
@@ -553,7 +553,10 @@ router.post('/dars/:darId/emit', botAuthMiddleware, async (req, res) => {
       /indispon[ií]vel|Load balancer|ECONNABORTED|ENOTFOUND|EAI_AGAIN|ECONNRESET|ETIMEDOUT|timeout/i.test(
         err.message || ''
       );
-    return res.status(isUnavailable ? 503 : 500).json({ error: err.message || 'Falha ao emitir a DAR.' });
+    const status = err.status || (isUnavailable ? 503 : 500);
+    const body = { error: err.message || 'Falha ao emitir a DAR.' };
+    if (err.detail) body.detail = err.detail;
+    return res.status(status).json(body);
   }
 });
 
@@ -650,7 +653,10 @@ router.post('/dars/:darId/reemit', botAuthMiddleware, async (req, res) => {
       /indispon[ií]vel|Load balancer|ECONNABORTED|ENOTFOUND|EAI_AGAIN|ECONNRESET|ETIMEDOUT|timeout/i.test(
         err.message || ''
       );
-    return res.status(isUnavailable ? 503 : 500).json({ error: err.message || 'Falha ao reemitir a DAR.' });
+    const status = err.status || (isUnavailable ? 503 : 500);
+    const body = { error: err.message || 'Falha ao reemitir a DAR.' };
+    if (err.detail) body.detail = err.detail;
+    return res.status(status).json(body);
   }
 });
 

--- a/src/services/sefazService.js
+++ b/src/services/sefazService.js
@@ -253,9 +253,15 @@ async function _postEmitir(payload) {
       console.error(body);
       const msg = (body && (body.message || body.detail || body.title)) || `Erro HTTP ${status}`;
       if (/Data Limite Pagamento.*menor que a data atual/i.test(JSON.stringify(body))) {
-        throw new Error('Data Limite Pagamento não pode ser menor que hoje. (Ajuste automático recomendado no payload)');
+        const e = new Error('Data Limite Pagamento não pode ser menor que hoje. (Ajuste automático recomendado no payload)');
+        e.status = status;
+        e.detail = body;
+        throw e;
       }
-      throw new Error(`Erro ${status}: ${msg} - ${JSON.stringify(body)}`);
+      const e = new Error(msg);
+      e.status = status;
+      e.detail = body;
+      throw e;
     }
     if (err.request) {
       const reason = (err.code === 'ECONNABORTED') ? 'timeout' : 'sem resposta';


### PR DESCRIPTION
## Summary
- throw Errors with status/detail from SEFAZ responses to avoid duplicate JSON logs
- forward `err.status` and `err.detail` in bot emission routes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a4dae16e088333946339520d371406