### PR TITLE
Fix down migration closing braces

### DIFF
--- a/src/migrations/20250818120000-add-emitido-por-id-to-dars.js
+++ b/src/migrations/20250818120000-add-emitido-por-id-to-dars.js
@@ -76,4 +76,5 @@ module.exports = {
         defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
       });
     }
+  }
 };


### PR DESCRIPTION
## Summary
- Correct missing closing braces in `add-emitido-por-id-to-dars` migration

## Testing
- `npx sequelize-cli db:migrate --config src/config/config.json --migrations-path src/migrations` *(fails: No description found for "Eventos" table)*
- `npm test` *(fails: 2 tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e994fab08333acb63d6d2b090f76