### PR TITLE
Sanitize SEFAZ receipt codes

### DIFF
--- a/cron/conciliarPagamentos.js
+++ b/cron/conciliarPagamentos.js
@@ -41,10 +41,16 @@ function toDateTimeISO(date, hh, mm, ss) {
 // ======= Receitas para conciliar =======
 function receitasAtivas() {
   const set = new Set();
-  const r1 = Number(process.env.RECEITA_CODIGO_PERMISSIONARIO || 0);
-  const r2 = Number(process.env.RECEITA_CODIGO_EVENTO || 0);
-  if (r1 > 0) set.add(r1);
-  if (r2 > 0) set.add(r2);
+  const r1 = Number(String(process.env.RECEITA_CODIGO_PERMISSIONARIO).replace(/\D/g, ''));
+  if (process.env.RECEITA_CODIGO_PERMISSIONARIO && !r1) {
+    throw new Error('RECEITA_CODIGO_PERMISSIONARIO inválido.');
+  }
+  const r2 = Number(String(process.env.RECEITA_CODIGO_EVENTO).replace(/\D/g, ''));
+  if (process.env.RECEITA_CODIGO_EVENTO && !r2) {
+    throw new Error('RECEITA_CODIGO_EVENTO inválido.');
+  }
+  if (r1) set.add(r1);
+  if (r2) set.add(r2);
   return Array.from(set);
 }
 

--- a/cron/conciliarPagamentosTeste.js
+++ b/cron/conciliarPagamentosTeste.js
@@ -32,10 +32,16 @@ function toDateTimeISO(date, hh, mm, ss) {
 
 function receitasAtivas() {
   const set = new Set();
-  const r1 = Number(process.env.RECEITA_CODIGO_PERMISSIONARIO || 0);
-  const r2 = Number(process.env.RECEITA_CODIGO_EVENTO || 0);
-  if (r1 > 0) set.add(r1);
-  if (r2 > 0) set.add(r2);
+  const r1 = Number(String(process.env.RECEITA_CODIGO_PERMISSIONARIO).replace(/\D/g, ''));
+  if (process.env.RECEITA_CODIGO_PERMISSIONARIO && !r1) {
+    throw new Error('RECEITA_CODIGO_PERMISSIONARIO inválido.');
+  }
+  const r2 = Number(String(process.env.RECEITA_CODIGO_EVENTO).replace(/\D/g, ''));
+  if (process.env.RECEITA_CODIGO_EVENTO && !r2) {
+    throw new Error('RECEITA_CODIGO_EVENTO inválido.');
+  }
+  if (r1) set.add(r1);
+  if (r2) set.add(r2);
   return Array.from(set);
 }
 

--- a/src/api/adminEventosRoutes.js
+++ b/src/api/adminEventosRoutes.js
@@ -255,6 +255,8 @@ router.post('/:eventoId/dars/:darId/reemitir', async (req, res) => {
     const tipoInscricao = documentoLimpo.length === 11 ? 3 : 4;
     const [ano, mes] = row.data_vencimento.split('-');
 
+    const receitaCod = Number(String(process.env.RECEITA_CODIGO_EVENTO).replace(/\D/g, ''));
+    if (!receitaCod) throw new Error('RECEITA_CODIGO_EVENTO inválido.');
     const payloadSefaz = {
       versao: '1.0',
       contribuinteEmitente: {
@@ -266,7 +268,7 @@ router.post('/:eventoId/dars/:darId/reemitir', async (req, res) => {
         numeroCep: onlyDigits(row.cep)
       },
       receitas: [{
-        codigo: Number(process.env.RECEITA_CODIGO_EVENTO),
+        codigo: receitaCod,
         competencia: { mes: Number(mes), ano: Number(ano) },
         valorPrincipal: row.valor,
         valorDesconto: 0.00,

--- a/src/api/darsRoutes.js
+++ b/src/api/darsRoutes.js
@@ -129,9 +129,9 @@ function buildSefazPayloadPermissionario({ perm, darLike }) {
   }
 
   const codigoIbge = Number(process.env.COD_IBGE_MUNICIPIO || 0);
-  const receitaCod = Number(process.env.RECEITA_CODIGO_PERMISSIONARIO || 0);
+  const receitaCod = Number(String(process.env.RECEITA_CODIGO_PERMISSIONARIO).replace(/\D/g, ''));
   if (!codigoIbge) throw new Error('COD_IBGE_MUNICIPIO não configurado (.env).');
-  if (!receitaCod) throw new Error('RECEITA_CODIGO_PERMISSIONARIO não configurado (.env).');
+  if (!receitaCod) throw new Error('RECEITA_CODIGO_PERMISSIONARIO inválido.');
 
   // Sem depender de colunas endereco/cep (usa fallbacks .env)
   const descricaoEndereco = (process.env.ENDERECO_PADRAO || 'R. Barão de Jaraguá, 590 - Jaraguá, Maceió/AL');

--- a/src/api/eventosRoutes.js
+++ b/src/api/eventosRoutes.js
@@ -149,6 +149,8 @@ router.post('/', async (req, res) => {
                 };
                 
                 // 3. Chama a API da SEFAZ
+                const receitaCod = Number(String(process.env.RECEITA_CODIGO_EVENTO).replace(/\D/g, ''));
+                if (!receitaCod) throw new Error('RECEITA_CODIGO_EVENTO inválido.');
                 const payloadSefaz = {
                     versao: '1.0',
                     contribuinteEmitente: {
@@ -160,7 +162,7 @@ router.post('/', async (req, res) => {
                         numeroCep: onlyDigits(cliente.cep)
                     },
                     receitas: [{
-                        codigo: Number(process.env.RECEITA_CODIGO_EVENTO),
+                        codigo: receitaCod,
                         competencia: { mes: dadosDar.mes_referencia, ano: dadosDar.ano_referencia },
                         valorPrincipal: dadosDar.valor,
                         valorDesconto: 0.00,

--- a/src/services/eventoDarService.js
+++ b/src/services/eventoDarService.js
@@ -115,6 +115,8 @@ async function criarEventoComDars(db, data, helpers) {
 
     const documentoLimpo = onlyDigits(cliente.documento);
     const tipoInscricao = documentoLimpo.length === 11 ? 3 : 4;
+    const receitaCod = Number(String(process.env.RECEITA_CODIGO_EVENTO).replace(/\D/g, ''));
+    if (!receitaCod) throw new Error('RECEITA_CODIGO_EVENTO inválido.');
 
     for (const [i, p] of parcelas.entries()) {
       const valorParcela = Number(p.valor) || 0;
@@ -152,7 +154,7 @@ async function criarEventoComDars(db, data, helpers) {
           numeroCep: onlyDigits(cliente.cep)
         },
         receitas: [{
-          codigo: Number(process.env.RECEITA_CODIGO_EVENTO),
+          codigo: receitaCod,
           competencia: { mes: Number(mes), ano: Number(ano) },
           valorPrincipal: valorParcela,
           valorDesconto: 0.00,
@@ -296,6 +298,8 @@ async function atualizarEventoComDars(db, id, data, helpers) {
 
     const docLimpo = onlyDigits(cliente.documento);
     const tipoInscricao = docLimpo.length === 11 ? 3 : 4;
+    const receitaCod = Number(String(process.env.RECEITA_CODIGO_EVENTO).replace(/\D/g, ''));
+    if (!receitaCod) throw new Error('RECEITA_CODIGO_EVENTO inválido.');
 
     for (let i = 0; i < parcelas.length; i++) {
       const p = parcelas[i];
@@ -333,7 +337,7 @@ async function atualizarEventoComDars(db, id, data, helpers) {
           numeroCep: onlyDigits(cliente.cep)
         },
         receitas: [{
-          codigo: Number(process.env.RECEITA_CODIGO_EVENTO),
+          codigo: receitaCod,
           competencia: { mes: Number(mes), ano: Number(ano) },
           valorPrincipal: valorParcela,
           valorDesconto: 0.00,

--- a/src/utils/sefazPayload.js
+++ b/src/utils/sefazPayload.js
@@ -53,9 +53,9 @@ function buildSefazPayloadPermissionario({ perm, darLike }) {
   }
 
   const codigoIbge = Number(process.env.COD_IBGE_MUNICIPIO || 0);
-  const receitaCod = Number(process.env.RECEITA_CODIGO_PERMISSIONARIO || 0);
+  const receitaCod = Number(String(process.env.RECEITA_CODIGO_PERMISSIONARIO).replace(/\D/g, ''));
   if (!codigoIbge) throw new Error('COD_IBGE_MUNICIPIO não configurado (.env).');
-  if (!receitaCod) throw new Error('RECEITA_CODIGO_PERMISSIONARIO não configurado (.env).');
+  if (!receitaCod) throw new Error('RECEITA_CODIGO_PERMISSIONARIO inválido.');
 
   // Endereço/CEP — fallbacks
   const descricaoEndereco =


### PR DESCRIPTION
## Summary
- sanitize and validate SEFAZ receipt codes from environment variables across services and routes
- ensure guide emission normalizes `receitas` codes before calling SEFAZ API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a61ffb20d08333ab2d1088a1f28b99