### PR TITLE
Impede reservas de sala em dias consecutivos

### DIFF
--- a/src/api/salasRoutes.js
+++ b/src/api/salasRoutes.js
@@ -127,6 +127,7 @@ router.post('/reservas', async (req, res) => {
     );
 
     const permissionarioId = req.user.id;
+    await reservaSalaService.verificarDiasConsecutivos(permissionarioId, sala_id, data);
     const result = await runAsync(
       `INSERT INTO reservas_salas (sala_id, permissionario_id, data, hora_inicio, hora_fim, participantes, status, checkin)
        VALUES (?, ?, ?, ?, ?, ?, 'pendente', NULL)`,

--- a/src/services/reservaSalaService.js
+++ b/src/services/reservaSalaService.js
@@ -61,8 +61,25 @@ async function verificarConflito(salaId, data, inicio, fim, ignoreId) {
   }
 }
 
+async function verificarDiasConsecutivos(permissionarioId, salaId, data) {
+  const baseDate = new Date(`${data}T00:00:00`);
+  if (isNaN(baseDate)) throw validationError('Data inválida.');
+  const prev = new Date(baseDate);
+  prev.setDate(baseDate.getDate() - 1);
+  const next = new Date(baseDate);
+  next.setDate(baseDate.getDate() + 1);
+  const prevStr = prev.toISOString().slice(0, 10);
+  const nextStr = next.toISOString().slice(0, 10);
+  const sql = `SELECT id FROM reservas_salas WHERE permissionario_id = ? AND sala_id = ? AND data IN (?, ?)`;
+  const conflito = await getAsync(sql, [permissionarioId, salaId, prevStr, nextStr]);
+  if (conflito) {
+    throw validationError('Não é permitido reservar sala em dias consecutivos.');
+  }
+}
+
 module.exports = {
   validarSalaECapacidade,
   validarHorarios,
   verificarConflito,
+  verificarDiasConsecutivos,
 };

--- a/tests/salasRoutes.test.js
+++ b/tests/salasRoutes.test.js
@@ -98,6 +98,17 @@ test('Reserva válida', async () => {
   assert.equal(audit[0].acao, 'CRIACAO');
 });
 
+test('Bloqueia reserva em dias consecutivos', async () => {
+  await insertReserva('2025-10-10','09:00','10:00');
+  const app = setupUserApp();
+  await supertest(app)
+    .post('/api/salas/reservas')
+    .set('Authorization', `Bearer ${userToken}`)
+    .send({ sala_id:1, data:'2025-10-11', horario_inicio:'09:00', horario_fim:'10:00', qtd_pessoas:2 })
+    .expect(400)
+    .then(res => assert.equal(res.body.error, 'Não é permitido reservar sala em dias consecutivos.'));
+});
+
 test('Lista disponibilidade retorna reservas existentes', async () => {
   await insertReserva('2025-10-10','09:00','10:30');
   const app = setupUserApp();


### PR DESCRIPTION
## Summary
- Bloqueia reservas consecutivas para o mesmo permissionário implementando verificação de dias contíguos
- Valida dias consecutivos ao criar reserva na rota de salas
- Garante via teste que reservas em dias seguidos são recusadas

## Testing
- `node --test tests/salasRoutes.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b08ca6a5a083338cb85170c5650702