### PR TITLE
Set Content-Length for termo PDF and send with res.end

### DIFF
--- a/src/api/adminEventosRoutes.js
+++ b/src/api/adminEventosRoutes.js
@@ -374,7 +374,8 @@ router.get('/:id/termo', async (req, res) => {
     const pdfBytes = await gerarTermoPermissao(ev, parcelas);
     res.setHeader('Content-Type', 'application/pdf');
     res.setHeader('Content-Disposition', `attachment; filename="termo_evento_${id}.pdf"`);
-    res.send(Buffer.from(pdfBytes));
+    res.setHeader('Content-Length', pdfBytes.length);
+    res.end(Buffer.from(pdfBytes));
   } catch (err) {
     console.error('[admin/eventos] termo erro:', err.message);
     res.status(500).json({ error: 'Falha ao gerar termo.' });


### PR DESCRIPTION
## Summary
- Add explicit Content-Length header when serving event term PDFs
- Use `res.end` for PDF response buffering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6363df1e083338739f9db952b0330