### PR TITLE
Link label to discount type input

### DIFF
--- a/public/admin/eventos-dars.html
+++ b/public/admin/eventos-dars.html
@@ -201,7 +201,7 @@
           <legend>3. Descontos</legend>
           <div class="row">
             <div class="col-md-6 mb-3">
-              <label class="form-label">Tipo de Desconto Automático</label>
+              <label for="tipo-desconto-auto" class="form-label">Tipo de Desconto Automático</label>
               <input type="text" id="tipo-desconto-auto" class="form-control" readonly>
             </div>
             <div class="col-md-6 mb-3">


### PR DESCRIPTION
## Summary
- Improve accessibility for discount type field by associating label with its input

## Testing
- `npm test` *(fails: Cannot find module 'sqlite3')*

------
https://chatgpt.com/codex/tasks/task_e_68a8b19c55688333bf7579f0d97d2f9b