### PR TITLE
Desabilita reenvio de termo de eventos

### DIFF
--- a/public/admin/eventos-dars.html
+++ b/public/admin/eventos-dars.html
@@ -693,7 +693,7 @@ async function carregarClientes(){
       if (!r.ok) throw new Error('Falha ao buscar eventos');
       const evs = await r.json();
       eventosTableBody.innerHTML = '';
-      (evs||[]).forEach(ev=>{
+      for (const ev of (evs||[])){
         const id = evIdOf(ev);
         const status = ev.status || 'Pendente';
         const badge = status==='Pago' ? 'bg-success'
@@ -702,6 +702,17 @@ async function carregarClientes(){
         const vfNum = typeof ev.valor_final==='number'
           ? ev.valor_final
           : parseFloat(String(ev.valor_final||'0').replace(/\./g,'').replace(',','.'))||0;
+
+        let btnAssinaturaDisabled = '';
+        try {
+          const rMeta = await fetch(`/api/documentos/termo/${id}/meta`, { headers: AUTH_HEADERS });
+          if (!rMeta.ok) throw new Error('meta');
+          const meta = await rMeta.json();
+          if (meta.status !== 'gerado') btnAssinaturaDisabled = 'disabled';
+        } catch {
+          btnAssinaturaDisabled = 'disabled';
+        }
+
         const tr = document.createElement('tr');
         tr.innerHTML = `
           <td>${id}</td>
@@ -723,7 +734,7 @@ async function carregarClientes(){
             <i class="bi bi-file-earmark-text"></i>
           </button>
           <button class="btn btn-sm btn-outline-primary btn-enviar-assinafy" title="Enviar p/ assinatura"
-                  data-evento-id="${id}">
+                  data-evento-id="${id}" ${btnAssinaturaDisabled}>
             <i class="bi bi-pen"></i>
           </button>
         </div>
@@ -739,7 +750,7 @@ async function carregarClientes(){
             </button>
           </td>`;
         eventosTableBody.appendChild(tr);
-      });
+      }
     }catch(e){
       console.error(e);
       eventosTableBody.innerHTML = '<tr><td colspan="8" class="text-center text-danger">Erro ao carregar eventos.</td></tr>';
@@ -1050,7 +1061,7 @@ async function carregarClientes(){
       const btnAssinafy = e.target.closest('.btn-enviar-assinafy');
         if (btnAssinafy) {
           const eventoId = btnAssinafy.dataset.eventoId;
-        
+
           // evita duplo clique
           if (btnAssinafy.dataset.loading === '1') return;
           const original = btnAssinafy.innerHTML;
@@ -1058,22 +1069,28 @@ async function carregarClientes(){
           btnAssinafy.disabled = true;
           btnAssinafy.setAttribute('aria-busy','true');
           btnAssinafy.innerHTML = `<span class="spinner-border spinner-border-sm me-1"></span> Enviando...`;
-        
+
+          let sucesso = false;
           try {
-            const r = await fetch(`/api/admin/eventos/${eventoId}/termo/enviar-assinafy`, {
+            const r = await fetch(`/api/admin/eventos/${eventoId}/termo/enviar-assinatura`, {
               method: 'POST',
               headers: AUTH_HEADERS
             });
             const j = await r.json().catch(()=> ({}));
             if (!r.ok || !j.ok) throw new Error(j.error || 'Falha no envio');
+            sucesso = true;
             alert('Documento enviado para assinatura com sucesso!');
+            // Oculta o botão para impedir reenvio
+            btnAssinafy.style.display = 'none';
           } catch (err) {
             alert(`Erro: ${err.message}`);
           } finally {
-            btnAssinafy.disabled = false;
             btnAssinafy.dataset.loading = '0';
             btnAssinafy.removeAttribute('aria-busy');
-            btnAssinafy.innerHTML = original;
+            if (!sucesso) {
+              btnAssinafy.disabled = false;
+              btnAssinafy.innerHTML = original;
+            }
           }
           return;
         }


### PR DESCRIPTION
## Summary
- consulta metadata do termo ao listar eventos e desabilita envio quando não gerado
- usa `/api/admin/eventos/:id/termo/enviar-assinatura` e oculta botão após envio

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a72bae23b08333ad5ab3c6022dc0bb