### PR TITLE
Adicionar select de espaço com mapeamento de área e capacidade

### DIFF
--- a/public/admin/eventos-dars.html
+++ b/public/admin/eventos-dars.html
@@ -128,7 +128,14 @@
             <label for="numero-oficio-sei" class="form-label">Número do Ofício SEI</label>
             <input type="text" class="form-control" id="numero-oficio-sei">
             <label for="espaco-utilizado" class="form-label">Espaço Utilizado</label>
-            <input type="text" class="form-control" id="espaco-utilizado">
+            <select class="form-select" id="espaco-utilizado">
+              <option value="">Selecione...</option>
+              <option value="Auditório">Auditório</option>
+              <option value="Hall">Hall</option>
+              <option value="Coworking">Coworking</option>
+              <option value="Área Externa">Área Externa</option>
+            </select>
+            <small id="capacidade-espaco" class="form-text text-muted"></small>
           </div>
           <div class="mb-3">
             <label for="area-m2" class="form-label">Área (m²)</label>
@@ -368,8 +375,16 @@ window.onload = () => {
   const numeroOficioSeiInput = document.getElementById('numero-oficio-sei');
   const numeroProcessoInput = document.getElementById('numero-processo');
   const numeroTermoInput = document.getElementById('numero-termo');
-  const espacoUtilizadoInput = document.getElementById('espaco-utilizado');
+  const espacoUtilizadoSelect = document.getElementById('espaco-utilizado');
+  const capacidadeEspacoDisplay = document.getElementById('capacidade-espaco');
   const areaM2Input = document.getElementById('area-m2');
+
+  const ESPACOS_MAPA = {
+    'Auditório':   { area: 313, capacidade: 313 },
+    'Hall':        { area: 200, capacidade: 150 },
+    'Coworking':   { area: 100, capacidade: 50 },
+    'Área Externa':{ area: 500, capacidade: 500 }
+  };
 
   const numeroOficioSeiMask = IMask(numeroOficioSeiInput, { mask: '00000.000000/0000-00' });
   const numeroProcessoMask  = IMask(numeroProcessoInput, {
@@ -389,6 +404,17 @@ window.onload = () => {
       { mask: '0000/0000' },
       { mask: '00000/0000' }
     ]
+  });
+
+  espacoUtilizadoSelect.addEventListener('change', () => {
+    const info = ESPACOS_MAPA[espacoUtilizadoSelect.value] || null;
+    if (info) {
+      areaM2Input.value = info.area;
+      capacidadeEspacoDisplay.textContent = `Capacidade: ${info.capacidade} pessoas`;
+    } else {
+      areaM2Input.value = '';
+      capacidadeEspacoDisplay.textContent = '';
+    }
   });
 
   const parcelasContainer = document.getElementById('parcelas-container');
@@ -715,7 +741,7 @@ async function carregarClientes(){
     const tipo_desconto_auto = ev.tipo_desconto_auto ?? ev.tipoDescontoAuto ?? ev.tipo_cliente ?? 'Geral';
     const desconto_manual_percent = ev.desconto_manual_percent ?? ev.descontoManualPercent ?? ev.desconto ?? 0;
     const espaco_utilizado = ev.espaco_utilizado ?? ev.espacoUtilizado ?? '';
-    const area_m2 = ev.area_m2 ?? ev.areaM2 ?? null;
+    const area_m2 = ev.area_m2 ?? ev.areaM2 ?? (ESPACOS_MAPA[espaco_utilizado]?.area ?? null);
     const numero_processo = ev.numero_processo ?? ev.numeroProcesso ?? '';
     const numero_termo = ev.numero_termo ?? ev.numeroTermo ?? '';
     let datas_evento = ev.datas_evento ?? ev.datas ?? ev.datasEvento ?? [];
@@ -766,8 +792,9 @@ async function carregarClientes(){
     clienteSelect.value = ev.id_cliente || '';
     document.getElementById('nome-evento').value = ev.nome_evento || '';
     numeroOficioSeiMask.value = ev.numero_oficio_sei || '';
-    espacoUtilizadoInput.value = ev.espaco_utilizado || '';
-    areaM2Input.value = ev.area_m2 != null ? ev.area_m2 : '';
+    espacoUtilizadoSelect.value = ev.espaco_utilizado || '';
+    espacoUtilizadoSelect.dispatchEvent(new Event('change'));
+    if (ev.area_m2 != null) areaM2Input.value = ev.area_m2;
     horaInicioInput.value = ev.hora_inicio || '';
     horaFimInput.value = ev.hora_fim || '';
     horaMontagemInput.value = ev.hora_montagem || '';
@@ -1059,7 +1086,7 @@ async function carregarClientes(){
       totalDiarias: n,
       valorBruto: vb,
       valorFinal: vf,
-      espacoUtilizado: espacoUtilizadoInput.value,
+      espacoUtilizado: espacoUtilizadoSelect.value,
       areaM2: parseFloat(areaM2Input.value) || null,
       horaInicio: horaInicioInput.value || null,
       horaFim: horaFimInput.value || null,
@@ -1108,6 +1135,7 @@ async function carregarClientes(){
   addEventoBtn.addEventListener('click', () => {
   form.reset();
   fp.clear();
+  capacidadeEspacoDisplay.textContent = '';
   parcelasContainer.innerHTML = '';
   if (parcelasMasks.length) {
     parcelasMasks.forEach(({ valorMask, picker }) => { valorMask.destroy(); picker.destroy(); });


### PR DESCRIPTION
## Resumo
- Substitui campo de texto de espaço por `<select>` com opções pré-definidas e exibição de capacidade
- Mapeia cada espaço para área e capacidade, atualizando automaticamente a área informada
- Ajusta normalização e envio do formulário para usar o valor selecionado

## Testes
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a659751bbc8333a27b3942bb8ed859