### PR TITLE
Use account-scoped Assinafy document endpoint

### DIFF
--- a/src/api/adminEventosRoutes.js
+++ b/src/api/adminEventosRoutes.js
@@ -353,7 +353,8 @@ router.get('/:id/termo/assinafy-status', async (req, res) => {
     );
     if (!row?.assinafy_id) return res.status(404).json({ ok: false, error: 'Sem assinafy_id para este termo.' });
 
-    const doc = await getDocument(row.assinafy_id);
+    const resp = await getDocument(row.assinafy_id);
+    const doc = resp?.data || resp;
     // se já “certified”, salvar a URL assinada e data
     if (doc?.status === 'certified') {
       const bestUrl = pickBestArtifactUrl(doc);

--- a/src/api/portalAssinaturaRoutes.js
+++ b/src/api/portalAssinaturaRoutes.js
@@ -174,7 +174,8 @@ router.get(
 router.get('/documentos/assinafy/:id/open', async (req, res) => {
   const id = req.params.id;
   try {
-    const info = await getDocument(id);
+    const doc = await getDocument(id);
+    const info = doc?.data || doc;
     const artifacts = info?.artifacts || {};
     const fileUrl = artifacts.certified || artifacts.original;
     if (!fileUrl) return res.status(404).send('Documento sem artefato disponível.');
@@ -217,8 +218,8 @@ router.get('/documentos/assinafy/:id/open', async (req, res) => {
 router.get('/documentos/assinafy/:id/status', async (req, res) => {
   const id = req.params.id;
   try {
-    const info = await getDocument(id);
-    res.json(info);
+    const doc = await getDocument(id);
+    res.json(doc?.data || doc);
   } catch (e) {
     const st = e?.response?.status || 500;
     res.status(st).json(e?.response?.data || { error: e.message || 'Erro ao consultar status.' });

--- a/src/api/webhooksAssinafyRoutes.js
+++ b/src/api/webhooksAssinafyRoutes.js
@@ -109,8 +109,9 @@ router.post('/', async (req, res) => {
     if (!status || !artifacts) {
       try {
         const doc = await getDocument(documentId);
-        status = status || doc?.status || null;
-        artifacts = artifacts || doc?.artifacts || null;
+        const info = doc?.data || doc;
+        status = status || info?.status || null;
+        artifacts = artifacts || info?.artifacts || null;
       } catch (e) {
         console.warn('[WEBHOOK] falha ao consultar documento na API:', e.message);
       }

--- a/src/services/assinafyService.js
+++ b/src/services/assinafyService.js
@@ -111,8 +111,9 @@ async function requestSignatures(documentId, signerIds, { message, expires_at } 
  * Consulta um documento no Assinafy (status + artifacts).
  */
 async function getDocument(documentId) {
+  assertAccount();
   const resp = await axios.get(
-    `${BASE}/documents/${documentId}`,
+    `${BASE}/accounts/${ACCOUNT_ID}/documents/${documentId}`,
     { headers: { ...authHeaders() } }
   );
   return resp.data;
@@ -137,14 +138,15 @@ async function waitForDocumentReady(
 
   for (let attempt = 0; attempt < retries; attempt++) {
     const data = await getDocument(documentId);
-    const status = data?.status;
+    const info = data?.data || data;
+    const status = info?.status;
 
     if (log) {
       console.log(`Assinafy document ${documentId} status: ${status}`);
     }
 
     if (status && READY_STATUSES.includes(status)) {
-      return data;
+      return info;
     }
 
     if (attempt < retries - 1) {


### PR DESCRIPTION
## Summary
- query documents using account-scoped Assinafy endpoint and assert account is configured
- unwrap nested document data when polling and when retrieving document details in routes

## Testing
- `npm test` *(fails: Cannot find module 'sqlite3' and 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68a795b2d6b083338d8b169494ddb3cc