### PR TITLE
Aplicar mínimo de participantes em reservas de salas

### DIFF
--- a/public/js/salas.js
+++ b/public/js/salas.js
@@ -78,6 +78,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         const start = document.getElementById('start').value;
         const end = document.getElementById('end').value;
         const qtd_pessoas = parseInt(document.getElementById('qtd_pessoas').value, 10);
+        if (qtd_pessoas < 3) {
+            alert('A quantidade mínima de pessoas é 3.');
+            return;
+        }
         const data = start.split('T')[0];
         const horario_inicio = start.split('T')[1];
         const horario_fim = end.split('T')[1];

--- a/public/salas.html
+++ b/public/salas.html
@@ -79,7 +79,7 @@
                             </div>
                             <div class="col-md-3">
                                 <label for="qtd_pessoas" class="form-label">Qtd. Pessoas</label>
-                                <input type="number" id="qtd_pessoas" class="form-control" required min="1">
+                                <input type="number" id="qtd_pessoas" class="form-control" required min="3" step="1">
                             </div>
                             <div class="col-12 text-end">
                                 <button type="submit" class="btn btn-primary">Reservar</button>


### PR DESCRIPTION
## Summary
- Exige pelo menos três pessoas na reserva de sala e evita valores fracionados
- Adiciona validação no cliente para alertar quando a quantidade de pessoas for insuficiente

## Testing
- `npm test` *(falha: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68b057bbe2c48333b09004bf9288774e