### PR TITLE
Check column existence before adding numero_processo and numero_termo

### DIFF
--- a/src/migrations/20250813120000-add-numero-proc-termo-to-eventos.js
+++ b/src/migrations/20250813120000-add-numero-proc-termo-to-eventos.js
@@ -2,14 +2,21 @@
 
 module.exports = {
   async up(queryInterface, Sequelize) {
-    await queryInterface.addColumn('Eventos', 'numero_processo', {
-      type: Sequelize.STRING,
-      allowNull: true,
-    });
-    await queryInterface.addColumn('Eventos', 'numero_termo', {
-      type: Sequelize.STRING,
-      allowNull: true,
-    });
+    const table = await queryInterface.describeTable('Eventos');
+
+    if (!table.numero_processo) {
+      await queryInterface.addColumn('Eventos', 'numero_processo', {
+        type: Sequelize.STRING,
+        allowNull: true,
+      });
+    }
+
+    if (!table.numero_termo) {
+      await queryInterface.addColumn('Eventos', 'numero_termo', {
+        type: Sequelize.STRING,
+        allowNull: true,
+      });
+    }
   },
 
   async down(queryInterface) {


### PR DESCRIPTION
## Summary
- prevent duplicate column errors by inspecting `Eventos` table before adding `numero_processo` and `numero_termo`

## Testing
- `npx --yes sequelize-cli db:migrate --url "sqlite:////tmp/eventos_no_cols.db" --migrations-path /tmp/migrations_single`
- `npx --yes sequelize-cli db:migrate --url "sqlite:////tmp/eventos_with_cols.db" --migrations-path /tmp/migrations_single`


------
https://chatgpt.com/codex/tasks/task_e_68a6132f56e48333953b98a2aadb37ad