### PR TITLE
feat: support Assinafy callback and embed options

### DIFF
--- a/src/api/documentosRoutes.js
+++ b/src/api/documentosRoutes.js
@@ -62,11 +62,12 @@ router.post('/:id/sign-assinafy', async (req, res) => {
     }
     if (!pdfBuffer) return res.status(404).json({ error: 'PDF não encontrado.' });
 
-    const resp = await assinafyService.uploadPdf(pdfBuffer, `documento_${id}.pdf`);
+    const options = req.body || {};
+    const resp = await assinafyService.uploadPdf(pdfBuffer, `documento_${id}.pdf`, options);
     if (resp?.id) {
       await dbRun('UPDATE documentos SET assinafy_id = ? WHERE id = ?', [resp.id, id]);
     }
-    res.json({ url: resp?.url || resp?.signUrl || resp?.redirectUrl || null, assinafyId: resp?.id });
+    res.json({ url: resp?.embedUrl || resp?.url || resp?.signUrl || resp?.redirectUrl || null, assinafyId: resp?.id });
   } catch (err) {
     console.error('[documentos] sign-assinafy erro:', err);
     res.status(500).json({ error: 'Falha ao enviar para assinatura.' });

--- a/src/services/assinafyService.js
+++ b/src/services/assinafyService.js
@@ -10,10 +10,25 @@ function getApiKey() {
   return key;
 }
 
-async function uploadPdf(pdfBuffer, filename = 'documento.pdf') {
+async function uploadPdf(pdfBuffer, filename = 'documento.pdf', config = {}) {
   const apiKey = getApiKey();
   const form = new FormData();
   form.append('file', pdfBuffer, { filename, contentType: 'application/pdf' });
+
+  const {
+    callbackUrl = process.env.ASSINAFY_CALLBACK_URL,
+    ...flags
+  } = config || {};
+
+  if (callbackUrl) {
+    form.append('callbackUrl', callbackUrl);
+  }
+
+  Object.entries(flags).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) {
+      form.append(key, typeof value === 'boolean' ? String(value) : value);
+    }
+  });
 
   const resp = await axios.post(`${BASE_URL}/documents`, form, {
     headers: {


### PR DESCRIPTION
## Summary
- allow `uploadPdf` to send callback URL and extra flags to Assinafy
- forward options from documentos route and surface `embedUrl` in response

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a613eb25288333a7610378a6569391