### PR TITLE
Improve DAR table layout for long competency names

### DIFF
--- a/src/api/adminRoutes.js
+++ b/src/api/adminRoutes.js
@@ -730,14 +730,15 @@ function generateDebtorsTable(doc, data) {
 
 function generateDarsTable(doc, dados) {
   let y = doc.y;
-  const rowHeight = 30;
-  const availableWidth = doc.page.width - doc.page.margins.left - doc.page.margins.right;
+  const rowHeight = 40;
+  const availableWidth =
+    doc.page.width - doc.page.margins.left - doc.page.margins.right;
   const colWidths = {
-    empresa: availableWidth * 0.32,
-    cnpj: availableWidth * 0.18,
-    emissao: availableWidth * 0.18,
-    dar: availableWidth * 0.16,
-    valor: availableWidth * 0.16,
+    empresa: availableWidth * 0.30,
+    cnpj: availableWidth * 0.17,
+    emissao: availableWidth * 0.17,
+    dar: availableWidth * 0.22,
+    valor: availableWidth * 0.14,
   };
   const headers = ['Empresa', 'CNPJ', 'Emissão', 'DAR/Comp.', 'Valor (R$)'];
 


### PR DESCRIPTION
## Summary
- allow two-line DAR rows by increasing row height
- widen DAR/competência column and rebalance remaining widths

## Testing
- `npm test`
- `node - <<'NODE' ... NODE` (generate PDF with long competence name)


------
https://chatgpt.com/codex/tasks/task_e_68b03ced04ac83338daae1d6eeada5cc