### PR TITLE
Corrige derivação de código de barras na emissão de DAR

### DIFF
--- a/src/utils/boleto.js
+++ b/src/utils/boleto.js
@@ -96,4 +96,43 @@ function codigoBarrasParaLinhaDigitavel(codigo = '') {
   return '';
 }
 
-module.exports = { codigoBarrasParaLinhaDigitavel };
+/** 48 (arrecadação) -> 44 (removendo DVs de cada bloco) */
+function linha48ToCodigo44(ld48 = '') {
+  const d = onlyDigits(ld48);
+  if (d.length !== 48 || d[0] !== '8') return '';
+  const b1 = d.slice(0, 12);
+  const b2 = d.slice(12, 24);
+  const b3 = d.slice(24, 36);
+  const b4 = d.slice(36, 48);
+  return b1.slice(0, 11) + b2.slice(0, 11) + b3.slice(0, 11) + b4.slice(0, 11);
+}
+
+/** 47 (boleto) -> 44 (layout FEBRABAN) */
+function linha47ToCodigo44(ld47 = '') {
+  const d = onlyDigits(ld47);
+  if (d.length !== 47) return '';
+  const c1 = d.slice(0, 9);
+  const c2 = d.slice(10, 20);
+  const c3 = d.slice(21, 31);
+  const dvGeral = d.slice(32, 33);
+  const fatorValor = d.slice(33, 47);
+  const bancoMoeda = c1.slice(0, 4);
+  const campoLivre = c1.slice(4, 9) + c2 + c3;
+  return bancoMoeda + dvGeral + fatorValor + campoLivre;
+}
+
+/**
+ * Inverte `codigoBarrasParaLinhaDigitavel`: converte uma linha digitável (47/48)
+ * em código de barras (44). Caso não seja possível converter, retorna string vazia.
+ */
+function linhaDigitavelParaCodigoBarras(linha = '') {
+  const d = onlyDigits(linha);
+  if (!d) return '';
+
+  if (d.length === 44) return d; // já é código de barras
+  if (d.length === 48 && d[0] === '8') return linha48ToCodigo44(d) || '';
+  if (d.length === 47) return linha47ToCodigo44(d) || '';
+  return '';
+}
+
+module.exports = { codigoBarrasParaLinhaDigitavel, linhaDigitavelParaCodigoBarras };

--- a/tests/darsRoutesEmitir.test.js
+++ b/tests/darsRoutesEmitir.test.js
@@ -1,0 +1,56 @@
+// tests/darsRoutesEmitir.test.js
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const fs = require('fs');
+const express = require('express');
+const supertest = require('supertest');
+
+const { codigoBarrasParaLinhaDigitavel, linhaDigitavelParaCodigoBarras } = require('../src/utils/boleto');
+
+test('codigo_barras atualizado a partir da linha digitavel', async () => {
+  const dbPath = path.resolve(__dirname, 'test-dars.db');
+  try { fs.unlinkSync(dbPath); } catch {}
+  process.env.SQLITE_STORAGE = dbPath;
+
+  const db = require('../src/database/db');
+  const run = (sql, params = []) => new Promise((res, rej) => db.run(sql, params, err => err ? rej(err) : res()));
+  const get = (sql, params = []) => new Promise((res, rej) => db.get(sql, params, (err, row) => err ? rej(err) : res(row)));
+
+  await run(`CREATE TABLE permissionarios (id INTEGER PRIMARY KEY, nome_empresa TEXT, cnpj TEXT, numero_documento TEXT, telefone_cobranca TEXT)`);
+  await run(`CREATE TABLE dars (id INTEGER PRIMARY KEY, permissionario_id INTEGER, data_vencimento TEXT, mes_referencia INTEGER, ano_referencia INTEGER, valor REAL, status TEXT, numero_documento TEXT, pdf_url TEXT, linha_digitavel TEXT, codigo_barras TEXT, link_pdf TEXT)`);
+  await run(`INSERT INTO permissionarios (id, nome_empresa, cnpj) VALUES (1, 'Perm', '12345678000199')`);
+  await run(`INSERT INTO dars (id, permissionario_id, data_vencimento, mes_referencia, ano_referencia, valor, status) VALUES (10, 1, '2025-12-31', 12, 2025, 100, 'Novo')`);
+
+  const cbOrig = '21290001192110001210904475617405975870000002000';
+  const ld = codigoBarrasParaLinhaDigitavel(cbOrig);
+  const cb44 = linhaDigitavelParaCodigoBarras(ld);
+
+  process.env.COD_IBGE_MUNICIPIO = '2704302';
+  process.env.RECEITA_CODIGO_PERMISSIONARIO = '12345';
+
+  const sefazPath = path.resolve(__dirname, '../src/services/sefazService.js');
+  require.cache[sefazPath] = { exports: { emitirGuiaSefaz: async () => ({ numeroGuia: '123', pdfBase64: 'PDFDATA', linhaDigitavel: ld }) } };
+
+  const tokenPath = path.resolve(__dirname, '../src/utils/token.js');
+  require.cache[tokenPath] = { exports: { gerarTokenDocumento: async () => 'TKN', imprimirTokenEmPdf: async pdf => pdf } };
+
+  const authPath = path.resolve(__dirname, '../src/middleware/authMiddleware.js');
+  require.cache[authPath] = { exports: (req, _res, next) => { req.user = { id: 1 }; next(); } };
+
+  const cobrancaPath = path.resolve(__dirname, '../src/services/cobrancaService.js');
+  require.cache[cobrancaPath] = { exports: { calcularEncargosAtraso: async dar => ({ valorAtualizado: dar.valor, novaDataVencimento: null }) } };
+
+  const darsRoutes = require('../src/api/darsRoutes');
+
+  const app = express();
+  app.use(express.json());
+  app.use('/', darsRoutes);
+
+  await supertest(app).post('/10/emitir').expect(200);
+
+  const row = await get(`SELECT codigo_barras, link_pdf FROM dars WHERE id = 10`);
+  assert.equal(row.codigo_barras, cb44);
+  assert.equal(row.link_pdf, 'PDFDATA');
+});
+


### PR DESCRIPTION
## Summary
- Ajusta atualização de `codigo_barras` em `/dars/:id/emitir`, derivando o valor a partir da resposta da SEFAZ ou da linha digitável e validando seu tamanho
- Adiciona utilitário para converter linha digitável em código de barras
- Cria teste que garante o preenchimento correto do `codigo_barras`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7300f96f083338ff7ae07092e5d56