### PR TITLE
Atualiza rotas de salas e reservas

### DIFF
--- a/src/api/adminSalasRoutes.js
+++ b/src/api/adminSalasRoutes.js
@@ -107,10 +107,22 @@ router.put(
       usada,
       qtd_pessoas,
       permissionario_id,
+      inicio,
+      fim,
     } = req.body || {};
     try {
       const updates = [];
       const params = [];
+      if (inicio) {
+        const [d, t] = inicio.split('T');
+        updates.push('data = ?'); params.push(d);
+        updates.push('hora_inicio = ?'); params.push(t.slice(0,5));
+      }
+      if (fim) {
+        const [d, t] = fim.split('T');
+        if (!inicio) { updates.push('data = ?'); params.push(d); }
+        updates.push('hora_fim = ?'); params.push(t.slice(0,5));
+      }
       if (data) { updates.push('data = ?'); params.push(data); }
       if (horario_inicio) { updates.push('hora_inicio = ?'); params.push(horario_inicio); }
       if (horario_fim) { updates.push('hora_fim = ?'); params.push(horario_fim); }


### PR DESCRIPTION
## Summary
- Ajusta script administrativo para usar novos endpoints de check-in, atualização de reservas e status das salas
- Aceita campos `inicio` e `fim` ao editar reservas

## Testing
- `npm test` *(falhou: Admin realiza check-in e outros testes)*

------
https://chatgpt.com/codex/tasks/task_e_68b0517219bc83339f22a1de74c4c027