### PR TITLE
Support 'Vencida' DAR status color on dashboard

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -186,7 +186,7 @@
                 }
                 
                 const ultimoDar = dars[0];
-                const statusColors = { 'Pendente': 'bg-warning text-dark', 'Pago': 'bg-success text-white', 'Vencido': 'bg-danger text-white' };
+                const statusColors = { 'Pendente': 'bg-warning text-dark', 'Pago': 'bg-success text-white', 'Vencido': 'bg-danger text-white', 'Vencida': 'bg-danger text-white' };
                 const statusColor = statusColors[ultimoDar.status] || 'bg-secondary';
                 
                 tableBody.innerHTML = `


### PR DESCRIPTION
## Summary
- handle the "Vencida" status in dashboard's last DAR card

## Testing
- `npm test` *(fails: SEFAZ_APP_TOKEN não configurado no .env)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0f41e0b48333bf361fc6e821cbcd