### PR TITLE
Evita reexecução de addColumn nas migrations de Eventos

### DIFF
--- a/src/migrations/20250811120000-add-tipo-desconto-to-eventos.js
+++ b/src/migrations/20250811120000-add-tipo-desconto-to-eventos.js
@@ -2,10 +2,13 @@
 
 module.exports = {
   async up(queryInterface, Sequelize) {
-    await queryInterface.addColumn('Eventos', 'tipo_desconto', {
-      type: Sequelize.STRING,
-      allowNull: true,
-    });
+    const table = await queryInterface.describeTable('Eventos');
+    if (!table['tipo_desconto']) {
+      await queryInterface.addColumn('Eventos', 'tipo_desconto', {
+        type: Sequelize.STRING,
+        allowNull: true,
+      });
+    }
   },
 
   async down(queryInterface) {

--- a/src/migrations/20250812103000-add-desconto-manual-to-eventos.js
+++ b/src/migrations/20250812103000-add-desconto-manual-to-eventos.js
@@ -2,10 +2,13 @@
 
 module.exports = {
   async up(queryInterface, Sequelize) {
-    await queryInterface.addColumn('Eventos', 'desconto_manual', {
-      type: Sequelize.DECIMAL(10, 2),
-      allowNull: true,
-    });
+    const table = await queryInterface.describeTable('Eventos');
+    if (!table['desconto_manual']) {
+      await queryInterface.addColumn('Eventos', 'desconto_manual', {
+        type: Sequelize.DECIMAL(10, 2),
+        allowNull: true,
+      });
+    }
   },
 
   async down(queryInterface) {

--- a/src/migrations/20250813180000-add-espaco-area-to-eventos.js
+++ b/src/migrations/20250813180000-add-espaco-area-to-eventos.js
@@ -2,14 +2,19 @@
 
 module.exports = {
   async up(queryInterface, Sequelize) {
-    await queryInterface.addColumn('Eventos', 'espaco_utilizado', {
-      type: Sequelize.STRING,
-      allowNull: true,
-    });
-    await queryInterface.addColumn('Eventos', 'area_m2', {
-      type: Sequelize.FLOAT,
-      allowNull: true,
-    });
+    const table = await queryInterface.describeTable('Eventos');
+    if (!table['espaco_utilizado']) {
+      await queryInterface.addColumn('Eventos', 'espaco_utilizado', {
+        type: Sequelize.STRING,
+        allowNull: true,
+      });
+    }
+    if (!table['area_m2']) {
+      await queryInterface.addColumn('Eventos', 'area_m2', {
+        type: Sequelize.FLOAT,
+        allowNull: true,
+      });
+    }
   },
 
   async down(queryInterface) {

--- a/src/migrations/20250813190000-add-numero-oficio-sei-to-eventos.js
+++ b/src/migrations/20250813190000-add-numero-oficio-sei-to-eventos.js
@@ -2,10 +2,13 @@
 
 module.exports = {
   async up(queryInterface, Sequelize) {
-    await queryInterface.addColumn('Eventos', 'numero_oficio_sei', {
-      type: Sequelize.STRING,
-      allowNull: true,
-    });
+    const table = await queryInterface.describeTable('Eventos');
+    if (!table['numero_oficio_sei']) {
+      await queryInterface.addColumn('Eventos', 'numero_oficio_sei', {
+        type: Sequelize.STRING,
+        allowNull: true,
+      });
+    }
   },
 
   async down(queryInterface) {

--- a/src/migrations/20250815100000-add-horas-to-eventos.js
+++ b/src/migrations/20250815100000-add-horas-to-eventos.js
@@ -2,22 +2,31 @@
 
 module.exports = {
   async up(queryInterface, Sequelize) {
-    await queryInterface.addColumn('Eventos', 'hora_inicio', {
-      type: Sequelize.STRING,
-      allowNull: true,
-    });
-    await queryInterface.addColumn('Eventos', 'hora_fim', {
-      type: Sequelize.STRING,
-      allowNull: true,
-    });
-    await queryInterface.addColumn('Eventos', 'hora_montagem', {
-      type: Sequelize.STRING,
-      allowNull: true,
-    });
-    await queryInterface.addColumn('Eventos', 'hora_desmontagem', {
-      type: Sequelize.STRING,
-      allowNull: true,
-    });
+    const table = await queryInterface.describeTable('Eventos');
+    if (!table['hora_inicio']) {
+      await queryInterface.addColumn('Eventos', 'hora_inicio', {
+        type: Sequelize.STRING,
+        allowNull: true,
+      });
+    }
+    if (!table['hora_fim']) {
+      await queryInterface.addColumn('Eventos', 'hora_fim', {
+        type: Sequelize.STRING,
+        allowNull: true,
+      });
+    }
+    if (!table['hora_montagem']) {
+      await queryInterface.addColumn('Eventos', 'hora_montagem', {
+        type: Sequelize.STRING,
+        allowNull: true,
+      });
+    }
+    if (!table['hora_desmontagem']) {
+      await queryInterface.addColumn('Eventos', 'hora_desmontagem', {
+        type: Sequelize.STRING,
+        allowNull: true,
+      });
+    }
   },
 
   async down(queryInterface) {

--- a/src/migrations/20250815120000-add-data-vigencia-final-to-eventos.js
+++ b/src/migrations/20250815120000-add-data-vigencia-final-to-eventos.js
@@ -2,10 +2,13 @@
 
 module.exports = {
   async up(queryInterface, Sequelize) {
-    await queryInterface.addColumn('Eventos', 'data_vigencia_final', {
-      type: Sequelize.DATEONLY,
-      allowNull: true,
-    });
+    const table = await queryInterface.describeTable('Eventos');
+    if (!table['data_vigencia_final']) {
+      await queryInterface.addColumn('Eventos', 'data_vigencia_final', {
+        type: Sequelize.DATEONLY,
+        allowNull: true,
+      });
+    }
   },
 
   async down(queryInterface) {


### PR DESCRIPTION
## Summary
- evita adicionar colunas duplicadas nas migrations de Eventos verificando schema existente

## Testing
- `npm test`
- `npx sequelize-cli db:migrate` *(erro: Cannot find "config/config.json")*

------
https://chatgpt.com/codex/tasks/task_e_68a6170665d88333804043a24fb88546