### PR TITLE
feat: add centralized logging and alerts

### DIFF
--- a/importar_dados.js
+++ b/importar_dados.js
@@ -1,27 +1,14 @@
 const fs = require('fs');
-const path = require('path');
 const csv = require('csv-parser');
 const sqlite3 = require('sqlite3').verbose();
 const axios = require('axios');
 require('dotenv').config();
+const logger = require('./src/utils/logger');
 
 // Paths configuráveis via variáveis de ambiente
 const DB_PATH = process.env.DB_PATH || './sistemacipt.db';
 const API_BASE_URL = process.env.CNPJ_API_BASE_URL || 'https://brasilapi.com.br/api/cnpj/v1/';
 const API_TIMEOUT = parseInt(process.env.CNPJ_API_TIMEOUT_MS || '5000', 10);
-const LOG_FILE = process.env.IMPORT_LOG_FILE || path.join('logs', 'importacao.log');
-
-fs.mkdirSync(path.dirname(LOG_FILE), { recursive: true });
-
-function logSuccess(message) {
-    console.log(message);
-    fs.appendFileSync(LOG_FILE, `[SUCESSO] ${message}\n`);
-}
-
-function logError(message) {
-    console.error(message);
-    fs.appendFileSync(LOG_FILE, `[ERRO] ${message}\n`);
-}
 
 const db = new sqlite3.Database(DB_PATH);
 
@@ -40,18 +27,18 @@ function dbRun(sql, params) {
 
 async function processarArquivo() {
     const results = [];
-    console.log('Lendo arquivo empresas.csv...');
+    logger.info('Lendo arquivo empresas.csv...');
     const stream = fs.createReadStream('empresas.csv').pipe(csv());
     for await (const row of stream) {
         results.push(row);
     }
 
     if (results.length === 0) {
-        console.log('Arquivo CSV está vazio.');
+        logger.warn('Arquivo CSV está vazio.');
         return;
     }
     
-    console.log(`Leitura concluída. ${results.length} empresas encontradas. Iniciando processo...`);
+    logger.info(`Leitura concluída. ${results.length} empresas encontradas. Iniciando processo...`);
 
     let sucesso = 0;
     let falhas = 0;
@@ -62,10 +49,10 @@ async function processarArquivo() {
         const numeroSala = row['Numero da Sala'];
         const aluguelRaw = row['Valor do Aluguel'];
 
-        console.log(`\n--- Processando CNPJ (original): ${cnpj} ---`);
+        logger.info(`--- Processando CNPJ (original): ${cnpj} ---`);
 
         if (!cnpj || !aluguelRaw || !numeroSala) {
-            logError('   -> ERRO: Linha pulada. Um dos campos (CNPJ, Numero da Sala, Valor do Aluguel) está vazio no CSV.');
+            logger.warn('Linha pulada. Um dos campos (CNPJ, Numero da Sala, Valor do Aluguel) está vazio no CSV.');
             falhas++;
             continue;
         }
@@ -76,7 +63,7 @@ async function processarArquivo() {
 
             if (cnpjLimpo.length === 13) {
                 cnpjLimpo = '0' + cnpjLimpo;
-                console.log(`   -> AVISO: CNPJ corrigido para 14 dígitos: ${cnpjLimpo}`);
+                logger.info(`CNPJ corrigido para 14 dígitos: ${cnpjLimpo}`);
             }
             // ------------------------------------
 
@@ -93,20 +80,23 @@ async function processarArquivo() {
             const sql = `INSERT INTO permissionarios (nome_empresa, cnpj, email, numero_sala, valor_aluguel) VALUES (?, ?, ?, ?, ?)`;
             
             await dbRun(sql, [razaoSocial, cnpj, email, numeroSala, aluguel]);
-            logSuccess(`   -> SUCESSO: Empresa "${razaoSocial}", Sala ${numeroSala}, Aluguel R$${aluguel.toFixed(2)} inserida.`);
+            logger.info(`Empresa "${razaoSocial}", Sala ${numeroSala}, Aluguel R$${aluguel.toFixed(2)} inserida.`);
             sucesso++;
 
         } catch (error) {
             const msg = error.response
                 ? `${error.response.status} ${error.response.data?.message || ''}`
                 : error.message;
-            logError(`   -> FALHA ao processar CNPJ ${cnpj}: ${msg}`);
+            logger.error(`FALHA ao processar CNPJ ${cnpj}: ${msg}`);
             falhas++;
         }
     }
 
     db.close();
-    console.log(`\n--- Processo de importação finalizado. Sucesso: ${sucesso}, Falhas: ${falhas} ---`);
+    logger.info(`Processo de importação finalizado. Sucesso: ${sucesso}, Falhas: ${falhas}`);
 }
 
-processarArquivo();
+processarArquivo().catch((err) => {
+    logger.error(`Erro inesperado durante importação: ${err.stack || err}`);
+    process.exit(1);
+});

--- a/src/services/alertService.js
+++ b/src/services/alertService.js
@@ -1,0 +1,30 @@
+const nodemailer = require('nodemailer');
+require('dotenv').config();
+
+let transporter;
+if (process.env.EMAIL_HOST) {
+  transporter = nodemailer.createTransport({
+    host: process.env.EMAIL_HOST,
+    port: process.env.EMAIL_PORT,
+    secure: true,
+    auth: { user: process.env.EMAIL_USER, pass: process.env.EMAIL_PASS },
+  });
+}
+
+async function enviarAlerta(assunto, mensagem) {
+  try {
+    if (!transporter) return;
+    const para = process.env.ALERT_EMAIL;
+    if (!para) return;
+    await transporter.sendMail({
+      from: `"Sistema CIPT" <${process.env.EMAIL_USER}>`,
+      to: para,
+      subject: assunto,
+      text: mensagem,
+    });
+  } catch (err) {
+    console.error('Falha ao enviar alerta crítico:', err);
+  }
+}
+
+module.exports = { enviarAlerta };

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const path = require('path');
+const { enviarAlerta } = require('../services/alertService');
+
+const LOG_FILE = process.env.LOG_FILE || path.join('logs', 'app.log');
+fs.mkdirSync(path.dirname(LOG_FILE), { recursive: true });
+
+function write(level, message) {
+  const line = `[${new Date().toISOString()}] [${level.toUpperCase()}] ${message}`;
+  fs.appendFileSync(LOG_FILE, line + '\n');
+  if (level === 'error') {
+    console.error(line);
+    enviarAlerta('Erro crítico no sistema', line).catch(() => {});
+  } else if (level === 'warn') {
+    console.warn(line);
+  } else {
+    console.log(line);
+  }
+}
+
+module.exports = {
+  info: (msg) => write('info', msg),
+  warn: (msg) => write('warn', msg),
+  error: (msg) => write('error', msg),
+  debug: (msg) => write('debug', msg),
+};


### PR DESCRIPTION
## Summary
- add reusable logger that writes to a centralized log file and dispatches alert emails on critical errors
- enhance import and enrichment scripts to log detailed steps and use the centralized logger
- add email-based alert service for critical failures

## Testing
- `npm test` *(fails: Cannot find module 'sqlite3')*

------
https://chatgpt.com/codex/tasks/task_e_68a752c061f88333a381ed577fbf8302