### PR TITLE
Check for column existence before removal in migration

### DIFF
--- a/src/migrations/20250818120000-add-emitido-por-id-to-dars.js
+++ b/src/migrations/20250818120000-add-emitido-por-id-to-dars.js
@@ -25,11 +25,23 @@ module.exports = {
   },
 
   async down(queryInterface, Sequelize) {
-    await queryInterface.removeColumn('dars', 'emitido_por_id');
-    await queryInterface.changeColumn('dars', 'data_emissao', {
-      type: Sequelize.DATE,
-      allowNull: false,
-      defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
-    });
+    let table;
+    try {
+      table = await queryInterface.describeTable('dars');
+    } catch (error) {
+      return;
+    }
+
+    if (table.emitido_por_id) {
+      await queryInterface.removeColumn('dars', 'emitido_por_id');
+    }
+
+    if (table.data_emissao) {
+      await queryInterface.changeColumn('dars', 'data_emissao', {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      });
+    }
   }
 };


### PR DESCRIPTION
## Summary
- Guard `emitido_por_id` removal and `data_emissao` revert in down migration by first describing the `dars` table and skipping operations when missing

## Testing
- `npm test` *(fails: Cannot find module 'express')*
- `npx sequelize-cli db:migrate --migrations-path src/migrations --url sqlite:./sistemacipt.db` *(fails: Unable to resolve sequelize package)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e04a07c88333af2779bd63c18d37