### PR TITLE
Fix Eventos insert placeholders to match columns

### DIFF
--- a/src/api/eventosRoutes.js
+++ b/src/api/eventosRoutes.js
@@ -52,7 +52,7 @@ router.post('/', async (req, res) => {
         horaInicio,
         horaFim,
         horaMontagem,
-        horaDesmontagem
+        horaDesmontagem,
 
         numeroProcesso,
         numeroTermo
@@ -90,8 +90,8 @@ router.post('/', async (req, res) => {
         try {
             // 1. Insere o evento principal na tabela Eventos
 
-            const eventoSql = `INSERT INTO Eventos (id_cliente, nome_evento, espaco_utilizado, area_m2, datas_evento, data_vigencia_final, total_diarias, valor_bruto, tipo_desconto_auto, percentual_desconto_manual, valor_final, numero_oficio_sei) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
-            const eventoParams = [idCliente, nomeEvento, espacoUtilizado || null, areaM2 || null, datasEvento.join(','), dataVigenciaFinal,totalDiarias, valorBruto, tipoDescontoAuto, descontoManualPercent, valorFinal, numeroOficioSei];
+            const eventoSql = `INSERT INTO Eventos (id_cliente, nome_evento, espaco_utilizado, area_m2, datas_evento, data_vigencia_final, total_diarias, valor_bruto, tipo_desconto_auto, percentual_desconto_manual, valor_final, numero_oficio_sei) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
+            const eventoParams = [idCliente, nomeEvento, espacoUtilizado || null, areaM2 || null, datasEvento.join(','), dataVigenciaFinal, totalDiarias, valorBruto, tipoDescontoAuto, descontoManualPercent, valorFinal, numeroOficioSei];
             const eventoId = await new Promise((resolve, reject) => {
                 db.run(eventoSql, eventoParams, function(err) {
                     if (err) reject(err);


### PR DESCRIPTION
## Summary
- align SQL placeholders in Eventos insert with all 12 columns
- keep `eventoParams` array in identical order and count

## Testing
- `npm test`
- `curl -s -D - -H "Content-Type: application/json" -d @payload.json http://localhost:3000/api/eventos`
- `sqlite3 sistemacipt.db "SELECT id, id_cliente, nome_evento, valor_final FROM Eventos;"`
- `sqlite3 sistemacipt.db "SELECT id, valor, numero_documento FROM dars;"`
- `sqlite3 sistemacipt.db "SELECT id_evento, id_dar, numero_parcela FROM DARs_Eventos;"`


------
https://chatgpt.com/codex/tasks/task_e_68a604524dcc83339f3e8f2895dd02da