### PR TITLE
Check for column existence before removal in migration

### DIFF
--- a/src/migrations/20250818120000-add-emitido-por-id-to-dars.js
+++ b/src/migrations/20250818120000-add-emitido-por-id-to-dars.js
@@ -25,7 +25,10 @@ module.exports = {
   },
 
   async down(queryInterface, Sequelize) {
-    await queryInterface.removeColumn('dars', 'emitido_por_id');
+    const table = await queryInterface.describeTable('dars');
+    if (table['emitido_por_id']) {
+      await queryInterface.removeColumn('dars', 'emitido_por_id');
+    }
     await queryInterface.changeColumn('dars', 'data_emissao', {
       type: Sequelize.DATE,
       allowNull: false,


### PR DESCRIPTION
## Summary
- Guard `emitido_por_id` removal in down migration by checking table schema first

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68b5e04a07c88333af2779bd63c18d37