### PR TITLE
Resolve DB path relative to repository root

### DIFF
--- a/cron/gerarDarsMensais.js
+++ b/cron/gerarDarsMensais.js
@@ -8,8 +8,8 @@ const { enviarEmailNovaDar } = require('../src/services/emailService');
 
 // ================== Config ==================
 const DB_PATH = process.env.SQLITE_STORAGE
-  ? path.resolve(process.cwd(), process.env.SQLITE_STORAGE)
-  : path.resolve(process.cwd(), './sistemacipt.db');
+  ? path.resolve(__dirname, '..', process.env.SQLITE_STORAGE)
+  : path.resolve(__dirname, '../sistemacipt.db');
 
 // Se quiser testar com apenas 1 permissionário, defina TEST_PERMISSIONARIO_ID no .env (ex.: 26)
 const TEST_PERMISSIONARIO_ID = process.env.TEST_PERMISSIONARIO_ID


### PR DESCRIPTION
## Summary
- resolve database location in cron task using __dirname so it works regardless of working directory

## Testing
- `npm test` *(fails: tests 16, pass 5, fail 11)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e9894018833390359768db873bb2