### PR TITLE
Use ensureSigner for event term signatures

### DIFF
--- a/src/api/adminEventosRoutes.js
+++ b/src/api/adminEventosRoutes.js
@@ -8,7 +8,7 @@ const { criarEventoComDars, atualizarEventoComDars } = require('../services/even
 
 const {
   uploadDocumentFromFile,
-  createSigner,
+  ensureSigner,
   requestSignatures,
   getDocument,
   pickBestArtifactUrl
@@ -129,7 +129,7 @@ router.post('/:id/termo/enviar-assinatura', async (req, res) => {
 
     // 3) Cria o signatário (se necessário)
     // Obs.: se você já mantém signerId, use direto. Aqui criamos sempre um simples.
-    const signer = await createSigner({
+    const signer = await ensureSigner({
       full_name: signerName,
       email: signerEmail,
       government_id: onlyDigits(signerCpf),


### PR DESCRIPTION
## Summary
- replace signer creation with ensureSigner for term signature flow
- implement ensureSigner helper that reuses existing signers via email

## Testing
- `npm test`
- `ASSINAFY_ACCOUNT_ID=1 ASSINAFY_API_KEY=foo node - <<'NODE' ... NODE` *(fails: Maximum number of redirects exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68a78f6ca9dc8333a6a0fb62e057cd73