### PR TITLE
feat: add configurable import script logging

### DIFF
--- a/importar_dados.js
+++ b/importar_dados.js
@@ -1,9 +1,29 @@
 const fs = require('fs');
+const path = require('path');
 const csv = require('csv-parser');
 const sqlite3 = require('sqlite3').verbose();
 const axios = require('axios');
+require('dotenv').config();
 
-const db = new sqlite3.Database('./sistemacipt.db');
+// Paths configuráveis via variáveis de ambiente
+const DB_PATH = process.env.DB_PATH || './sistemacipt.db';
+const API_BASE_URL = process.env.CNPJ_API_BASE_URL || 'https://brasilapi.com.br/api/cnpj/v1/';
+const API_TIMEOUT = parseInt(process.env.CNPJ_API_TIMEOUT_MS || '5000', 10);
+const LOG_FILE = process.env.IMPORT_LOG_FILE || path.join('logs', 'importacao.log');
+
+fs.mkdirSync(path.dirname(LOG_FILE), { recursive: true });
+
+function logSuccess(message) {
+    console.log(message);
+    fs.appendFileSync(LOG_FILE, `[SUCESSO] ${message}\n`);
+}
+
+function logError(message) {
+    console.error(message);
+    fs.appendFileSync(LOG_FILE, `[ERRO] ${message}\n`);
+}
+
+const db = new sqlite3.Database(DB_PATH);
 
 // Função para envolver db.run em uma Promise, para podermos usar await
 function dbRun(sql, params) {
@@ -33,6 +53,9 @@ async function processarArquivo() {
     
     console.log(`Leitura concluída. ${results.length} empresas encontradas. Iniciando processo...`);
 
+    let sucesso = 0;
+    let falhas = 0;
+
     for (const row of results) {
         const cnpj = row['CNPJ'];
         const email = row['Email'];
@@ -42,7 +65,8 @@ async function processarArquivo() {
         console.log(`\n--- Processando CNPJ (original): ${cnpj} ---`);
 
         if (!cnpj || !aluguelRaw || !numeroSala) {
-            console.error('   -> ERRO: Linha pulada. Um dos campos (CNPJ, Numero da Sala, Valor do Aluguel) está vazio no CSV.');
+            logError('   -> ERRO: Linha pulada. Um dos campos (CNPJ, Numero da Sala, Valor do Aluguel) está vazio no CSV.');
+            falhas++;
             continue;
         }
         
@@ -63,21 +87,26 @@ async function processarArquivo() {
                 throw new Error(`O valor do aluguel "[${aluguelRaw}]" não pôde ser convertido para um número.`);
             }
 
-            const response = await axios.get(`https://brasilapi.com.br/api/cnpj/v1/${cnpjLimpo}`);
+            const response = await axios.get(`${API_BASE_URL}${cnpjLimpo}`, { timeout: API_TIMEOUT });
             const razaoSocial = response.data.razao_social;
             
             const sql = `INSERT INTO permissionarios (nome_empresa, cnpj, email, numero_sala, valor_aluguel) VALUES (?, ?, ?, ?, ?)`;
             
             await dbRun(sql, [razaoSocial, cnpj, email, numeroSala, aluguel]);
-            console.log(`   -> SUCESSO: Empresa "${razaoSocial}", Sala ${numeroSala}, Aluguel R$${aluguel.toFixed(2)} inserida.`);
+            logSuccess(`   -> SUCESSO: Empresa "${razaoSocial}", Sala ${numeroSala}, Aluguel R$${aluguel.toFixed(2)} inserida.`);
+            sucesso++;
 
         } catch (error) {
-            console.error(`   -> FALHA ao processar CNPJ ${cnpj}: ${error.message}`);
+            const msg = error.response
+                ? `${error.response.status} ${error.response.data?.message || ''}`
+                : error.message;
+            logError(`   -> FALHA ao processar CNPJ ${cnpj}: ${msg}`);
+            falhas++;
         }
     }
 
     db.close();
-    console.log('\n--- Processo de importação finalizado. ---');
+    console.log(`\n--- Processo de importação finalizado. Sucesso: ${sucesso}, Falhas: ${falhas} ---`);
 }
 
 processarArquivo();


### PR DESCRIPTION
## Summary
- make import script configurable via env vars and log results

## Testing
- `npm test`
- `DB_PATH=test-sistemacipt.db IMPORT_LOG_FILE=logs/test-import.log CNPJ_API_TIMEOUT_MS=500 node importar_dados.js`

------
https://chatgpt.com/codex/tasks/task_e_68a7510d175c83339081895cc31d40df