### PR TITLE
feat: add document preparation helper

### DIFF
--- a/src/services/assinafyService.js
+++ b/src/services/assinafyService.js
@@ -120,6 +120,22 @@ async function getDocument(documentId) {
 }
 
 /**
+ * Prepara um documento para assinatura informando campos a preencher.
+ * Endpoint: POST /accounts/:accountId/documents/:documentId/prepare
+ * Body: { fields: [] }
+ */
+async function prepareDocument(documentId, fields = []) {
+  assertAccount();
+  const url = `${BASE}/accounts/${ACCOUNT_ID}/documents/${documentId}/prepare`;
+  const resp = await axios.post(
+    url,
+    { fields },
+    { headers: { ...authHeaders(), 'Content-Type': 'application/json' } },
+  );
+  return resp.data;
+}
+
+/**
  * Aguarda até que o documento esteja pronto para solicitações de assinatura.
  * Fica consultando o Assinafy até que o status seja considerado "ready".
  * Status considerados prontos (segundo a documentação do Assinafy):
@@ -185,6 +201,7 @@ module.exports = {
   ensureSigner,
   requestSignatures,
   getDocument,
+  prepareDocument,
   waitForDocumentReady,
   pickBestArtifactUrl,
 };


### PR DESCRIPTION
## Summary
- add `prepareDocument` helper to send document preparation fields
- export helper from Assinafy service

## Testing
- `npm test` *(fails: test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a1975e688333b7f7f94b67883468