### PR TITLE
Normalize invalid data_emissao before type change

### DIFF
--- a/src/migrations/20250818120000-add-emitido-por-id-to-dars.js
+++ b/src/migrations/20250818120000-add-emitido-por-id-to-dars.js
@@ -16,6 +16,29 @@ module.exports = {
       });
     }
     if (table['data_emissao']) {
+      const [dars] = await queryInterface.sequelize.query(
+        "SELECT id, data_emissao FROM dars"
+      );
+
+      for (const dar of dars) {
+        if (dar.data_emissao) {
+          const date = new Date(dar.data_emissao);
+          if (isNaN(date.getTime())) {
+            await queryInterface.bulkUpdate(
+              'dars',
+              { data_emissao: null },
+              { id: dar.id }
+            );
+          } else {
+            await queryInterface.bulkUpdate(
+              'dars',
+              { data_emissao: date.toISOString() },
+              { id: dar.id }
+            );
+          }
+        }
+      }
+
       await queryInterface.changeColumn('dars', 'data_emissao', {
         type: Sequelize.DATE,
         allowNull: true,


### PR DESCRIPTION
## Summary
- clean `dars.data_emissao` values before altering column type

## Testing
- `npm test` *(fails: Cannot find module 'express', cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_e_68b5e037b2b08333a092a7cfac4105c2