### PR TITLE
Ignorar reservas canceladas ao verificar conflito de sala

### DIFF
--- a/src/services/reservaSalaService.js
+++ b/src/services/reservaSalaService.js
@@ -42,6 +42,7 @@ async function verificarConflito(salaId, data, inicio, fim, ignoreId) {
   try {
     let sql = `SELECT id FROM reservas_salas
                WHERE sala_id = ? AND data = ?
+                 AND status <> 'cancelada'
                  AND NOT (? >= hora_fim OR ? <= hora_inicio)`;
     const params = [salaId, data, inicio, fim];
     if (ignoreId) {


### PR DESCRIPTION
## Summary
- Ignora reservas com status `cancelada` ao verificar conflitos de sala
- Garante via teste que reserva cancelada pelo admin libera o mesmo horário

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b08dd99e588333a549ff7084c1105f