### PR TITLE
Avoid regenerating signed event term PDFs

### DIFF
--- a/public/admin/eventos-dars.html
+++ b/public/admin/eventos-dars.html
@@ -1035,10 +1035,26 @@ async function carregarClientes(){
           <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
           Gerando...
         `;
-      
+
         try{
-          const r = await fetch(`/api/admin/eventos/${eventoId}/termo`, { headers: AUTH_HEADERS, cache: 'no-store', });
-          if(!r.ok) throw new Error('Falha ao gerar termo');
+          let meta;
+          try {
+            const rMeta = await fetch(`/api/documentos/termo/${eventoId}/meta`, { headers: AUTH_HEADERS, cache: 'no-store' });
+            if (rMeta.ok) meta = await rMeta.json();
+          } catch {}
+
+          if (meta?.signed_pdf_public_url) {
+            const a = document.createElement('a');
+            a.href = meta.signed_pdf_public_url;
+            a.download = `termo_evento_${eventoId}.pdf`;
+            document.body.appendChild(a);
+            a.click();
+            a.remove();
+            return;
+          }
+
+          const r = await fetch(`/api/admin/eventos/${eventoId}/termo`, { headers: AUTH_HEADERS, cache: 'no-store' });
+          if (!r.ok) throw new Error('Falha ao gerar termo');
           const blob = await r.blob();
           const url = URL.createObjectURL(blob);
           const a = document.createElement('a');

--- a/src/api/adminTermoEventosRoutes.js
+++ b/src/api/adminTermoEventosRoutes.js
@@ -202,6 +202,22 @@ router.get(
 
       const { eventoId } = req.params;
 
+      // Se houver PDF assinado, retorna diretamente
+      const docAssinado = await dbGet(
+        `SELECT signed_pdf_public_url FROM documentos WHERE evento_id = ? AND tipo = 'termo_evento' ORDER BY id DESC LIMIT 1`,
+        [eventoId]
+      );
+      if (docAssinado?.signed_pdf_public_url) {
+        const filePath = path.join(
+          process.cwd(),
+          'public',
+          docAssinado.signed_pdf_public_url.replace(/^\/+/, '')
+        );
+        if (fs.existsSync(filePath)) {
+          return res.sendFile(filePath);
+        }
+      }
+
       // Evento + Cliente
       const ev = await dbGet(
         `SELECT e.*, c.nome_razao_social, c.tipo_pessoa, c.documento, c.email, c.telefone,


### PR DESCRIPTION
## Summary
- Serve existing signed term document in admin route before generating a new PDF
- Make "Emitir Termo" button download signed term directly when available

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a72d3135408333a0dc7c915b0afae6