### PR TITLE
feat: support DAR reissuance with updated values

### DIFF
--- a/public/admin/eventos-dars.html
+++ b/public/admin/eventos-dars.html
@@ -1227,18 +1227,13 @@ function normalizarEvento(payload){
   }
 
   async function reemitirDAR(eventoId, darId, extra={}){
-    const tentativas = [
-      { url: `/api/admin/eventos/${eventoId}/dars/${darId}/reemitir`, opt:{ method:'POST', headers: AUTH_HEADERS } },
-      { url: `/api/admin/eventos/${eventoId}/dars/reemitir`,        opt:{ method:'POST', headers:{...AUTH_HEADERS,'Content-Type':'application/json'}, body: JSON.stringify({ dar_id:darId, ...extra }) } },
-      { url: `/api/admin/dars/${darId}/reemitir`,                   opt:{ method:'POST', headers:{...AUTH_HEADERS,'Content-Type':'application/json'}, body: JSON.stringify({ evento_id:eventoId, ...extra }) } }
-    ];
-    for (const t of tentativas){
-      try{
-        const r = await fetch(t.url, t.opt);
-        const j = await r.json().catch(()=> ({}));
-        if (r.ok) return j;
-      }catch{}
-    }
+    const resp = await fetch(`/api/admin/dars/${darId}/reemitir`, {
+      method: 'POST',
+      headers: { ...AUTH_HEADERS, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ evento_id: eventoId, ...extra })
+    });
+    const json = await resp.json().catch(() => ({}));
+    if (resp.ok) return json;
     throw new Error('Não foi possível reemitir a DAR.');
   }
 

--- a/public/eventos/dashboard-eventos.html
+++ b/public/eventos/dashboard-eventos.html
@@ -281,20 +281,13 @@
       async function reemitirDAR(headers, eventoId, dar){
         const darId   = dar.id || dar.dar_id || dar.parcela_id || dar.referencia || dar.parcela_num;
         const parcNum = dar.parcela_num || dar.referencia || null;
-        const tentativas = [
-          { url: `/api/portal/eventos/${eventoId}/dars/${darId}/reemitir`, opt:{ method:'POST', headers } },
-          { url: `/api/eventos/clientes/eventos/${eventoId}/dars/${darId}/reemitir`, opt:{ method:'POST', headers } },
-          { url: `/api/portal/eventos/${eventoId}/dars/reemitir`,  opt:{ method:'POST', headers, body: JSON.stringify({ dar_id:darId, parcela_num:parcNum }) } },
-          { url: `/api/eventos/clientes/eventos/${eventoId}/dars/reemitir`, opt:{ method:'POST', headers, body: JSON.stringify({ dar_id:darId, parcela_num:parcNum }) } },
-          { url: `/api/eventos/dars/${darId}/reemitir`, opt:{ method:'POST', headers, body: JSON.stringify({ parcela_num:parcNum, evento_id:eventoId }) } }
-        ];
-        for (const t of tentativas){
-          try{
-            const r = await fetch(t.url, t.opt);
-            const j = await r.json().catch(()=> ({}));
-            if (r.ok) return j;
-          }catch{}
-        }
+        const resp = await fetch(`/api/admin/dars/${darId}/reemitir`, {
+          method: 'POST',
+          headers: { ...headers, 'Content-Type': 'application/json' },
+          body: JSON.stringify({ evento_id: eventoId, parcela_num: parcNum })
+        });
+        const json = await resp.json().catch(() => ({}));
+        if (resp.ok) return json;
         throw new Error('Não foi possível emitir a DAR.');
       }
 

--- a/tests/adminDarsReemitir.test.js
+++ b/tests/adminDarsReemitir.test.js
@@ -1,0 +1,54 @@
+// tests/adminDarsReemitir.test.js
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const fs = require('fs');
+const express = require('express');
+const supertest = require('supertest');
+
+test('reemitir DAR vencido atualiza valor e vencimento', async () => {
+  const dbPath = path.resolve(__dirname, 'test-admin-reemit.db');
+  try { fs.unlinkSync(dbPath); } catch {}
+  process.env.SQLITE_STORAGE = dbPath;
+
+  const db = require('../src/database/db');
+  const run = (sql, params=[]) => new Promise((res, rej) => db.run(sql, params, err => err ? rej(err) : res()));
+  const get = (sql, params=[]) => new Promise((res, rej) => db.get(sql, params, (err, row) => err ? rej(err) : res(row)));
+
+  await run(`CREATE TABLE permissionarios (id INTEGER PRIMARY KEY, nome_empresa TEXT, cnpj TEXT)`);
+  await run(`CREATE TABLE dars (id INTEGER PRIMARY KEY, permissionario_id INTEGER, data_vencimento TEXT, mes_referencia INTEGER, ano_referencia INTEGER, valor REAL, status TEXT, numero_documento TEXT, pdf_url TEXT, codigo_barras TEXT, link_pdf TEXT)`);
+  await run(`INSERT INTO permissionarios (id, nome_empresa, cnpj) VALUES (1, 'Perm', '12345678000199')`);
+  await run(`INSERT INTO dars (id, permissionario_id, data_vencimento, mes_referencia, ano_referencia, valor, status) VALUES (99, 1, '2024-01-01', 1, 2024, 100, 'Vencido')`);
+
+  process.env.COD_IBGE_MUNICIPIO = '2704302';
+  process.env.RECEITA_CODIGO_PERMISSIONARIO = '12345';
+
+  const sefazPath = path.resolve(__dirname, '../src/services/sefazService.js');
+  require.cache[sefazPath] = { exports: { emitirGuiaSefaz: async () => ({ numeroGuia: '999', pdfBase64: 'PDF' }) } };
+
+  const cobrancaPath = path.resolve(__dirname, '../src/services/cobrancaService.js');
+  require.cache[cobrancaPath] = { exports: { calcularEncargosAtraso: async () => ({ valorAtualizado: 150, novaDataVencimento: '2030-01-31' }) } };
+
+  const tokenPath = path.resolve(__dirname, '../src/utils/token.js');
+  require.cache[tokenPath] = { exports: { gerarTokenDocumento: async () => 'T', imprimirTokenEmPdf: async (pdf) => pdf } };
+
+  const authPath = path.resolve(__dirname, '../src/middleware/authMiddleware.js');
+  require.cache[authPath] = { exports: (req, _res, next) => { req.user = { id: 1 }; next(); } };
+
+  const rolePath = path.resolve(__dirname, '../src/middleware/roleMiddleware.js');
+  require.cache[rolePath] = { exports: () => (req, _res, next) => next() };
+
+  const adminDarsRoutes = require('../src/api/adminDarsRoutes');
+  const app = express();
+  app.use(express.json());
+  app.use('/api/admin/dars', adminDarsRoutes);
+
+  await supertest(app).post('/api/admin/dars/99/reemitir').send({}).expect(200);
+
+  const row = await get(`SELECT valor, data_vencimento, status, numero_documento, pdf_url FROM dars WHERE id = 99`);
+  assert.equal(row.valor, 150);
+  assert.equal(row.data_vencimento, '2030-01-31');
+  assert.equal(row.status, 'Reemitido');
+  assert.equal(row.numero_documento, '999');
+  assert.equal(row.pdf_url, 'PDF');
+});


### PR DESCRIPTION
## Summary
- add `/api/admin/dars/:id/reemitir` endpoint that recalculates overdue charges and updates value/vencimento
- adjust admin and event dashboards to use new reissue endpoint
- cover reissue flow with unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b09be6b2a08333b19b103b2f2087d6