### PR TITLE
Padroniza status vencido e inclui opção 'Vencida'

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,14 @@ Adicione no arquivo `.env` ou nas variáveis do servidor:
 - `ASSINAFY_CALLBACK_URL`: URL pública para o retorno após a assinatura, ex.: `https://seusistema/api/documentos/assinafy/callback`.
 
 Certifique-se de reiniciar o servidor após alterar as variáveis.
+
+## Status das DARs
+
+As DARs utilizam os seguintes status padronizados:
+
+- `Pendente` – guia gerada mas ainda não emitida.
+- `Emitido` / `Reemitido` – guia emitida para pagamento.
+- `Pago` – pagamento confirmado.
+- `Vencido` – vencimento ultrapassado sem pagamento.
+
+O valor legado `Vencida` foi unificado para `Vencido` e não deve mais ser utilizado.

--- a/public/dars.html
+++ b/public/dars.html
@@ -82,6 +82,7 @@
                                     <option value="Pendente">Pendente</option>
                                     <option value="Pago">Pago</option>
                                     <option value="Vencido">Vencido</option>
+                                    <option value="Vencida">Vencida</option>
                                 </select>
                             </div>
                         </div>
@@ -236,7 +237,7 @@
                         return;
                     }
 
-                    const statusColors = { 'Pendente': 'bg-warning text-dark', 'Pago': 'bg-success text-white', 'Vencido': 'bg-danger text-white' };
+                    const statusColors = { 'Pendente': 'bg-warning text-dark', 'Pago': 'bg-success text-white', 'Vencido': 'bg-danger text-white', 'Vencida': 'bg-danger text-white' };
                     let tableHTML = '';
                     dars.forEach(dar => {
                         const statusColor = statusColors[dar.status] || 'bg-secondary text-white';
@@ -276,7 +277,7 @@
                 button.innerHTML = `<span class="spinner-border spinner-border-sm"></span>`;
 
                 try {
-                    if (darStatus === 'Vencido') {
+                    if (darStatus === 'Vencido' || darStatus === 'Vencida') {
                         const response = await fetch(`/api/dars/${darId}/recalcular`, { headers });
                         if (!response.ok) throw new Error('Erro ao recalcular o DAR.');
                         const calculo = await response.json();

--- a/src/api/darsRoutes.js
+++ b/src/api/darsRoutes.js
@@ -180,8 +180,12 @@ router.get('/', authMiddleware, (req, res) => {
     params.push(ano);
   }
   if (status && status !== 'todos') {
-    sql += ` AND status = ?`;
-    params.push(status);
+    if (status === 'Vencido') {
+      sql += ` AND status IN ('Vencido','Vencida')`;
+    } else {
+      sql += ` AND status = ?`;
+      params.push(status);
+    }
   }
 
   sql += ` ORDER BY ano_referencia DESC, mes_referencia DESC`;
@@ -231,7 +235,7 @@ router.get('/:id/preview', authMiddleware, async (req, res) => {
 
     // corrige vencimento no passado
     let guiaSource = { ...dar };
-    if (dar.status === 'Vencido') {
+    if (['Vencido', 'Vencida'].includes(dar.status)) {
       const calculo = await calcularEncargosAtraso(dar);
       guiaSource.valor = calculo.valorAtualizado;
       guiaSource.data_vencimento = calculo.novaDataVencimento || isoHojeLocal();
@@ -268,7 +272,7 @@ router.post('/:id/emitir', authMiddleware, async (req, res) => {
 
     // corrige vencimento no passado
     let guiaSource = { ...dar };
-    if (dar.status === 'Vencido') {
+    if (['Vencido', 'Vencida'].includes(dar.status)) {
       const calculo = await calcularEncargosAtraso(dar);
       guiaSource.valor = calculo.valorAtualizado;
       guiaSource.data_vencimento = calculo.novaDataVencimento || isoHojeLocal();

--- a/src/migrations/20250816000000-unify-vencida-status.js
+++ b/src/migrations/20250816000000-unify-vencida-status.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.query(
+      "UPDATE dars SET status='Vencido' WHERE status='Vencida'"
+    );
+  },
+
+  async down() {
+    // Nenhuma ação necessária para reverter
+  }
+};


### PR DESCRIPTION
## Summary
- Tratei `Vencida` como equivalente a `Vencido` nas rotas de listagem e emissão de DARs
- Adicionei a opção de filtro "Vencida" e suporte no front-end
- Criei migração para unificar registros antigos e documentei os status válidos

## Testing
- `npm test` *(fails: Cannot find module 'express', 'sqlite3', 'axios')*

------
https://chatgpt.com/codex/tasks/task_e_68adfdd1f8e483338adbc2d63f5c08f1