### PR TITLE
Add DAR detail route for bot and handle 409 emissions

### DIFF
--- a/src/bot/index.js
+++ b/src/bot/index.js
@@ -1,0 +1,32 @@
+const axios = require('axios');
+
+/**
+ * Emite uma DAR pelo endpoint do bot. Caso a DAR já esteja emitida (409),
+ * realiza uma chamada à rota de consulta para obter dados da guia existente.
+ *
+ * @param {string} baseURL - URL base da API.
+ * @param {number} darId - Identificador da DAR.
+ * @param {{ msisdn?: string }} [body] - Dados enviados na emissão.
+ * @returns {Promise<object>} Resposta da API ou dados da DAR existente.
+ */
+async function apiEmitDar(baseURL, darId, body = {}) {
+  try {
+    const res = await axios.post(`${baseURL}/api/bot/dars/${darId}/emit`, body);
+    return res.data;
+  } catch (err) {
+    if (err.response && err.response.status === 409) {
+      // DAR já emitida: buscar dados existentes
+      try {
+        const msisdn = body.msisdn;
+        const info = await axios.get(`${baseURL}/api/bot/dars/${darId}`, { params: { msisdn } });
+        return info.data;
+      } catch (consultaErr) {
+        // se a consulta falhar, retorna o erro original
+        throw err;
+      }
+    }
+    throw err;
+  }
+}
+
+module.exports = { apiEmitDar };


### PR DESCRIPTION
## Summary
- add GET /api/bot/dars/:darId to fetch linha digitável, competência, vencimento and valor with msisdn validation
- create bot helper apiEmitDar that falls back to detail route when emission returns 409

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a62ecb9f288333986792515d4890eb