### PR TITLE
Generate linha digitavel from numero_documento when missing

### DIFF
--- a/src/api/botRoutes.js
+++ b/src/api/botRoutes.js
@@ -441,6 +441,11 @@ router.get('/dars/:darId', botAuthMiddleware, async (req, res) => {
       const cb = codigo_barras || numero_documento;
       if (cb) {
         ld = codigoBarrasParaLinhaDigitavel(cb);
+        if (ld) {
+          try {
+            await qRun('UPDATE dars SET linha_digitavel = ? WHERE id = ?', [ld, ctx.dar.id]);
+          } catch {}
+        }
       }
     }
     const competencia = `${String(mes_referencia).padStart(2, '0')}/${ano_referencia}`;

--- a/tests/botRoutes.test.js
+++ b/tests/botRoutes.test.js
@@ -81,6 +81,17 @@ test('GET /api/bot/dars/:id retorna linha_digitavel a partir do codigo_barras', 
   assert.strictEqual(res.body.dar.linha_digitavel, EXPECTED);
 });
 
+test('GET /api/bot/dars/:id usa numero_documento quando codigo_barras é nulo', async () => {
+  await reset();
+  await run('UPDATE dars SET codigo_barras=NULL, numero_documento=? WHERE id=1', [BARCODE]);
+  const res = await request
+    .get('/api/bot/dars/1')
+    .set('X-Bot-Key', 'secret')
+    .query({ msisdn: MSISDN });
+  assert.strictEqual(res.statusCode, 200);
+  assert.strictEqual(res.body.dar.linha_digitavel, EXPECTED);
+});
+
 test('POST /api/bot/dars/:id/emit gera linha_digitavel quando apenas codigo_barras é retornado', async () => {
   await reset();
   const res = await request


### PR DESCRIPTION
## Summary
- compute linha_digitavel from codigo_barras or numero_documento in bot DAR route and persist to DB
- add test for numero_documento fallback when codigo_barras is null

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6627c0b008333ba8c05b29e720f23