### PR TITLE
Prefer signed term PDF when downloading

### DIFF
--- a/public/eventos/meus-eventos.html
+++ b/public/eventos/meus-eventos.html
@@ -207,7 +207,7 @@
             try{
               const r = await fetch(`/api/portal/eventos/${eventoId}/termo/meta`, { headers });
               const j = await r.json();
-              const url = j.pdf_public_url || j.url_visualizacao || j.pdf_url;
+              const url = j.signed_pdf_public_url || j.url_visualizacao || j.pdf_public_url || j.pdf_url;
               if (!r.ok || !url) throw new Error(j.error || 'Termo indisponível.');
               window.open(url, '_blank');
             }catch(err){

--- a/src/api/portalAssinaturaRoutes.js
+++ b/src/api/portalAssinaturaRoutes.js
@@ -8,6 +8,7 @@ const fs      = require('fs');
 const https   = require('https');
 const sqlite3 = require('sqlite3').verbose();
 const axios   = require('axios');
+const path    = require('path');
 
 const authMiddleware  = require('../middleware/authMiddleware');
 const authorizeRole   = require('../middleware/roleMiddleware');
@@ -82,12 +83,17 @@ router.get(
       if (!doc) return res.status(404).json({ error: 'Termo não localizado.' });
 
       const out = {};
-      if (doc.pdf_public_url) out.pdf_public_url = doc.pdf_public_url;
-      if (doc.assinafy_id) out.url_visualizacao = `/api/documentos/assinafy/${encodeURIComponent(doc.assinafy_id)}/open`;
-      if (!out.pdf_public_url && !out.url_visualizacao && doc.pdf_url && fs.existsSync(doc.pdf_url)) {
+      if (doc.signed_pdf_public_url) {
+        out.signed_pdf_public_url = doc.signed_pdf_public_url;
+      } else if (doc.assinafy_id) {
+        out.url_visualizacao = `/api/documentos/assinafy/${encodeURIComponent(doc.assinafy_id)}/open`;
+      } else if (doc.pdf_public_url) {
+        out.pdf_public_url = doc.pdf_public_url;
+      } else if (doc.pdf_url && fs.existsSync(doc.pdf_url)) {
         out.pdf_url = doc.pdf_url; // servidor deve expor estaticamente se quiser
       }
-      if (!out.pdf_public_url && !out.url_visualizacao && !out.pdf_url) {
+
+      if (!out.signed_pdf_public_url && !out.url_visualizacao && !out.pdf_public_url && !out.pdf_url) {
         return res.status(409).json({ error: 'Termo ainda não disponível.' });
       }
       res.json(out);


### PR DESCRIPTION
## Summary
- Return signed PDF link or Assinafy URL from term metadata endpoint
- Use signed PDF or Assinafy link when downloading term in events page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a720435b688333a2f092a7b72ca1d5