### PR TITLE
refactor: encapsulate event and DAR logic with transactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node src/index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "dependencies": {
     "@google-cloud/storage": "^7.16.0",

--- a/src/services/eventoDarService.js
+++ b/src/services/eventoDarService.js
@@ -1,0 +1,368 @@
+const onlyDigits = (v = '') => String(v).replace(/\D/g, '');
+
+const dbRun = (db, sql, p = []) =>
+  new Promise((resolve, reject) => {
+    db.run(sql, p, function (err) {
+      if (err) return reject(err);
+      resolve(this);
+    });
+  });
+
+const dbGet = (db, sql, p = []) =>
+  new Promise((resolve, reject) => {
+    db.get(sql, p, (err, row) => {
+      if (err) return reject(err);
+      resolve(row);
+    });
+  });
+
+const dbAll = (db, sql, p = []) =>
+  new Promise((resolve, reject) => {
+    db.all(sql, p, (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows);
+    });
+  });
+
+async function criarEventoComDars(db, data, helpers) {
+  const {
+    emitirGuiaSefaz,
+    gerarTokenDocumento,
+    imprimirTokenEmPdf,
+  } = helpers;
+
+  const {
+    idCliente,
+    nomeEvento,
+    numeroOficioSei,
+    datasEvento,
+    totalDiarias,
+    valorBruto,
+    tipoDescontoAuto,
+    descontoManualPercent,
+    valorFinal,
+    parcelas,
+    espacoUtilizado,
+    areaM2,
+    horaInicio,
+    horaFim,
+    horaMontagem,
+    horaDesmontagem,
+    numeroProcesso,
+    numeroTermo,
+  } = data;
+
+  if (!idCliente || !nomeEvento || !Array.isArray(parcelas) || parcelas.length === 0) {
+    throw new Error('Campos obrigatórios estão faltando.');
+  }
+
+  const somaParcelas = parcelas.reduce((acc, p) => acc + (Number(p.valor) || 0), 0);
+  if (Math.abs(somaParcelas - Number(valorFinal || 0)) > 0.01) {
+    throw new Error(`A soma das parcelas (R$ ${somaParcelas.toFixed(2)}) não corresponde ao Valor Final (R$ ${Number(valorFinal||0).toFixed(2)}).`);
+  }
+  const datasOrdenadas = Array.isArray(datasEvento) ? [...datasEvento].sort((a,b)=> new Date(a)-new Date(b)) : [];
+  const dataVigenciaFinal = datasOrdenadas.length ? datasOrdenadas[datasOrdenadas.length-1] : null;
+
+  await dbRun(db, 'BEGIN TRANSACTION');
+  try {
+    const eventoStmt = await dbRun(
+      db,
+      `INSERT INTO Eventos (
+         id_cliente, nome_evento, espaco_utilizado, area_m2, datas_evento,
+         data_vigencia_final, total_diarias, valor_bruto,
+         tipo_desconto, desconto_manual, valor_final, numero_oficio_sei,
+         hora_inicio, hora_fim, hora_montagem, hora_desmontagem,
+         numero_processo, numero_termo, status
+       ) VALUES (
+         ?, ?, ?, ?, ?,
+         ?, ?, ?,
+         ?, ?, ?, ?,
+         ?, ?, ?, ?,
+         ?, ?, ?
+       )`,
+      [
+        idCliente,
+        nomeEvento,
+        espacoUtilizado || null,
+        areaM2 != null ? Number(areaM2) : null,
+        JSON.stringify(datasEvento || []),
+        dataVigenciaFinal,
+        Number(totalDiarias || 0),
+        Number(valorBruto || 0),
+        String(tipoDescontoAuto || 'Geral'),
+        Number(descontoManualPercent || 0),
+        Number(valorFinal || 0),
+        numeroOficioSei || null,
+        horaInicio || null,
+        horaFim || null,
+        horaMontagem || null,
+        horaDesmontagem || null,
+        numeroProcesso || null,
+        numeroTermo || null,
+        'Pendente'
+      ]
+    );
+
+    const eventoId = eventoStmt.lastID;
+
+    const cliente = await dbGet(
+      db,
+      `SELECT nome_razao_social, documento, endereco, cep
+         FROM Clientes_Eventos WHERE id = ?`,
+      [idCliente]
+    );
+    if (!cliente) throw new Error(`Cliente com ID ${idCliente} não foi encontrado no banco.`);
+
+    const documentoLimpo = onlyDigits(cliente.documento);
+    const tipoInscricao = documentoLimpo.length === 11 ? 3 : 4;
+
+    for (const [i, p] of parcelas.entries()) {
+      const valorParcela = Number(p.valor) || 0;
+      const vencimentoISO = p.vencimento;
+      if (!vencimentoISO || Number.isNaN(new Date(`${vencimentoISO}T12:00:00`).getTime())) {
+        throw new Error(`A data de vencimento da parcela ${i + 1} é inválida.`);
+      }
+      if (valorParcela <= 0) {
+        throw new Error(`O valor da parcela ${i + 1} deve ser maior que zero.`);
+      }
+      const [ano, mes] = vencimentoISO.split('-');
+      const darStmt = await dbRun(
+        db,
+        `INSERT INTO dars (valor, data_vencimento, status, mes_referencia, ano_referencia)
+         VALUES (?, ?, 'Pendente', ?, ?)`,
+        [valorParcela, vencimentoISO, Number(mes), Number(ano)]
+      );
+      const darId = darStmt.lastID;
+
+      await dbRun(
+        db,
+        `INSERT INTO DARs_Eventos (id_dar, id_evento, numero_parcela, valor_parcela, data_vencimento)
+         VALUES (?, ?, ?, ?, ?)`,
+        [darId, eventoId, i + 1, valorParcela, vencimentoISO]
+      );
+
+      const payloadSefaz = {
+        versao: '1.0',
+        contribuinteEmitente: {
+          codigoTipoInscricao: tipoInscricao,
+          numeroInscricao: documentoLimpo,
+          nome: cliente.nome_razao_social,
+          codigoIbgeMunicipio: Number(process.env.COD_IBGE_MUNICIPIO),
+          descricaoEndereco: cliente.endereco,
+          numeroCep: onlyDigits(cliente.cep)
+        },
+        receitas: [{
+          codigo: Number(process.env.RECEITA_CODIGO_EVENTO),
+          competencia: { mes: Number(mes), ano: Number(ano) },
+          valorPrincipal: valorParcela,
+          valorDesconto: 0.00,
+          dataVencimento: vencimentoISO
+        }],
+        dataLimitePagamento: vencimentoISO,
+        observacao: `CIPT Evento: ${nomeEvento} (Montagem ${horaMontagem || '-'}; Evento ${horaInicio || '-'}-${horaFim || '-'}; Desmontagem ${horaDesmontagem || '-'}) | Parcela ${i + 1} de ${parcelas.length}`
+      };
+
+      const retorno = await emitirGuiaSefaz(payloadSefaz);
+      const tokenDoc = await gerarTokenDocumento('DAR_EVENTO', null, db);
+      const pdf = await imprimirTokenEmPdf(retorno.pdfBase64, tokenDoc);
+      await dbRun(
+        db,
+        `UPDATE dars SET numero_documento = ?, pdf_url = ?, status = 'Emitido' WHERE id = ?`,
+        [retorno.numeroGuia, pdf, darId]
+      );
+    }
+
+    await dbRun(db, 'COMMIT');
+    return eventoId;
+  } catch (err) {
+    try { await dbRun(db, 'ROLLBACK'); } catch {}
+    throw err;
+  }
+}
+
+async function atualizarEventoComDars(db, id, data, helpers) {
+  const {
+    emitirGuiaSefaz,
+    gerarTokenDocumento,
+    imprimirTokenEmPdf,
+  } = helpers;
+
+  const {
+    idCliente,
+    nomeEvento,
+    numeroOficioSei,
+    espacoUtilizado = null,
+    areaM2 = null,
+    datasEvento = [],
+    totalDiarias = 0,
+    valorBruto = 0,
+    tipoDescontoAuto = null,
+    descontoManualPercent = 0,
+    valorFinal = 0,
+    parcelas = [],
+    horaInicio,
+    horaFim,
+    horaMontagem,
+    horaDesmontagem,
+    numeroProcesso,
+    numeroTermo
+  } = data || {};
+
+  if (!idCliente || !nomeEvento || !Array.isArray(parcelas) || parcelas.length === 0) {
+    throw new Error('Campos obrigatórios estão faltando.');
+  }
+  const somaParcelas = parcelas.reduce((acc, p) => acc + (Number(p.valor) || 0), 0);
+  if (Math.abs(somaParcelas - Number(valorFinal || 0)) > 0.01) {
+    throw new Error(`A soma das parcelas (R$ ${somaParcelas.toFixed(2)}) não corresponde ao Valor Final (R$ ${Number(valorFinal||0).toFixed(2)}).`);
+  }
+  const datasOrdenadas = Array.isArray(datasEvento) ? [...datasEvento].sort((a,b)=> new Date(a)-new Date(b)) : [];
+  const dataVigenciaFinal = datasOrdenadas.length ? datasOrdenadas[datasOrdenadas.length-1] : null;
+
+  await dbRun(db, 'BEGIN TRANSACTION');
+  try {
+    const upd = await dbRun(
+      db,
+      `UPDATE Eventos
+          SET id_cliente = ?,
+              nome_evento = ?,
+              espaco_utilizado = ?,
+              area_m2 = ?,
+              datas_evento = ?,
+              data_vigencia_final = ?,
+              total_diarias = ?,
+              valor_bruto = ?,
+              tipo_desconto = ?,
+              desconto_manual = ?,
+              valor_final = ?,
+              numero_oficio_sei = ?,
+              hora_inicio = ?,
+              hora_fim = ?,
+              hora_montagem = ?,
+              hora_desmontagem = ?,
+              numero_processo = ?,
+              numero_termo = ?,
+              status = ?
+        WHERE id = ?`,
+      [
+        idCliente,
+        nomeEvento,
+        espacoUtilizado || null,
+        areaM2 != null ? Number(areaM2) : null,
+        JSON.stringify(datasEvento || []),
+        dataVigenciaFinal,
+        Number(totalDiarias || 0),
+        Number(valorBruto || 0),
+        String(tipoDescontoAuto || 'Geral'),
+        Number(descontoManualPercent || 0),
+        Number(valorFinal || 0),
+        numeroOficioSei || null,
+        horaInicio || null,
+        horaFim || null,
+        horaMontagem || null,
+        horaDesmontagem || null,
+        numeroProcesso || null,
+        numeroTermo || null,
+        'Pendente',
+        id
+      ]
+    );
+
+    if (upd.changes === 0) {
+      throw Object.assign(new Error('Evento não encontrado.'), { status: 404 });
+    }
+
+    const antigos = await dbAll(
+      db,
+      'SELECT id_dar FROM DARs_Eventos WHERE id_evento = ?',
+      [id]
+    );
+    const antigosIds = antigos.map(r => r.id_dar);
+    await dbRun(db, 'DELETE FROM DARs_Eventos WHERE id_evento = ?', [id]);
+    if (antigosIds.length) {
+      const ph = antigosIds.map(() => '?').join(',');
+      await dbRun(db, `DELETE FROM dars WHERE id IN (${ph})`, antigosIds);
+    }
+
+    const cliente = await dbGet(
+      db,
+      `SELECT nome_razao_social, documento, endereco, cep
+         FROM Clientes_Eventos
+        WHERE id = ?`,
+      [idCliente]
+    );
+    if (!cliente) {
+      throw new Error(`Cliente com ID ${idCliente} não encontrado.`);
+    }
+
+    const docLimpo = onlyDigits(cliente.documento);
+    const tipoInscricao = docLimpo.length === 11 ? 3 : 4;
+
+    for (let i = 0; i < parcelas.length; i++) {
+      const p = parcelas[i];
+      const valorParcela = Number(p.valor) || 0;
+      const vencimentoISO = p.vencimento;
+      if (!vencimentoISO || !(new Date(vencimentoISO).getTime() > 0)) {
+        throw new Error(`A data de vencimento da parcela ${i + 1} é inválida.`);
+      }
+      if (valorParcela <= 0) {
+        throw new Error(`O valor da parcela ${i + 1} deve ser maior que zero.`);
+      }
+      const [ano, mes] = vencimentoISO.split('-');
+      const darStmt = await dbRun(
+        db,
+        `INSERT INTO dars (valor, data_vencimento, status, mes_referencia, ano_referencia)
+         VALUES (?, ?, 'Pendente', ?, ?)`,
+        [valorParcela, vencimentoISO, Number(mes), Number(ano)]
+      );
+      const darId = darStmt.lastID;
+      await dbRun(
+        db,
+        `INSERT INTO DARs_Eventos (id_dar, id_evento, numero_parcela, valor_parcela, data_vencimento)
+         VALUES (?, ?, ?, ?, ?)`,
+        [darId, id, i + 1, valorParcela, vencimentoISO]
+      );
+
+      const payloadSefaz = {
+        versao: '1.0',
+        contribuinteEmitente: {
+          codigoTipoInscricao: tipoInscricao,
+          numeroInscricao: docLimpo,
+          nome: cliente.nome_razao_social,
+          codigoIbgeMunicipio: Number(process.env.COD_IBGE_MUNICIPIO),
+          descricaoEndereco: cliente.endereco,
+          numeroCep: onlyDigits(cliente.cep)
+        },
+        receitas: [{
+          codigo: Number(process.env.RECEITA_CODIGO_EVENTO),
+          competencia: { mes: Number(mes), ano: Number(ano) },
+          valorPrincipal: valorParcela,
+          valorDesconto: 0.00,
+          dataVencimento: vencimentoISO
+        }],
+        dataLimitePagamento: vencimentoISO,
+        observacao: `CIPT Evento: ${nomeEvento} (Montagem ${horaMontagem || '-'}; Evento ${horaInicio || '-'}-${horaFim || '-'}; Desmontagem ${horaDesmontagem || '-'}) | Parcela ${i + 1} de ${parcelas.length} (Atualização)`
+      };
+
+      const retorno = await emitirGuiaSefaz(payloadSefaz);
+      const tokenDoc = await gerarTokenDocumento('DAR_EVENTO', null, db);
+      const pdf = await imprimirTokenEmPdf(retorno.pdfBase64, tokenDoc);
+      await dbRun(
+        db,
+        `UPDATE dars SET numero_documento = ?, pdf_url = ?, status = 'Emitido' WHERE id = ?`,
+        [retorno.numeroGuia, pdf, darId]
+      );
+    }
+
+    await dbRun(db, 'COMMIT');
+    return id;
+  } catch (err) {
+    try { await dbRun(db, 'ROLLBACK'); } catch {}
+    throw err;
+  }
+}
+
+module.exports = {
+  criarEventoComDars,
+  atualizarEventoComDars,
+};
+

--- a/tests/eventoDarService.test.js
+++ b/tests/eventoDarService.test.js
@@ -1,0 +1,171 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const sqlite3 = require('sqlite3').verbose();
+const { criarEventoComDars, atualizarEventoComDars } = require('../src/services/eventoDarService');
+process.env.COD_IBGE_MUNICIPIO = process.env.COD_IBGE_MUNICIPIO || '0000000';
+process.env.RECEITA_CODIGO_EVENTO = process.env.RECEITA_CODIGO_EVENTO || '12345';
+
+function run(db, sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.run(sql, params, function (err) {
+      if (err) reject(err); else resolve(this);
+    });
+  });
+}
+function all(db, sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.all(sql, params, (err, rows) => {
+      if (err) reject(err); else resolve(rows);
+    });
+  });
+}
+
+function createDb() {
+  const db = new sqlite3.Database(':memory:');
+  return db;
+}
+
+async function setupSchema(db) {
+  await run(db, `CREATE TABLE Clientes_Eventos (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    nome_razao_social TEXT,
+    documento TEXT,
+    endereco TEXT,
+    cep TEXT
+  );`);
+  await run(db, `CREATE TABLE Eventos (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    id_cliente INTEGER,
+    nome_evento TEXT,
+    espaco_utilizado TEXT,
+    area_m2 REAL,
+    datas_evento TEXT,
+    data_vigencia_final TEXT,
+    total_diarias INTEGER,
+    valor_bruto REAL,
+    tipo_desconto TEXT,
+    desconto_manual REAL,
+    valor_final REAL,
+    numero_oficio_sei TEXT,
+    hora_inicio TEXT,
+    hora_fim TEXT,
+    hora_montagem TEXT,
+    hora_desmontagem TEXT,
+    numero_processo TEXT,
+    numero_termo TEXT,
+    status TEXT
+  );`);
+  await run(db, `CREATE TABLE dars (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    valor REAL,
+    data_vencimento TEXT,
+    status TEXT,
+    mes_referencia INTEGER,
+    ano_referencia INTEGER,
+    numero_documento TEXT,
+    pdf_url TEXT
+  );`);
+  await run(db, `CREATE TABLE DARs_Eventos (
+    id_evento INTEGER,
+    id_dar INTEGER,
+    numero_parcela INTEGER,
+    valor_parcela REAL,
+    data_vencimento TEXT
+  );`);
+}
+
+const helpers = {
+  emitirGuiaSefaz: async () => ({ numeroGuia: '123', pdfBase64: 'pdf' }),
+  gerarTokenDocumento: async () => 'token',
+  imprimirTokenEmPdf: async (pdf, token) => `${pdf}-${token}`,
+};
+
+const failingHelpers = {
+  emitirGuiaSefaz: async () => { throw new Error('falha'); },
+  gerarTokenDocumento: async () => 'token',
+  imprimirTokenEmPdf: async (pdf, token) => `${pdf}-${token}`,
+};
+
+async function seedCliente(db) {
+  await run(db, `INSERT INTO Clientes_Eventos (nome_razao_social, documento, endereco, cep) VALUES ('Cliente', '12345678901', 'Rua A', '12345000');`);
+}
+
+test('criarEventoComDars insere evento e dars', async () => {
+  const db = createDb();
+  await setupSchema(db);
+  await seedCliente(db);
+  const data = {
+    idCliente: 1,
+    nomeEvento: 'Show',
+    numeroOficioSei: null,
+    datasEvento: ['2025-10-10'],
+    totalDiarias: 1,
+    valorBruto: 100,
+    tipoDescontoAuto: 'Geral',
+    descontoManualPercent: 0,
+    valorFinal: 100,
+    parcelas: [{ valor: 100, vencimento: '2025-09-01' }],
+  };
+  const id = await criarEventoComDars(db, data, helpers);
+  assert.strictEqual(id, 1);
+  const eventos = await all(db, 'SELECT * FROM Eventos');
+  assert.strictEqual(eventos.length, 1);
+  const dars = await all(db, 'SELECT * FROM dars');
+  assert.strictEqual(dars.length, 1);
+  await new Promise(res => db.close(res));
+});
+
+test('criarEventoComDars faz rollback em falha', async () => {
+  const db = createDb();
+  await setupSchema(db);
+  await seedCliente(db);
+  const data = {
+    idCliente: 1,
+    nomeEvento: 'Show',
+    numeroOficioSei: null,
+    datasEvento: ['2025-10-10'],
+    totalDiarias: 1,
+    valorBruto: 100,
+    tipoDescontoAuto: 'Geral',
+    descontoManualPercent: 0,
+    valorFinal: 100,
+    parcelas: [{ valor: 100, vencimento: '2025-09-01' }],
+  };
+  await assert.rejects(() => criarEventoComDars(db, data, failingHelpers));
+  const eventos = await all(db, 'SELECT * FROM Eventos');
+  assert.strictEqual(eventos.length, 0);
+  const dars = await all(db, 'SELECT * FROM dars');
+  assert.strictEqual(dars.length, 0);
+  await new Promise(res => db.close(res));
+});
+
+test('atualizarEventoComDars substitui dars', async () => {
+  const db = createDb();
+  await setupSchema(db);
+  await seedCliente(db);
+  const data = {
+    idCliente: 1,
+    nomeEvento: 'Show',
+    numeroOficioSei: null,
+    datasEvento: ['2025-10-10'],
+    totalDiarias: 1,
+    valorBruto: 100,
+    tipoDescontoAuto: 'Geral',
+    descontoManualPercent: 0,
+    valorFinal: 100,
+    parcelas: [{ valor: 100, vencimento: '2025-09-01' }],
+  };
+  const id = await criarEventoComDars(db, data, helpers);
+  const updateData = {
+    ...data,
+    valorFinal: 200,
+    parcelas: [
+      { valor: 100, vencimento: '2025-09-01' },
+      { valor: 100, vencimento: '2025-10-01' },
+    ],
+  };
+  await atualizarEventoComDars(db, id, updateData, helpers);
+  const dars = await all(db, 'SELECT * FROM dars');
+  assert.strictEqual(dars.length, 2);
+  await new Promise(res => db.close(res));
+});


### PR DESCRIPTION
## Summary
- move creation and update of eventos/DARs into `eventoDarService`
- use service from admin routes to ensure atomic transactions
- add tests covering service success and rollback scenarios

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a615201d08833387f2ea4a014ad55d