### PR TITLE
Store SEFAZ barcode when emitting DARs

### DIFF
--- a/src/api/botRoutes.js
+++ b/src/api/botRoutes.js
@@ -583,9 +583,10 @@ router.post('/dars/:darId/emit', botAuthMiddleware, async (req, res) => {
       throw new Error('Retorno da SEFAZ incompleto (numeroGuia/pdfBase64).');
     }
 
+    const codigoBarras = sefazResp.codigoBarras || null;
     const linhaDigitavel =
       (sefazResp.linhaDigitavel && sefazResp.linhaDigitavel.trim()) ||
-      (sefazResp.codigoBarras ? codigoBarrasParaLinhaDigitavel(sefazResp.codigoBarras) : null);
+      (codigoBarras ? codigoBarrasParaLinhaDigitavel(codigoBarras) : null);
 
     // Token opcional no PDF
     let pdfOut = sefazResp.pdfBase64;
@@ -606,7 +607,7 @@ router.post('/dars/:darId/emit', botAuthMiddleware, async (req, res) => {
              linha_digitavel = COALESCE(?, linha_digitavel),
              status = 'Emitido'
        WHERE id = ?`,
-      [sefazResp.numeroGuia, pdfOut, sefazResp.codigoBarras, linhaDigitavel, darId]
+      [sefazResp.numeroGuia, pdfOut, codigoBarras, linhaDigitavel, darId]
     );
 
     return res.json({
@@ -614,6 +615,7 @@ router.post('/dars/:darId/emit', botAuthMiddleware, async (req, res) => {
       darId,
       numero_documento: sefazResp.numeroGuia,
       linha_digitavel: linhaDigitavel,
+      codigo_barras: codigoBarras,
       pdf_url: pdfOut
     });
   } catch (err) {
@@ -693,9 +695,10 @@ router.post('/dars/:darId/reemit', botAuthMiddleware, async (req, res) => {
       throw new Error('Retorno da SEFAZ incompleto (numeroGuia/pdfBase64).');
     }
 
+    const codigoBarras = sefazResp.codigoBarras || null;
     const linhaDigitavel =
       (sefazResp.linhaDigitavel && sefazResp.linhaDigitavel.trim()) ||
-      (sefazResp.codigoBarras ? codigoBarrasParaLinhaDigitavel(sefazResp.codigoBarras) : null);
+      (codigoBarras ? codigoBarrasParaLinhaDigitavel(codigoBarras) : null);
 
     // Token opcional
     let pdfOut = sefazResp.pdfBase64;
@@ -714,7 +717,7 @@ router.post('/dars/:darId/reemit', botAuthMiddleware, async (req, res) => {
              linha_digitavel = COALESCE(?, linha_digitavel),
              status = 'Reemitido'
        WHERE id = ?`,
-      [sefazResp.numeroGuia, pdfOut, sefazResp.codigoBarras, linhaDigitavel, darId]
+      [sefazResp.numeroGuia, pdfOut, codigoBarras, linhaDigitavel, darId]
     );
 
     return res.json({
@@ -722,6 +725,7 @@ router.post('/dars/:darId/reemit', botAuthMiddleware, async (req, res) => {
       darId,
       numero_documento: sefazResp.numeroGuia,
       linha_digitavel: linhaDigitavel,
+      codigo_barras: codigoBarras,
       pdf_url: pdfOut
     });
   } catch (err) {

--- a/tests/botRoutes.test.js
+++ b/tests/botRoutes.test.js
@@ -92,25 +92,32 @@ test('GET /api/bot/dars/:id usa numero_documento quando codigo_barras é nulo', 
   assert.strictEqual(res.body.dar.linha_digitavel, EXPECTED);
 });
 
-test('POST /api/bot/dars/:id/emit gera linha_digitavel quando apenas codigo_barras é retornado', async () => {
+test('POST /api/bot/dars/:id/emit grava codigo_barras e linha_digitavel', async () => {
   await reset();
+  await run('UPDATE dars SET codigo_barras=NULL WHERE id=1');
   const res = await request
     .post('/api/bot/dars/1/emit')
     .set('X-Bot-Key', 'secret')
     .send({ msisdn: MSISDN });
   assert.strictEqual(res.statusCode, 200);
   assert.strictEqual(res.body.linha_digitavel, EXPECTED);
-  const row = await get('SELECT linha_digitavel FROM dars WHERE id = 1');
+  assert.strictEqual(res.body.codigo_barras, BARCODE);
+  const row = await get('SELECT linha_digitavel, codigo_barras FROM dars WHERE id = 1');
   assert.strictEqual(row.linha_digitavel, EXPECTED);
+  assert.strictEqual(row.codigo_barras, BARCODE);
 });
 
-test('POST /api/bot/dars/:id/reemit também retorna linha_digitavel', async () => {
+test('POST /api/bot/dars/:id/reemit grava codigo_barras e linha_digitavel', async () => {
   await reset();
-  await run(`UPDATE dars SET status='Emitido', numero_documento='old', linha_digitavel=NULL WHERE id=1`);
+  await run("UPDATE dars SET status='Emitido', numero_documento='old', linha_digitavel=NULL, codigo_barras=NULL WHERE id=1");
   const res = await request
     .post('/api/bot/dars/1/reemit')
     .set('X-Bot-Key', 'secret')
     .send({ msisdn: MSISDN });
   assert.strictEqual(res.statusCode, 200);
   assert.strictEqual(res.body.linha_digitavel, EXPECTED);
+  assert.strictEqual(res.body.codigo_barras, BARCODE);
+  const row = await get('SELECT linha_digitavel, codigo_barras FROM dars WHERE id = 1');
+  assert.strictEqual(row.linha_digitavel, EXPECTED);
+  assert.strictEqual(row.codigo_barras, BARCODE);
 });


### PR DESCRIPTION
## Summary
- capture `codigoBarras` from SEFAZ and persist as `codigo_barras`
- ensure `dars.codigo_barras` column exists
- test barcode persistence on DAR emission and reemission

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6655298688333935bd966148a87a7