### PR TITLE
Add payments report endpoint and UI

### DIFF
--- a/public/admin/relatorios.html
+++ b/public/admin/relatorios.html
@@ -70,7 +70,31 @@
 
             <main class="content">
                 <h1 class="h2 mb-4">Relatórios</h1>
-                <button id="btnRelatorioDevedores" class="btn btn-primary">Relatório de Devedores</button>
+                <div class="mb-3">
+                    <input type="month" id="mesAno" class="form-control d-inline-block w-auto">
+                    <button id="btnRelatorioPagamentos" class="btn btn-secondary ms-2">Buscar Pagamentos</button>
+                    <button id="btnRelatorioDevedores" class="btn btn-primary ms-2">Relatório de Devedores</button>
+                </div>
+
+                <div id="secaoPagos" class="mt-4" style="display:none;">
+                    <h2 class="h5">Pagos</h2>
+                    <table class="table table-sm" id="tabelaPagos">
+                        <thead>
+                            <tr><th>Permissionário</th><th>CNPJ</th><th>Valor</th></tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
+
+                <div id="secaoDevedores" class="mt-4" style="display:none;">
+                    <h2 class="h5">Devedores</h2>
+                    <table class="table table-sm" id="tabelaDevedores">
+                        <thead>
+                            <tr><th>Permissionário</th><th>CNPJ</th><th>Valor</th></tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
             </main>
         </div>
     </div>

--- a/public/js/admin-relatorios.js
+++ b/public/js/admin-relatorios.js
@@ -1,19 +1,75 @@
 // public/js/admin-relatorios.js
 window.addEventListener('DOMContentLoaded', () => {
-  const btn = document.getElementById('btnRelatorioDevedores');
-  if (!btn) return;
+  const btnDevedores = document.getElementById('btnRelatorioDevedores');
+  if (btnDevedores) {
+    btnDevedores.addEventListener('click', async () => {
+      try {
+        const resp = await fetch('/api/admin/relatorios/devedores');
+        if (!resp.ok) throw new Error('Falha ao gerar relatório');
+        const blob = await resp.blob();
+        const url = URL.createObjectURL(blob);
+        window.open(url, '_blank');
+        setTimeout(() => URL.revokeObjectURL(url), 1000);
+      } catch (err) {
+        console.error(err);
+        alert('Erro ao gerar relatório de devedores.');
+      }
+    });
+  }
 
-  btn.addEventListener('click', async () => {
-    try {
-      const resp = await fetch('/api/admin/relatorios/devedores');
-      if (!resp.ok) throw new Error('Falha ao gerar relatório');
-      const blob = await resp.blob();
-      const url = URL.createObjectURL(blob);
-      window.open(url, '_blank');
-      setTimeout(() => URL.revokeObjectURL(url), 1000);
-    } catch (err) {
-      console.error(err);
-      alert('Erro ao gerar relatório de devedores.');
-    }
-  });
+  const btnPagamentos = document.getElementById('btnRelatorioPagamentos');
+  if (btnPagamentos) {
+    btnPagamentos.addEventListener('click', async () => {
+      const mesAno = document.getElementById('mesAno').value;
+      if (!mesAno) {
+        alert('Selecione o mês e o ano.');
+        return;
+      }
+      const [ano, mes] = mesAno.split('-').map(Number);
+      if (!ano || !mes) {
+        alert('Data inválida.');
+        return;
+      }
+
+      const secaoPagos = document.getElementById('secaoPagos');
+      const secaoDevedores = document.getElementById('secaoDevedores');
+      const tbodyPagos = document.querySelector('#tabelaPagos tbody');
+      const tbodyDevedores = document.querySelector('#tabelaDevedores tbody');
+
+      secaoPagos.style.display = 'none';
+      secaoDevedores.style.display = 'none';
+      tbodyPagos.innerHTML = '';
+      tbodyDevedores.innerHTML = '';
+
+      btnPagamentos.disabled = true;
+      const originalText = btnPagamentos.textContent;
+      btnPagamentos.textContent = 'Carregando...';
+
+      try {
+        const resp = await fetch(`/api/admin/relatorios/pagamentos?mes=${mes}&ano=${ano}`);
+        if (!resp.ok) throw new Error('Falha ao buscar relatório');
+        const dados = await resp.json();
+
+        dados.pagos.forEach((item) => {
+          const tr = document.createElement('tr');
+          tr.innerHTML = `<td>${item.nome_empresa}</td><td>${item.cnpj}</td><td>R$ ${Number(item.valor).toFixed(2)}</td>`;
+          tbodyPagos.appendChild(tr);
+        });
+        dados.devedores.forEach((item) => {
+          const tr = document.createElement('tr');
+          tr.innerHTML = `<td>${item.nome_empresa}</td><td>${item.cnpj}</td><td>R$ ${Number(item.valor).toFixed(2)}</td>`;
+          tbodyDevedores.appendChild(tr);
+        });
+
+        if (dados.pagos.length) secaoPagos.style.display = 'block';
+        if (dados.devedores.length) secaoDevedores.style.display = 'block';
+      } catch (err) {
+        console.error(err);
+        alert('Erro ao buscar relatório de pagamentos.');
+      } finally {
+        btnPagamentos.disabled = false;
+        btnPagamentos.textContent = originalText;
+      }
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- add payments report endpoint to list monthly paid and owed values
- expose month/ year selector and tables on admin report page
- implement client-side logic to fetch and render payments report

## Testing
- `npm test` *(fails: 5 pass, 6 fail)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1c997f448333a21de1f4e4afc1e0