### PR TITLE
Refactor admin-salas modal actions

### DIFF
--- a/public/js/admin-salas.js
+++ b/public/js/admin-salas.js
@@ -60,23 +60,11 @@ async function fetchReservas(fetchInfo, successCallback, failureCallback) {
 }
 
 function onEventClick(info) {
-  const acao = prompt('Digite "c" para cancelar ou "u" para registrar uso:');
-  if (acao === 'c') {
-    fetch(`/api/admin/salas/reservas/${info.event.id}`, { method: 'DELETE' })
-      .then(resp => {
-        if (resp.ok) info.event.remove();
-        else alert('Falha ao cancelar reserva');
-      });
-  } else if (acao === 'u') {
-    fetch(`/api/admin/salas/reservas/${info.event.id}/uso`, { method: 'POST' })
-      .then(resp => {
-        if (resp.ok) alert('Uso registrado');
-        else alert('Falha ao registrar uso');
-      });
   eventoSelecionado = info.event;
   modalReserva?.show();
 }
 
+async function cancelarReserva() {
   if (!eventoSelecionado) return;
   try {
     const resp = await fetch(`/api/admin/salas/reservas/${eventoSelecionado.id}`, { method: 'DELETE' });
@@ -94,7 +82,7 @@ function onEventClick(info) {
 async function registrarCheckin() {
   if (!eventoSelecionado) return;
   try {
-    const resp = await fetch(`/api/admin/salas/reservas/${eventoSelecionado.id}/checkin`, { method: 'POST' });
+    const resp = await fetch(`/api/admin/salas/reservas/${eventoSelecionado.id}/uso`, { method: 'POST' });
     if (!resp.ok) throw new Error('Falha ao registrar check-in');
     mostrarMensagem('Check-in registrado com sucesso', 'success');
   } catch (err) {


### PR DESCRIPTION
## Summary
- simplify event click handler to open modal without prompt
- add explicit `cancelarReserva` async function
- register check-in via `/reservas/:id/uso` endpoint

## Testing
- `npm test` *(fails: Cannot find module...)*

------
https://chatgpt.com/codex/tasks/task_e_68b088f58e8c8333901bd3b1f021ee3c