### PR TITLE
feat: listar e cancelar reservas de salas

### DIFF
--- a/public/js/salas.js
+++ b/public/js/salas.js
@@ -128,27 +128,50 @@ document.addEventListener('DOMContentLoaded', async () => {
             });
             if (!res.ok) throw new Error('Erro ao reservar');
             calendar.refetchEvents();
+            carregarReservas();
             e.target.reset();
         } catch (err) {
             alert(err.message);
         }
     });
 
-    document.getElementById('cancelForm').addEventListener('submit', async (e) => {
-        e.preventDefault();
-        const id = document.getElementById('reservaId').value;
+    const reservasBody = document.querySelector('#reservasTable tbody');
+    async function carregarReservas() {
         try {
-            const res = await fetch(`/api/salas/reservas/${id}`, {
-                method: 'DELETE',
-                headers
+            const resp = await fetch('/api/salas/minhas-reservas', { headers });
+            if (!resp.ok) throw new Error('Falha ao carregar reservas');
+            const reservas = await resp.json();
+            reservasBody.innerHTML = '';
+            reservas.forEach(r => {
+                const tr = document.createElement('tr');
+                tr.innerHTML = `
+                    <td>${r.sala}</td>
+                    <td>${r.data}</td>
+                    <td>${r.hora_inicio}</td>
+                    <td>${r.hora_fim}</td>
+                    <td><button class="btn btn-sm btn-danger" data-id="${r.id}">Cancelar</button></td>`;
+                reservasBody.appendChild(tr);
             });
-            if (!res.ok) throw new Error('Erro ao cancelar');
-            calendar.refetchEvents();
-            e.target.reset();
         } catch (err) {
-            alert(err.message);
+            reservasBody.innerHTML = '';
+        }
+    }
+
+    reservasBody.addEventListener('click', async (e) => {
+        if (e.target.matches('button[data-id]')) {
+            const id = e.target.getAttribute('data-id');
+            try {
+                const res = await fetch(`/api/salas/reservas/${id}`, { method: 'DELETE', headers });
+                if (!res.ok) throw new Error('Erro ao cancelar');
+                calendar.refetchEvents();
+                carregarReservas();
+            } catch (err) {
+                alert(err.message);
+            }
         }
     });
+
+    carregarReservas();
 });
 
 function formatarCNPJ(cnpj) {

--- a/public/salas.html
+++ b/public/salas.html
@@ -90,16 +90,21 @@
 
                 <div class="card mt-4">
                     <div class="card-body">
-                        <h5 class="card-title">Cancelar Reserva</h5>
-                        <form id="cancelForm" class="row g-3">
-                            <div class="col-md-6">
-                                <label for="reservaId" class="form-label">ID da Reserva</label>
-                                <input type="text" id="reservaId" class="form-control" required>
-                            </div>
-                            <div class="col-12 text-end">
-                                <button type="submit" class="btn btn-danger">Cancelar</button>
-                            </div>
-                        </form>
+                        <h5 class="card-title">Minhas Reservas</h5>
+                        <div class="table-responsive">
+                            <table id="reservasTable" class="table">
+                                <thead>
+                                    <tr>
+                                        <th>Sala</th>
+                                        <th>Data</th>
+                                        <th>Início</th>
+                                        <th>Fim</th>
+                                        <th></th>
+                                    </tr>
+                                </thead>
+                                <tbody></tbody>
+                            </table>
+                        </div>
                     </div>
                 </div>
             </main>

--- a/src/api/salasRoutes.js
+++ b/src/api/salasRoutes.js
@@ -75,6 +75,24 @@ router.get('/:id/disponibilidade', async (req, res) => {
   }
 });
 
+// Reservas futuras do usuário
+router.get('/minhas-reservas', async (req, res) => {
+  try {
+    const reservas = await allAsync(
+      `SELECT r.id, s.numero AS sala, r.data, r.hora_inicio, r.hora_fim
+         FROM reservas_salas r
+         JOIN salas_reuniao s ON r.sala_id = s.id
+        WHERE r.permissionario_id = ?
+          AND datetime(r.data || 'T' || r.hora_fim) >= datetime('now')
+        ORDER BY r.data, r.hora_inicio`,
+      [req.user.id]
+    );
+    res.json(reservas);
+  } catch (e) {
+    res.status(500).json({ error: 'Erro ao listar reservas.' });
+  }
+});
+
 // Reservas da sala em intervalo
 router.get('/:id/reservas', async (req, res) => {
   const salaId = parseInt(req.params.id, 10);


### PR DESCRIPTION
## Summary
- add endpoint to list future room reservations for the logged in user
- show user's reservations in table with cancel buttons
- remove manual id cancellation form from the rooms page

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68b0627ae7ec8333aef4d2195ab12039