### PR TITLE
chore: run migrations on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,13 @@ As DARs utilizam os seguintes status padronizados:
 - `Vencido` – vencimento ultrapassado sem pagamento.
 
 O valor legado `Vencida` foi unificado para `Vencido` e não deve mais ser utilizado.
+
+## Migrações do Banco de Dados
+
+Para configurar um novo ambiente, execute as migrações do Sequelize antes de iniciar o servidor:
+
+```bash
+npx sequelize-cli db:migrate
+```
+
+O projeto também tenta rodar esse comando automaticamente na inicialização, mas executar manualmente garante que o schema esteja atualizado.

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,9 @@
 // src/index.js
 require('dotenv').config();
 
+// Garante que as migrações do Sequelize sejam executadas ao iniciar
+require('./database/init');
+
 console.log('[BOOT] BOT_SHARED_KEY len =', (process.env.BOT_SHARED_KEY || '').length);
 
 const express = require('express');


### PR DESCRIPTION
## Summary
- remove direct table creation for meeting rooms and audits
- trigger Sequelize migrations during startup
- document database migration steps for new environments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b06548b18c8333ac4693eade61b82a