### PR TITLE
Add unavailable status toggle for rooms

### DIFF
--- a/public/admin/salas.html
+++ b/public/admin/salas.html
@@ -93,7 +93,7 @@
                             <div class="tab-pane fade" id="salas" role="tabpanel" aria-labelledby="salas-tab">
                                 <table class="table" id="tabelaSalas">
                                     <thead>
-                                        <tr><th>Nome</th><th>Disponível</th><th>Manutenção</th></tr>
+                                        <tr><th>Nome</th><th>Disponível</th><th>Manutenção</th><th>Indisponível</th></tr>
                                     </thead>
                                     <tbody></tbody>
                                 </table>

--- a/public/js/admin-salas.js
+++ b/public/js/admin-salas.js
@@ -131,28 +131,29 @@ async function carregarSalas() {
         tr.innerHTML = `
           <td>${sala.nome}</td>
           <td><input type="checkbox" class="chk-disponivel" ${sala.status === 'disponivel' ? 'checked' : ''}></td>
-          <td><input type="checkbox" class="chk-manutencao" ${sala.status === 'manutencao' ? 'checked' : ''}></td>`;
+          <td><input type="checkbox" class="chk-manutencao" ${sala.status === 'manutencao' ? 'checked' : ''}></td>
+          <td><input type="checkbox" class="chk-indisponivel" ${sala.status === 'indisponivel' ? 'checked' : ''}></td>`;
         tabela.appendChild(tr);
         const chkDisp = tr.querySelector('.chk-disponivel');
         const chkManu = tr.querySelector('.chk-manutencao');
-        chkDisp.addEventListener('change', () => {
-          if (chkDisp.checked) chkManu.checked = false;
+        const chkIndisp = tr.querySelector('.chk-indisponivel');
+        const checkboxes = [chkDisp, chkManu, chkIndisp];
+        const atualizar = () => {
+          checkboxes.forEach((chk, idx) => {
+            if (chk.checked) {
+              checkboxes.forEach((outro, j) => { if (j !== idx) outro.checked = false; });
+            }
+          });
           const status = chkDisp.checked
             ? 'disponivel'
             : chkManu.checked
               ? 'manutencao'
-              : 'indisponivel';
+              : chkIndisp.checked
+                ? 'indisponivel'
+                : 'indisponivel';
           atualizarSala(sala.id, status);
-        });
-        chkManu.addEventListener('change', () => {
-          if (chkManu.checked) chkDisp.checked = false;
-          const status = chkManu.checked
-            ? 'manutencao'
-            : chkDisp.checked
-              ? 'disponivel'
-              : 'indisponivel';
-          atualizarSala(sala.id, status);
-        });
+        };
+        checkboxes.forEach(chk => chk.addEventListener('change', atualizar));
       }
 
       if (selectSala) {


### PR DESCRIPTION
## Summary
- Add third "Indisponível" column with checkbox to admin Salas table
- Extend room loader to handle exclusive Disponível/Manutenção/Indisponível checkboxes

## Testing
- `npm test` *(fails: tests 16, pass 5, fail 11)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d04d278883339c169a370f1908cf