### PR TITLE
Add loading indicators to password reset forms

### DIFF
--- a/public/definir-senha-evento.html
+++ b/public/definir-senha-evento.html
@@ -117,6 +117,9 @@
         form.addEventListener('submit', async (e) => {
             e.preventDefault();
             messageDiv.style.display = 'none';
+            const submitButton = form.querySelector('button[type="submit"]');
+            submitButton.disabled = true;
+            submitButton.innerHTML = '<span class="spinner-border spinner-border-sm me-2" aria-hidden="true"></span> Salvando...';
 
             const senha = document.getElementById('nova_senha').value;
             const confirmacao = document.getElementById('confirmar_nova_senha').value;
@@ -125,6 +128,8 @@
                 messageDiv.className = 'alert alert-warning';
                 messageDiv.textContent = 'A senha deve ter no mínimo 8 caracteres.';
                 messageDiv.style.display = 'block';
+                submitButton.disabled = false;
+                submitButton.innerHTML = 'Salvar Nova Senha';
                 return;
             }
             
@@ -132,6 +137,8 @@
                 messageDiv.className = 'alert alert-danger';
                 messageDiv.textContent = 'As senhas não coincidem. Por favor, tente novamente.';
                 messageDiv.style.display = 'block';
+                submitButton.disabled = false;
+                submitButton.innerHTML = 'Salvar Nova Senha';
                 return;
             }
 
@@ -155,6 +162,9 @@
                 messageDiv.className = 'alert alert-danger';
                 messageDiv.textContent = `Erro: ${err.message}`;
                 messageDiv.style.display = 'block';
+            } finally {
+                submitButton.disabled = false;
+                submitButton.innerHTML = 'Salvar Nova Senha';
             }
         });
     });

--- a/public/definir-senha.html
+++ b/public/definir-senha.html
@@ -115,6 +115,10 @@
 
         form.addEventListener('submit', async (event) => {
             event.preventDefault();
+            const submitButton = form.querySelector('button[type="submit"]');
+            submitButton.disabled = true;
+            submitButton.innerHTML = '<span class="spinner-border spinner-border-sm me-2" aria-hidden="true"></span> Salvando...';
+
             const senha = document.getElementById('nova_senha').value;
             const confirmacao = document.getElementById('confirmar_nova_senha').value;
             
@@ -122,6 +126,8 @@
                 messageDiv.innerText = 'A senha deve conter no mínimo 8 caracteres.';
                 messageDiv.className = 'alert alert-warning';
                 messageDiv.style.display = 'block';
+                submitButton.disabled = false;
+                submitButton.innerHTML = 'Salvar Nova Senha';
                 return;
             }
 
@@ -129,6 +135,8 @@
                 messageDiv.innerText = 'As senhas não coincidem.';
                 messageDiv.className = 'alert alert-danger';
                 messageDiv.style.display = 'block';
+                submitButton.disabled = false;
+                submitButton.innerHTML = 'Salvar Nova Senha';
                 return;
             }
 
@@ -163,6 +171,8 @@
                 messageDiv.className = 'alert alert-danger';
             } finally {
                 messageDiv.style.display = 'block';
+                submitButton.disabled = false;
+                submitButton.innerHTML = 'Salvar Nova Senha';
             }
         });
     });

--- a/public/solicitar-redefinicao.html
+++ b/public/solicitar-redefinicao.html
@@ -102,6 +102,10 @@
             const messageDiv = document.getElementById('message');
             const formContainer = document.getElementById('formContainer');
             const cnpj = cnpjInput.value;
+            const submitButton = form.querySelector('button[type="submit"]');
+
+            submitButton.disabled = true;
+            submitButton.innerHTML = '<span class="spinner-border spinner-border-sm me-2" aria-hidden="true"></span> Enviando...';
             
             try {
                 const response = await fetch('/api/auth/solicitar-acesso', {
@@ -128,6 +132,9 @@
                 messageDiv.innerText = error.message;
                 messageDiv.className = 'alert alert-danger';
                 messageDiv.style.display = 'block';
+            } finally {
+                submitButton.disabled = false;
+                submitButton.innerHTML = 'Enviar Código';
             }
         });
     </script>

--- a/public/verificar-codigo.html
+++ b/public/verificar-codigo.html
@@ -96,6 +96,7 @@
             const urlParams = new URLSearchParams(window.location.search);
             const cnpj = urlParams.get('cnpj');
             const codigo = document.getElementById('codigo').value;
+            const submitButton = form.querySelector('button[type="submit"]');
 
             if (!cnpj) {
                 messageDiv.innerText = 'Erro: CNPJ não encontrado. Por favor, reinicie o processo.';
@@ -103,6 +104,9 @@
                 messageDiv.style.display = 'block';
                 return;
             }
+
+            submitButton.disabled = true;
+            submitButton.innerHTML = '<span class="spinner-border spinner-border-sm me-2" aria-hidden="true"></span> Consultando...';
 
             try {
                 const response = await fetch('/api/auth/verificar-codigo', {
@@ -127,6 +131,9 @@
                 messageDiv.innerText = error.message;
                 messageDiv.className = 'alert alert-danger';
                 messageDiv.style.display = 'block';
+            } finally {
+                submitButton.disabled = false;
+                submitButton.innerHTML = 'Verificar Código';
             }
         });
     </script>


### PR DESCRIPTION
## Summary
- Disable submit buttons and show spinners while sending password reset emails and verifying codes
- Add loading states to new password forms to prevent double submissions

## Testing
- `npm test` (fails: SEFAZ_APP_TOKEN não configurado no .env.)

------
https://chatgpt.com/codex/tasks/task_e_68adf5bbcf508333aec6ed2a0775babe