### PR TITLE
Expose client and discount inputs for event forms

### DIFF
--- a/public/admin/eventos-dars.html
+++ b/public/admin/eventos-dars.html
@@ -512,7 +512,6 @@ window.onload = () => {
       const res = await fetch(API_CLIENTES_URL, { headers:{ Authorization:`Bearer ${token}` } });
       const data = await res.json();
       clientes = data || [];
-      const clienteSelect = document.getElementById('cliente-select');
       clienteSelect.innerHTML = '<option value="">Selecione um cliente...</option>';
       clientes.forEach(c=>{
         const opt = document.createElement('option');
@@ -527,6 +526,8 @@ window.onload = () => {
   }
 
   const form = document.getElementById('evento-form');
+  const clienteSelect = document.getElementById('cliente-select');
+  const descontoManualInput = document.getElementById('desconto-manual');
   let modoEdicao = false;
   let editEventoId = null;
   function atualizarStatusNaTabelaEventos(eventoId, status){


### PR DESCRIPTION
## Summary
- Expose cliente select and manual discount inputs for broader use
- Simplify carregarClientes to use shared clienteSelect

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8b367b8608333b7ba41ba959360f0