### PR TITLE
feat: add reservas audit migration

### DIFF
--- a/atualizar_db_v7.js
+++ b/atualizar_db_v7.js
@@ -32,10 +32,11 @@ const isWin = process.platform === 'win32';
 const sqliteUrl = `sqlite:${isWin ? '/' : '////'}${newDbPath}`;
 
 log(`Rodando migrations em ${sqliteUrl} ...`);
-execSync(`npx sequelize-cli db:migrate --url "${sqliteUrl}"`, {
+execSync(`npx sequelize-cli db:migrate --migrations-path src/migrations --url "${sqliteUrl}"`, {
   stdio: 'inherit',
   cwd: root,
 });
 
 log('Migrations concluídas com sucesso.');
 log('Agora, aponte o .env para a NOVA base e reinicie o PM2.');
+

--- a/scripts/atualizar_db_v7.js
+++ b/scripts/atualizar_db_v7.js
@@ -32,10 +32,11 @@ const isWin = process.platform === 'win32';
 const sqliteUrl = `sqlite:${isWin ? '/' : '////'}${newDbPath}`;
 
 log(`Rodando migrations em ${sqliteUrl} ...`);
-execSync(`npx sequelize-cli db:migrate --url "${sqliteUrl}"`, {
+execSync(`npx sequelize-cli db:migrate --migrations-path src/migrations --url "${sqliteUrl}"`, {
   stdio: 'inherit',
   cwd: root,
 });
 
 log('Migrations concluídas com sucesso.');
 log('Agora, aponte o .env para a NOVA base e reinicie o PM2.');
+

--- a/src/migrations/20250829120000-create-reservas-audit.js
+++ b/src/migrations/20250829120000-create-reservas-audit.js
@@ -1,0 +1,39 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('reservas_audit', {
+      id: {
+        type: Sequelize.INTEGER,
+        autoIncrement: true,
+        primaryKey: true,
+      },
+      reserva_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'reservas_salas',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      acao: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      detalhes: {
+        type: Sequelize.TEXT,
+      },
+      data_registro: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('reservas_audit');
+  }
+};


### PR DESCRIPTION
## Summary
- add migration for reservas_audit table
- ensure deploy scripts run migrations from src/migrations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0654653748333afe1446704387817