### PR TITLE
Add TermoService for template population and PDF validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.zip
+node_modules/
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "sistemadepagamentocipt",
+  "version": "1.0.0",
+  "type": "commonjs",
+  "scripts": {
+    "test": "node test/TermoService.test.js"
+  },
+  "dependencies": {
+    "pdfkit": "^0.13.0"
+  }
+}

--- a/src/services/TermoService.js
+++ b/src/services/TermoService.js
@@ -1,0 +1,59 @@
+class TermoService {
+  static _formatCurrency(value) {
+    return new Intl.NumberFormat('pt-BR', {
+      style: 'currency',
+      currency: 'BRL'
+    }).format(value).replace(/\u00A0/g, ' ');
+  }
+
+  static _formatDate(date) {
+    return new Intl.DateTimeFormat('pt-BR', {
+      day: '2-digit',
+      month: 'long',
+      year: 'numeric'
+    }).format(new Date(date));
+  }
+
+  static populateTemplate(template, data) {
+    const replacements = {
+      valor: data.valor !== undefined ? this._formatCurrency(data.valor) : undefined,
+      data: data.data ? this._formatDate(data.data) : undefined,
+      vigenciaInicio: data.vigencia && data.vigencia.inicio ? this._formatDate(data.vigencia.inicio) : undefined,
+      vigenciaFim: data.vigencia && data.vigencia.fim ? this._formatDate(data.vigencia.fim) : undefined,
+      saldoPagamento: data.saldoPagamento !== undefined ? this._formatCurrency(data.saldoPagamento) : undefined,
+      clausulas: Array.isArray(data.clausulas) ? data.clausulas.join('; ') : undefined
+    };
+
+    return template.replace(/\{\{(\w+)\}\}/g, (_, key) => {
+      return replacements[key] !== undefined ? replacements[key] : '';
+    });
+  }
+
+  static async generatePdf(template, data) {
+    if (typeof data.saldoPagamento !== 'number' || data.saldoPagamento <= 0) {
+      throw new Error('Saldo de pagamento insuficiente.');
+    }
+    if (!data.vigencia || !data.vigencia.inicio || !data.vigencia.fim) {
+      throw new Error('Período de vigência inválido.');
+    }
+    if (!Array.isArray(data.clausulas) || data.clausulas.length === 0) {
+      throw new Error('Cláusulas específicas não informadas.');
+    }
+
+    const content = this.populateTemplate(template, data);
+
+    const PDFDocument = require('pdfkit');
+    const doc = new PDFDocument();
+    const chunks = [];
+
+    return await new Promise((resolve, reject) => {
+      doc.on('data', (chunk) => chunks.push(chunk));
+      doc.on('end', () => resolve(Buffer.concat(chunks)));
+      doc.on('error', reject);
+      doc.text(content);
+      doc.end();
+    });
+  }
+}
+
+module.exports = TermoService;

--- a/test/TermoService.test.js
+++ b/test/TermoService.test.js
@@ -1,0 +1,30 @@
+const assert = require('assert');
+const TermoService = require('../src/services/TermoService');
+
+const template = 'Evento em {{data}} com valor de {{valor}}. Vigência: {{vigenciaInicio}} a {{vigenciaFim}}. Saldo: {{saldoPagamento}}. Cláusulas: {{clausulas}}.';
+const dados = {
+  data: '2025-08-12',
+  valor: 2495,
+  vigencia: { inicio: '2025-01-01', fim: '2025-12-31' },
+  saldoPagamento: 3000,
+  clausulas: ['Cláusula 1', 'Cláusula 2']
+};
+
+const resultado = TermoService.populateTemplate(template, dados);
+assert.ok(resultado.includes('12 de agosto de 2025'));
+assert.ok(resultado.includes('R$ 2.495,00'));
+
+ (async () => {
+  const pdf = await TermoService.generatePdf(template, dados);
+  assert.ok(Buffer.isBuffer(pdf) && pdf.length > 0);
+
+  let erroCapturado = false;
+  try {
+    await TermoService.generatePdf(template, { ...dados, saldoPagamento: 0 });
+  } catch (err) {
+    erroCapturado = true;
+  }
+  assert.ok(erroCapturado, 'Deve lançar erro quando não há saldo de pagamento');
+
+  console.log('Todos os testes passaram.');
+ })();


### PR DESCRIPTION
## Summary
- add TermoService.populateTemplate to replace placeholders with localized currency and date formats
- validate payment balance, period and clauses before generating PDF
- cover formatting and validation with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a63c28d93c8333bdcaf0489b787bde