### PR TITLE
Integrate Assinafy digital signature workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Sistema de Pagamento CIPT
+
+Este projeto integra o fluxo de assinaturas digitais utilizando o serviço **Assinafy**.
+
+## Token da API do Assinafy
+1. Crie uma conta no [painel do Assinafy](https://assinafy.com/).
+2. Acesse a área de desenvolvedores e gere um **API Key**.
+3. Copie o token e defina-o em sua configuração de ambiente.
+
+## Variáveis de Ambiente
+Adicione no arquivo `.env` ou nas variáveis do servidor:
+
+- `ASSINAFY_API_KEY`: token de acesso gerado no painel.
+- `ASSINAFY_API_URL` (opcional): URL base da API. Padrão `https://api.assinafy.com`.
+- `ASSINAFY_CALLBACK_URL`: URL pública para o retorno após a assinatura, ex.: `https://seusistema/api/documentos/assinafy/callback`.
+
+Certifique-se de reiniciar o servidor após alterar as variáveis.

--- a/public/eventos/termo.html
+++ b/public/eventos/termo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+  <meta charset="UTF-8" />
+  <title>Termo do Evento</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="p-4">
+  <h1>Termo de Uso</h1>
+  <p>Leia atentamente o termo e assine digitalmente.</p>
+  <button id="btnAssinar" class="btn btn-primary">Assinar com Assinafy</button>
+  <div id="status" class="mt-3"></div>
+
+  <script>
+    const params = new URLSearchParams(location.search);
+    const documentoId = params.get('id');
+    const statusEl = document.getElementById('status');
+
+    document.getElementById('btnAssinar').addEventListener('click', async () => {
+      if (!documentoId) {
+        alert('ID do documento ausente.');
+        return;
+      }
+      statusEl.textContent = 'Enviando para Assinafy...';
+      try {
+        const resp = await fetch(`/api/documentos/${documentoId}/sign-assinafy`, { method: 'POST' });
+        const data = await resp.json();
+        if (data.url) {
+          window.location.href = data.url;
+        } else {
+          statusEl.textContent = 'Falha ao iniciar assinatura.';
+        }
+      } catch (err) {
+        console.error(err);
+        statusEl.textContent = 'Erro ao comunicar com o servidor.';
+      }
+    });
+
+    async function verificarStatus() {
+      if (!documentoId) return;
+      try {
+        const r = await fetch(`/api/documentos/${documentoId}/sign-assinafy-status`);
+        const j = await r.json();
+        if (j.status === 'signed') {
+          statusEl.textContent = 'Documento assinado com sucesso.';
+          return;
+        }
+      } catch (e) {}
+      setTimeout(verificarStatus, 4000);
+    }
+    verificarStatus();
+  </script>
+</body>
+</html>

--- a/src/api/documentosRoutes.js
+++ b/src/api/documentosRoutes.js
@@ -1,6 +1,10 @@
 const express = require('express');
 const sqlite3 = require('sqlite3').verbose();
 const path = require('path');
+const fs = require('fs');
+const crypto = require('crypto');
+
+const assinafyService = require('../services/assinafyService');
 
 const router = express.Router();
 const DB_PATH = path.resolve(process.cwd(), process.env.SQLITE_STORAGE || './sistemacipt.db');
@@ -8,6 +12,12 @@ const db = new sqlite3.Database(DB_PATH);
 
 const dbGet = (sql, params = []) =>
   new Promise((resolve, reject) => db.get(sql, params, (err, row) => (err ? reject(err) : resolve(row))));
+
+const dbRun = (sql, params = []) =>
+  new Promise((resolve, reject) => db.run(sql, params, function (err) {
+    if (err) return reject(err);
+    resolve(this);
+  }));
 
 router.get('/verify/:token', async (req, res) => {
   try {
@@ -28,4 +38,105 @@ router.get('/verify/:token', async (req, res) => {
   }
 });
 
+router.post('/:id/sign-assinafy', async (req, res) => {
+  try {
+    const id = req.params.id;
+    const doc = await dbGet('SELECT id, pdf_url FROM documentos WHERE id = ?', [id]);
+    if (!doc) return res.status(404).json({ error: 'Documento não encontrado.' });
+    let pdfBuffer;
+
+    if (doc.pdf_url) {
+      const url = String(doc.pdf_url);
+      if (/^data:application\/pdf;base64,/i.test(url)) {
+        const b64 = url.replace(/^data:application\/pdf;base64,/i, '');
+        pdfBuffer = Buffer.from(b64, 'base64');
+      } else if (fs.existsSync(url)) {
+        pdfBuffer = fs.readFileSync(url);
+      }
+    }
+    if (!pdfBuffer) {
+      const audit = await dbGet('SELECT pdf_path FROM oficios_audit WHERE documento_id = ?', [id]);
+      if (audit?.pdf_path && fs.existsSync(audit.pdf_path)) {
+        pdfBuffer = fs.readFileSync(audit.pdf_path);
+      }
+    }
+    if (!pdfBuffer) return res.status(404).json({ error: 'PDF não encontrado.' });
+
+    const resp = await assinafyService.uploadPdf(pdfBuffer, `documento_${id}.pdf`);
+    if (resp?.id) {
+      await dbRun('UPDATE documentos SET assinafy_id = ? WHERE id = ?', [resp.id, id]);
+    }
+    res.json({ url: resp?.url || resp?.signUrl || resp?.redirectUrl || null, assinafyId: resp?.id });
+  } catch (err) {
+    console.error('[documentos] sign-assinafy erro:', err);
+    res.status(500).json({ error: 'Falha ao enviar para assinatura.' });
+  }
+});
+
+router.get('/assinafy/callback', async (req, res) => {
+  const assinafyId = req.query.id || req.query.documentId;
+  const documentoId = req.query.documentoId || req.query.localId || null;
+  if (!assinafyId) return res.status(400).send('id ausente');
+
+  try {
+    const info = await assinafyService.getDocumentStatus(assinafyId);
+    const pdfBuffer = await assinafyService.downloadSignedPdf(assinafyId);
+
+    const hash = crypto.createHash('sha256').update(pdfBuffer).digest('hex');
+    const signer = info?.signer?.name || (info?.signatures && info.signatures[0]?.signer) || '';
+    const signedAt = info?.signedAt || new Date().toISOString();
+
+    const dir = path.resolve(process.cwd(), 'public', 'assinados');
+    fs.mkdirSync(dir, { recursive: true });
+    const filePath = path.join(dir, `documento_${assinafyId}.pdf`);
+    fs.writeFileSync(filePath, pdfBuffer);
+
+    await dbRun(`CREATE TABLE IF NOT EXISTS assinafy_audit (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      documento_id INTEGER,
+      assinafy_id TEXT,
+      hash TEXT,
+      signer TEXT,
+      signed_at TEXT,
+      pdf_path TEXT
+    )`);
+
+    await dbRun(
+      `INSERT INTO assinafy_audit (documento_id, assinafy_id, hash, signer, signed_at, pdf_path)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      [documentoId, assinafyId, hash, signer, signedAt, filePath]
+    );
+
+    res.json({ ok: true });
+  } catch (err) {
+    console.error('[assinafy callback] erro:', err);
+    res.status(500).json({ error: 'Erro no callback.' });
+  }
+});
+
+router.get('/:id/sign-assinafy-status', async (req, res) => {
+  try {
+    const id = req.params.id;
+    await dbRun(`CREATE TABLE IF NOT EXISTS assinafy_audit (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      documento_id INTEGER,
+      assinafy_id TEXT,
+      hash TEXT,
+      signer TEXT,
+      signed_at TEXT,
+      pdf_path TEXT
+    )`);
+    const row = await dbGet(
+      'SELECT hash, signer, signed_at, pdf_path FROM assinafy_audit WHERE documento_id = ? ORDER BY id DESC LIMIT 1',
+      [id]
+    );
+    if (!row) return res.json({ status: 'pending' });
+    res.json({ status: 'signed', ...row });
+  } catch (err) {
+    console.error('[documentos] status erro:', err);
+    res.status(500).json({ error: 'Erro ao consultar status.' });
+  }
+});
+
 module.exports = router;
+

--- a/src/services/assinafyService.js
+++ b/src/services/assinafyService.js
@@ -1,0 +1,49 @@
+const axios = require('axios');
+const FormData = require('form-data');
+require('dotenv').config();
+
+const BASE_URL = process.env.ASSINAFY_API_URL || 'https://api.assinafy.com';
+
+function getApiKey() {
+  const key = process.env.ASSINAFY_API_KEY;
+  if (!key) throw new Error('ASSINAFY_API_KEY não configurado.');
+  return key;
+}
+
+async function uploadPdf(pdfBuffer, filename = 'documento.pdf') {
+  const apiKey = getApiKey();
+  const form = new FormData();
+  form.append('file', pdfBuffer, { filename, contentType: 'application/pdf' });
+
+  const resp = await axios.post(`${BASE_URL}/documents`, form, {
+    headers: {
+      ...form.getHeaders(),
+      Authorization: `Bearer ${apiKey}`
+    }
+  });
+  return resp.data;
+}
+
+async function getDocumentStatus(id) {
+  const apiKey = getApiKey();
+  const resp = await axios.get(`${BASE_URL}/documents/${id}`, {
+    headers: { Authorization: `Bearer ${apiKey}` }
+  });
+  return resp.data;
+}
+
+async function downloadSignedPdf(id) {
+  const apiKey = getApiKey();
+  const resp = await axios.get(`${BASE_URL}/documents/${id}`, {
+    headers: { Authorization: `Bearer ${apiKey}`, Accept: 'application/pdf' },
+    responseType: 'arraybuffer'
+  });
+  return resp.data;
+}
+
+module.exports = {
+  uploadPdf,
+  getDocumentStatus,
+  downloadSignedPdf
+};
+


### PR DESCRIPTION
## Summary
- add Assinafy service for uploading PDFs and checking signed documents
- expose signing endpoints and callback to store signed PDF metadata
- add example front-end page and README instructions for Assinafy

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a61083076c8333a4b0d68dc0d9432d