### PR TITLE
Handle array responses when listing eventos

### DIFF
--- a/public/admin/eventos-dars.html
+++ b/public/admin/eventos-dars.html
@@ -402,8 +402,11 @@ window.onload = () => {
               throw new Error(errorData.error || 'Falha ao buscar eventos.');
           }
           const data = await response.json();
-          await renderTable(data.eventos || data.data); // Usar await se renderTable for async
-          renderPagination(data.totalPages, data.currentPage);
+          const eventos = Array.isArray(data) ? data : data.eventos || data.data;
+          await renderTable(eventos);
+          const totalPages = Array.isArray(data) ? 1 : data.totalPages || 1;
+          const currentPageData = Array.isArray(data) ? 1 : data.currentPage || 1;
+          renderPagination(totalPages, currentPageData);
       } catch (error) {
           eventosTableBody.innerHTML = `<tr><td colspan="9" class="text-center text-danger">${error.message}</td></tr>`;
       }
@@ -1243,8 +1246,7 @@ window.onload = () => {
   // =======================
   inicializarEventListeners();
   carregarClientes();
-  carregarEventos();
-};
+  fetchEventos();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- tolerate array-only responses from `/api/admin/eventos` by normalizing response and defaulting pagination
- ensure admin eventos page loads with array results

## Testing
- `npm test`
- `node -e "const puppeteer = require('puppeteer'); const jwt=require('jsonwebtoken'); (async()=>{const token=jwt.sign({id:1,nome:'Admin',role:'admin'}, 'secret'); const browser=await puppeteer.launch({headless:'new', args:['--no-sandbox','--disable-setuid-sandbox']}); const page=await browser.newPage(); await page.goto('http://localhost:3000/admin/login.html'); await page.evaluate(t=>localStorage.setItem('adminAuthToken',t), token); await page.goto('http://localhost:3000/admin/eventos-dars.html', {waitUntil:'networkidle0'}); await new Promise(r=>setTimeout(r,1000)); const rows=await page.$$eval('#eventos-table-body tr', trs=>trs.map(tr=>tr.textContent.trim())); console.log('Rows:', rows); await browser.close();})()"

------
https://chatgpt.com/codex/tasks/task_e_68a8a6466d548333ab4900159b83ed01