### PR TITLE
Add term permission PDF generator and admin download

### DIFF
--- a/public/admin/eventos-dars.html
+++ b/public/admin/eventos-dars.html
@@ -103,6 +103,7 @@
                     <th class="text-end">Valor Final</th>
                     <th class="text-center">Status</th>
                     <th class="text-center">DAR</th>
+                    <th class="text-center">Termo</th>
                     <th class="text-center">Ações</th>
                   </tr>
                 </thead>
@@ -639,6 +640,12 @@ async function carregarClientes(){
             </button>
           </td>
           <td class="text-center">
+            <button class="btn btn-sm btn-outline-success btn-termo" title="Emitir Termo"
+                    data-evento-id="${id}">
+              <i class="bi bi-file-earmark-text"></i>
+            </button>
+          </td>
+          <td class="text-center">
             <button class="btn btn-sm btn-outline-secondary btn-editar" title="Editar"
                     data-evento-id="${id}">
               <i class="bi bi-pencil"></i>
@@ -889,6 +896,7 @@ async function carregarClientes(){
     // Tabela principal
     eventosTableBody.addEventListener('click', async (e)=>{
       const btnDars   = e.target.closest('.btn-dars');
+      const btnTermo  = e.target.closest('.btn-termo');
       const btnApagar = e.target.closest('.btn-apagar');
       const btnEditar = e.target.closest('.btn-editar');
 
@@ -896,6 +904,24 @@ async function carregarClientes(){
         const eventoId = btnDars.dataset.eventoId;
         const eventoNome = btnDars.dataset.eventoNome || `#${eventoId}`;
         abrirModalDARs(eventoId, eventoNome);
+      }
+      if (btnTermo){
+        const eventoId = btnTermo.dataset.eventoId;
+        try{
+          const r = await fetch(`/api/admin/eventos/${eventoId}/termo`, { headers: AUTH_HEADERS });
+          if(!r.ok) throw new Error('Falha ao gerar termo');
+          const blob = await r.blob();
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement('a');
+          a.href = url;
+          a.download = `termo_evento_${eventoId}.pdf`;
+          document.body.appendChild(a);
+          a.click();
+          a.remove();
+          URL.revokeObjectURL(url);
+        }catch(err){
+          alert(`Erro ao gerar termo: ${err.message}`);
+        }
       }
       if (btnApagar){
         const eventoId = btnApagar.dataset.eventoId;

--- a/src/assets/termo_permissao_modelo.pdf
+++ b/src/assets/termo_permissao_modelo.pdf
@@ -1,0 +1,106 @@
+%PDF-1.3
+%
+7 0 obj
+<<
+/Type /Page
+/Parent 1 0 R
+/MediaBox [0 0 612 792]
+/Contents 5 0 R
+/Resources 6 0 R
+>>
+endobj
+6 0 obj
+<<
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font <<
+/F1 8 0 R
+>>
+/ColorSpace <<
+>>
+>>
+endobj
+5 0 obj
+<<
+/Length 107
+/Filter /FlateDecode
+>>
+stream
+xe=
+PE~Vq7BNN.o$.;dPWV;J*5='r=edXy;'zʽ%z
+endstream
+endobj
+10 0 obj
+(PDFKit)
+endobj
+11 0 obj
+(PDFKit)
+endobj
+12 0 obj
+(D:20250820190806Z)
+endobj
+9 0 obj
+<<
+/Producer 10 0 R
+/Creator 11 0 R
+/CreationDate 12 0 R
+>>
+endobj
+8 0 obj
+<<
+/Type /Font
+/BaseFont /Helvetica
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+>>
+endobj
+4 0 obj
+<<
+>>
+endobj
+3 0 obj
+<<
+/Type /Catalog
+/Pages 1 0 R
+/Names 2 0 R
+>>
+endobj
+1 0 obj
+<<
+/Type /Pages
+/Count 1
+/Kids [7 0 R]
+>>
+endobj
+2 0 obj
+<<
+/Dests <<
+  /Names [
+]
+>>
+>>
+endobj
+xref
+0 13
+0000000000 65535 f 
+0000000746 00000 n 
+0000000803 00000 n 
+0000000684 00000 n 
+0000000663 00000 n 
+0000000226 00000 n 
+0000000119 00000 n 
+0000000015 00000 n 
+0000000566 00000 n 
+0000000491 00000 n 
+0000000405 00000 n 
+0000000430 00000 n 
+0000000455 00000 n 
+trailer
+<<
+/Size 13
+/Root 3 0 R
+/Info 9 0 R
+/ID [<467557f7b3c4b612ae6049c444357c28> <467557f7b3c4b612ae6049c444357c28>]
+>>
+startxref
+850
+%%EOF

--- a/src/services/termoService.js
+++ b/src/services/termoService.js
@@ -1,0 +1,59 @@
+const fs = require('fs');
+const path = require('path');
+const { PDFDocument, StandardFonts } = require('pdf-lib');
+
+async function gerarTermoPermissao(evento, parcelas = []) {
+  const templatePath = path.join(__dirname, '..', 'assets', 'termo_permissao_modelo.pdf');
+  const templateBytes = fs.readFileSync(templatePath);
+  const pdfDoc = await PDFDocument.load(templateBytes);
+  const page = pdfDoc.getPages()[0];
+  const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
+
+  const draw = (text, x, y, options = {}) => {
+    page.drawText(text ?? '', { x, y, size: 12, font, ...options });
+  };
+
+  draw(`Processo: ${evento.numero_processo || ''}`, 50, 750);
+  draw(`Termo: ${evento.numero_termo || ''}`, 350, 750);
+
+  const cliente = `${evento.nome_razao_social || ''} - ${evento.documento || ''}`;
+  draw(cliente, 50, 730);
+
+  const datas = Array.isArray(evento.datas_evento)
+    ? evento.datas_evento.join(', ')
+    : String(evento.datas_evento || '');
+
+  const clausula1 =
+    `Área: ${evento.area_m2 || '-'} m², Evento: ${evento.nome_evento || '-'}, Datas: ${datas}, ` +
+    `Horário: ${evento.hora_inicio || '-'}-${evento.hora_fim || '-'}, Ofício SEI: ${evento.numero_oficio_sei || '-'}`;
+  draw(clausula1, 50, 700, { maxWidth: 500, lineHeight: 14 });
+
+  draw('Área', 60, 640);
+  draw(String(evento.area_m2 || '-'), 200, 640);
+  draw(String(evento.total_diarias || '-'), 300, 640);
+  const valorFmt = new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(
+    Number(evento.valor_final) || 0
+  );
+  draw(valorFmt, 400, 640);
+
+  const vigencia = evento.data_vigencia_final
+    ? new Date(evento.data_vigencia_final + 'T00:00:00').toLocaleDateString('pt-BR')
+    : '-';
+  draw(`Vigência até ${vigencia}`, 50, 610, { maxWidth: 500, lineHeight: 14 });
+
+  if (parcelas.length) {
+    const partes = parcelas.map(
+      p => `${p.numero_parcela}ª parcela em ${new Date(p.data_vencimento + 'T00:00:00').toLocaleDateString('pt-BR')} - ` +
+      new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(Number(p.valor_parcela) || 0)
+    );
+    draw('Pagamentos: ' + partes.join('; '), 50, 580, { maxWidth: 500, lineHeight: 14 });
+  }
+
+  const dataDoc = new Date().toLocaleDateString('pt-BR');
+  draw(`Maceió, ${dataDoc}`, 50, 520);
+
+  const pdfBytes = await pdfDoc.save();
+  return pdfBytes;
+}
+
+module.exports = { gerarTermoPermissao };


### PR DESCRIPTION
## Summary
- add PDF template and utility to fill "Termo de Permissão"
- expose `/api/admin/eventos/:id/termo` route using new service
- add "Emitir Termo" button on admin events page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a61c7bc0cc8333b65338fd52d610af