### PR TITLE
Use SQLITE_STORAGE for conciliation scripts

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+ADMIN_BASE_URL=https://admin.portalcipt.com.br
+SQLITE_STORAGE=./sistemacipt.db

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 # Example environment configuration for CIPT
 # Administrative panel base URL
 ADMIN_BASE_URL=https://admin.portalcipt.com.br
+
+# Path to the SQLite database file used by the application
+SQLITE_STORAGE=./sistemacipt.db

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Este projeto integra o fluxo de assinaturas digitais utilizando o serviço **Ass
 ## Variáveis de Ambiente
 Adicione no arquivo `.env` ou nas variáveis do servidor:
 
+- `SQLITE_STORAGE`: caminho do arquivo SQLite utilizado pela aplicação e pelos scripts de conciliação, por exemplo `./sistemacipt.db`.
 - `ASSINAFY_API_KEY`: token de acesso gerado no painel.
 - `ASSINAFY_API_URL` (opcional): URL base da API. Padrão `https://api.assinafy.com`.
 - `ASSINAFY_CALLBACK_URL`: URL pública para o retorno após a assinatura, ex.: `https://seusistema/api/documentos/assinafy/callback`.

--- a/cron/conciliarPagamentosAno.js
+++ b/cron/conciliarPagamentosAno.js
@@ -1,12 +1,15 @@
 // Em: cron/conciliarPagamentosAno.js
 require('dotenv').config({ path: require('path').resolve(__dirname, '../.env') });
 const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
 
 const {
-  DB_PATH = '/home/pedroivodesouza/sistemadepagamentocipt/sistemacipt.db',
+  SQLITE_STORAGE,
   CONCILIACAO_TOLERANCIA_CENTAVOS = '500', // 5 reais
   DEBUG_CONCILIACAO = 'true',
 } = process.env;
+
+const DB_PATH = path.resolve(SQLITE_STORAGE || '/home/pedroivodesouza/sistemadepagamentocipt/sistemacipt.db');
 
 const TOL_BASE = Number(CONCILIACAO_TOLERANCIA_CENTAVOS) || 500;
 const DBG = String(DEBUG_CONCILIACAO).toLowerCase() === 'true';

--- a/cron/conciliarPagamentosmes.js
+++ b/cron/conciliarPagamentosmes.js
@@ -10,11 +10,13 @@ const sqlite3 = require('sqlite3').verbose();
 const cron = require('node-cron');
 
 const {
-  DB_PATH = '/home/pedroivodesouza/sistemadepagamentocipt/sistemacipt.db',
+  SQLITE_STORAGE,
   CONCILIACAO_TOLERANCIA_CENTAVOS = '500',
   DEBUG_CONCILIACAO = 'true',
   CONCILIAR_BASE_DIA = 'ontem', // "ontem" (padrão) ou "hoje"
 } = process.env;
+
+const DB_PATH = path.resolve(SQLITE_STORAGE || '/home/pedroivodesouza/sistemadepagamentocipt/sistemacipt.db');
 
 const TOL_BASE = Number(CONCILIACAO_TOLERANCIA_CENTAVOS) || 500;
 const DBG = String(DEBUG_CONCILIACAO).toLowerCase() === 'true';


### PR DESCRIPTION
## Summary
- read SQLite path from `SQLITE_STORAGE` in daily and yearly conciliation scripts with local fallback
- document `SQLITE_STORAGE` in env files and README

## Testing
- `node -e "require('dotenv').config(); const path=require('path'); console.log('WEB_APP_DB', path.resolve(process.env.SQLITE_STORAGE));"`
- `SEFAZ_APP_TOKEN=dummy node cron/conciliarPagamentosmes.js --date=2025-01-01 | head -n 20`
- `SEFAZ_APP_TOKEN=dummy node cron/conciliarPagamentosAno.js --ano=2025 | head -n 20`
- `npm test >/tmp/unit.log 2>&1 && tail -n 20 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_68b09cf762f8833380085947104ee0f0