### PR TITLE
Add space and area fields to events

### DIFF
--- a/public/admin/eventos-dars.html
+++ b/public/admin/eventos-dars.html
@@ -122,6 +122,14 @@
             <label for="nome-evento" class="form-label">Nome do Evento *</label>
             <input type="text" class="form-control" id="nome-evento" required>
           </div>
+          <div class="mb-3">
+            <label for="espaco-utilizado" class="form-label">Espaço Utilizado</label>
+            <input type="text" class="form-control" id="espaco-utilizado">
+          </div>
+          <div class="mb-3">
+            <label for="area-m2" class="form-label">Área (m²)</label>
+            <input type="number" step="0.01" class="form-control" id="area-m2">
+          </div>
         </fieldset>
 
         <fieldset>
@@ -311,6 +319,8 @@ window.onload = () => {
   const tipoDescontoAutoDisplay = document.getElementById('tipo-desconto-auto');
   const descontoManualInput = document.getElementById('desconto-manual');
   const valorFinalDisplay = document.getElementById('valor-final');
+  const espacoUtilizadoInput = document.getElementById('espaco-utilizado');
+  const areaM2Input = document.getElementById('area-m2');
 
   const parcelasContainer = document.getElementById('parcelas-container');
   const addParcelaBtn = document.getElementById('add-parcela-btn');
@@ -628,13 +638,15 @@ async function carregarClientes(){
     const nome_evento = ev.nome_evento ?? ev.nome ?? ev.titulo ?? '';
     const tipo_desconto_auto = ev.tipo_desconto_auto ?? ev.tipoDescontoAuto ?? ev.tipo_cliente ?? 'Geral';
     const desconto_manual_percent = ev.desconto_manual_percent ?? ev.descontoManualPercent ?? ev.desconto ?? 0;
+    const espaco_utilizado = ev.espaco_utilizado ?? ev.espacoUtilizado ?? '';
+    const area_m2 = ev.area_m2 ?? ev.areaM2 ?? null;
     let datas_evento = ev.datas_evento ?? ev.datas ?? ev.datasEvento ?? [];
     if (typeof datas_evento === 'string') datas_evento = datas_evento.split(',').map(s=>s.trim()).filter(Boolean);
     if (!Array.isArray(datas_evento)) datas_evento = [];
     const parcelas = Array.isArray(ev.parcelas) ? ev.parcelas
                   : Array.isArray(ev.DARs) ? ev.DARs
                   : [];
-    return { id_cliente, nome_evento, tipo_desconto_auto, desconto_manual_percent, datas_evento, parcelas };
+    return { id_cliente, nome_evento, tipo_desconto_auto, desconto_manual_percent, datas_evento, parcelas, espaco_utilizado, area_m2 };
   }
 
   async function editarEvento(eventoId){
@@ -654,6 +666,8 @@ async function carregarClientes(){
     // preencher
     clienteSelect.value = ev.id_cliente || '';
     document.getElementById('nome-evento').value = ev.nome_evento || '';
+    espacoUtilizadoInput.value = ev.espaco_utilizado || '';
+    areaM2Input.value = ev.area_m2 != null ? ev.area_m2 : '';
     if (Array.isArray(ev.datas_evento) && ev.datas_evento.length) fp.setDate(ev.datas_evento, true);
     tipoDescontoAutoDisplay.value = ev.tipo_desconto_auto || (clienteSelect.selectedOptions[0]?.dataset.tipo || '');
     descontoManualInput.value = ev.desconto_manual_percent || 0;
@@ -901,6 +915,8 @@ async function carregarClientes(){
       totalDiarias: n,
       valorBruto: vb,
       valorFinal: vf,
+      espacoUtilizado: espacoUtilizadoInput.value,
+      areaM2: parseFloat(areaM2Input.value) || null,
       parcelas
     };
 

--- a/src/api/adminEventosRoutes.js
+++ b/src/api/adminEventosRoutes.js
@@ -59,7 +59,8 @@ router.post('/', async (req, res) => {
 
   const {
     idCliente, nomeEvento, datasEvento, totalDiarias, valorBruto,
-    tipoDescontoAuto, descontoManualPercent, valorFinal, parcelas
+    tipoDescontoAuto, descontoManualPercent, valorFinal, parcelas,
+    espacoUtilizado, areaM2
   } = req.body;
 
   if (!idCliente || !nomeEvento || !Array.isArray(parcelas) || parcelas.length === 0) {
@@ -78,12 +79,14 @@ router.post('/', async (req, res) => {
     // FIX: remover "INSERT INTO Eventos (...)" (placeholders inválidos) e listar colunas reais
     const eventoStmt = await dbRun(
       `INSERT INTO Eventos
-         (id_cliente, nome_evento, datas_evento, total_diarias, valor_bruto,
+         (id_cliente, nome_evento, espaco_utilizado, area_m2, datas_evento, total_diarias, valor_bruto,
           tipo_desconto, desconto_manual, valor_final, status)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         idCliente,
         nomeEvento,
+        espacoUtilizado || null,
+        areaM2 != null ? Number(areaM2) : null,
         JSON.stringify(datasEvento || []),
         Number(totalDiarias || 0),
         Number(valorBruto || 0),
@@ -285,6 +288,8 @@ router.get('/:id', async (req, res) => {
         id: ev.id,
         id_cliente: ev.id_cliente,
         nome_evento: ev.nome_evento,
+        espaco_utilizado: ev.espaco_utilizado,
+        area_m2: ev.area_m2,
         datas_evento: datas,
         total_diarias: ev.total_diarias,
         valor_bruto: ev.valor_bruto,
@@ -319,6 +324,8 @@ router.put('/:id', async (req, res) => {
   const {
     idCliente,             // obrigatório
     nomeEvento,            // obrigatório
+    espacoUtilizado = null,
+    areaM2 = null,
     datasEvento = [],      // array ISO YYYY-MM-DD
     totalDiarias = 0,
     valorBruto = 0,
@@ -347,6 +354,8 @@ router.put('/:id', async (req, res) => {
       `UPDATE Eventos
           SET id_cliente = ?,
               nome_evento = ?,
+              espaco_utilizado = ?,
+              area_m2 = ?,
               datas_evento = ?,
               total_diarias = ?,
               valor_bruto = ?,
@@ -358,6 +367,8 @@ router.put('/:id', async (req, res) => {
       [
         idCliente,
         nomeEvento,
+        espacoUtilizado || null,
+        areaM2 != null ? Number(areaM2) : null,
         JSON.stringify(datasEvento),
         Number(totalDiarias || 0),
         Number(valorBruto || 0),

--- a/src/api/eventosRoutes.js
+++ b/src/api/eventosRoutes.js
@@ -35,6 +35,8 @@ router.post('/', async (req, res) => {
     const {
         idCliente,
         nomeEvento,
+        espacoUtilizado,
+        areaM2,
         datasEvento, // Espera um array de strings de data: ["2025-10-20", "2025-10-21"]
         tipoDescontoAuto, // 'Geral', 'Governo', 'Permissionario'
         descontoManualPercent,
@@ -71,8 +73,8 @@ router.post('/', async (req, res) => {
 
         try {
             // 1. Insere o evento principal na tabela Eventos
-            const eventoSql = `INSERT INTO Eventos (id_cliente, nome_evento, datas_evento, total_diarias, valor_bruto, tipo_desconto_auto, percentual_desconto_manual, valor_final) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`;
-            const eventoParams = [idCliente, nomeEvento, datasEvento.join(','), totalDiarias, valorBruto, tipoDescontoAuto, descontoManualPercent, valorFinal];
+            const eventoSql = `INSERT INTO Eventos (id_cliente, nome_evento, espaco_utilizado, area_m2, datas_evento, total_diarias, valor_bruto, tipo_desconto_auto, percentual_desconto_manual, valor_final) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
+            const eventoParams = [idCliente, nomeEvento, espacoUtilizado || null, areaM2 || null, datasEvento.join(','), totalDiarias, valorBruto, tipoDescontoAuto, descontoManualPercent, valorFinal];
             
             const eventoId = await new Promise((resolve, reject) => {
                 db.run(eventoSql, eventoParams, function(err) {

--- a/src/migrations/20250813180000-add-espaco-area-to-eventos.js
+++ b/src/migrations/20250813180000-add-espaco-area-to-eventos.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('Eventos', 'espaco_utilizado', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+    await queryInterface.addColumn('Eventos', 'area_m2', {
+      type: Sequelize.FLOAT,
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('Eventos', 'espaco_utilizado');
+    await queryInterface.removeColumn('Eventos', 'area_m2');
+  }
+};


### PR DESCRIPTION
## Summary
- add `espaco_utilizado` and `area_m2` columns to Eventos table
- expose space and area fields in admin event endpoints and panel

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a5fa75037c833380416ae7530f4f07