### PR TITLE
Declare DAR modal references

### DIFF
--- a/public/admin/eventos-dars.html
+++ b/public/admin/eventos-dars.html
@@ -421,6 +421,9 @@ window.onload = () => {
   // ... (todas as suas outras referências de elementos originais)
   const addEventoBtn = document.getElementById('add-evento-btn');
   const modal = document.getElementById('evento-modal');
+  const darsModal = document.getElementById('dars-modal');
+  const darsList  = document.getElementById('dars-list');
+  const closeDarsModalBtn = document.getElementById('close-dars-modal-btn');
   // ... e assim por diante
   
   // =======================


### PR DESCRIPTION
## Summary
- retrieve DAR modal, list, and close button elements on window load to avoid undefined references

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8fd3b6c2083339dac73218619fc31