### PR TITLE
Checar assinafy_id antes de abrir assinatura no portal

### DIFF
--- a/public/eventos/meus-eventos.html
+++ b/public/eventos/meus-eventos.html
@@ -249,67 +249,80 @@
             return;
           }
 
-          if (btnAssinar) {
-            const eventoId = btnAssinar.dataset.assinarTermo;
+            if (btnAssinar) {
+              const eventoId = btnAssinar.dataset.assinarTermo;
 
-            // >>> abre a janela ANTES do fetch (evita bloqueio de pop-up)
-            const w = window.open('about:blank', '_blank');
-            const writeWait = (html) => { try{ w.document.body.innerHTML = html; }catch{} };
-
-            const original = btnAssinar.innerHTML;
-            btnAssinar.disabled = true;
-            btnAssinar.innerHTML = `<span class="spinner-border spinner-border-sm"></span> Preparando...`;
-            document.getElementById(`sig-status-${eventoId}`).textContent = '';
-
-            try{
-              // solicita ao servidor o link de assinatura
-              const r = await fetch(`/api/portal/eventos/${eventoId}/termo/assinafy/link`, { method:'POST', headers });
-              const j = await r.json().catch(()=> ({}));
-
-              if (r.status === 409) {
-                writeWait('<p style="font:14px/1.4 sans-serif">O termo ainda não foi disponibilizado para assinatura.</p>');
-                document.getElementById(`sig-status-${eventoId}`).textContent = 'Termo ainda não disponível para assinatura.';
-                try{ w.close(); }catch{}
+              // verifica metadados do termo antes de iniciar a assinatura
+              try {
+                const metaResp = await fetch(`/api/portal/eventos/${eventoId}/termo/meta`, { headers });
+                const meta = await metaResp.json().catch(() => ({}));
+                if (!meta?.assinafy_id) {
+                  alert('Termo ainda não enviado para assinatura');
+                  return;
+                }
+              } catch (err) {
+                alert('Falha ao verificar termo.');
                 return;
               }
 
-              // se já vier url — abre na hora
-              if (r.ok && j.url) {
-                writeWait('<p style="font:14px/1.4 sans-serif">Redirecionando para a Assinafy…</p>');
-                w.location = j.url;
-                document.getElementById(`sig-status-${eventoId}`).textContent = 'Assinatura iniciada…';
-              } else if (r.ok && j.pending) {
-                // mostra mensagem amigável e faz polling por alguns segundos
-                writeWait(`<p style="font:14px/1.4 sans-serif">${j.message || 'Convite enviado. Aguardando link de assinatura…'}</p>`);
-                document.getElementById(`sig-status-${eventoId}`).textContent = j.message || 'Convite enviado. Aguardando link…';
+              // >>> abre a janela ANTES do fetch (evita bloqueio de pop-up)
+              const w = window.open('about:blank', '_blank');
+              const writeWait = (html) => { try{ w.document.body.innerHTML = html; }catch{} };
 
-                let opened = false;
-                for (let i=0;i<6;i++){
-                  await new Promise(r => setTimeout(r, 4000)); // 4s
-                  const r2 = await fetch(`/api/portal/eventos/${eventoId}/termo/assinafy/link`, { headers });
-                  const j2 = await r2.json().catch(()=> ({}));
-                  if (r2.ok && j2.url) {
-                    w.location = j2.url;
-                    opened = true;
+              const original = btnAssinar.innerHTML;
+              btnAssinar.disabled = true;
+              btnAssinar.innerHTML = `<span class="spinner-border spinner-border-sm"></span> Preparando...`;
+              document.getElementById(`sig-status-${eventoId}`).textContent = '';
+
+              try{
+                // solicita ao servidor o link de assinatura
+                const r = await fetch(`/api/portal/eventos/${eventoId}/termo/assinafy/link`, { method:'POST', headers });
+                const j = await r.json().catch(()=> ({}));
+
+                if (r.status === 409) {
+                  writeWait('<p style="font:14px/1.4 sans-serif">O termo ainda não foi disponibilizado para assinatura.</p>');
+                  document.getElementById(`sig-status-${eventoId}`).textContent = 'Termo ainda não disponível para assinatura.';
+                  try{ w.close(); }catch{}
+                  return;
+                }
+
+                  // se já vier url — abre na hora
+                  if (r.ok && j.url) {
+                    writeWait('<p style="font:14px/1.4 sans-serif">Redirecionando para a Assinafy…</p>');
+                    w.location = j.url;
                     document.getElementById(`sig-status-${eventoId}`).textContent = 'Assinatura iniciada…';
-                    break;
+                  } else if (r.ok && j.pending) {
+                    // mostra mensagem amigável e faz polling por alguns segundos
+                    writeWait(`<p style="font:14px/1.4 sans-serif">${j.message || 'Convite enviado. Aguardando link de assinatura…'}</p>`);
+                    document.getElementById(`sig-status-${eventoId}`).textContent = j.message || 'Convite enviado. Aguardando link…';
+
+                    let opened = false;
+                    for (let i=0;i<6;i++){
+                      await new Promise(r => setTimeout(r, 4000)); // 4s
+                      const r2 = await fetch(`/api/portal/eventos/${eventoId}/termo/assinafy/link`, { headers });
+                      const j2 = await r2.json().catch(()=> ({}));
+                      if (r2.ok && j2.url) {
+                        w.location = j2.url;
+                        opened = true;
+                        document.getElementById(`sig-status-${eventoId}`).textContent = 'Assinatura iniciada…';
+                        break;
+                      }
+                      if (j2.status === 'signed' || j2.status === 'assinado') {
+                        document.getElementById(`sig-status-${eventoId}`).textContent = 'Termo assinado.';
+                        try { w.close(); } catch {}
+                        await atualizarUIEvento(eventoId);
+                        opened = true;
+                        break;
+                      }
+                    }
+                    if (!opened) {
+                      writeWait('<p style="font:14px/1.4 sans-serif">O link direto ainda não foi gerado. Verifique seu e-mail para assinar.</p>');
+                    }
+                  } else {
+                    writeWait('<p style="font:14px/1.4 sans-serif">Falha ao iniciar assinatura.</p>');
+                    alert(j.error || 'Falha ao iniciar assinatura.');
+                    try{ w.close(); }catch{}
                   }
-                  if (j2.status === 'signed' || j2.status === 'assinado') {
-                    document.getElementById(`sig-status-${eventoId}`).textContent = 'Termo assinado.';
-                    try { w.close(); } catch {}
-                    await atualizarUIEvento(eventoId);
-                    opened = true;
-                    break;
-                  }
-                }
-                if (!opened) {
-                  writeWait('<p style="font:14px/1.4 sans-serif">O link direto ainda não foi gerado. Verifique seu e-mail para assinar.</p>');
-                }
-              } else {
-                writeWait('<p style="font:14px/1.4 sans-serif">Falha ao iniciar assinatura.</p>');
-                alert(j.error || 'Falha ao iniciar assinatura.');
-                try{ w.close(); }catch{}
-              }
             }catch(err){
               writeWait('<p style="font:14px/1.4 sans-serif">Falha ao iniciar. Tente novamente em instantes.</p>');
               alert(err.message || 'Falha ao iniciar assinatura.');


### PR DESCRIPTION
## Summary
- Verifica metadados do termo no portal antes de iniciar assinatura
- Alerta o usuário quando o assinafy_id ainda não existe
- Apenas solicita link de assinatura quando assinafy_id está presente

## Testing
- `npm test` *(fails: Cannot find module 'sqlite3')*

------
https://chatgpt.com/codex/tasks/task_e_68a75243af208333ba7ae7741acee2df