### PR TITLE
Configure SMTP host and use dynamic secure flag for mailer

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+EMAIL_HOST="smtp.gmail.com"
+EMAIL_PORT=587
+EMAIL_USER="supcti.secti@gmail.com"
+EMAIL_PASS="qnmc rgwt uaod qvzw"

--- a/src/services/emailService.js
+++ b/src/services/emailService.js
@@ -6,8 +6,9 @@ require('dotenv').config();
 
 const transporter = nodemailer.createTransport({
   host: process.env.EMAIL_HOST,
-  port: process.env.EMAIL_PORT,
-  secure: true,
+  port: Number(process.env.EMAIL_PORT),
+  // Porta 465 utiliza TLS; outras portas (ex. 587) usam STARTTLS
+  secure: Number(process.env.EMAIL_PORT) === 465,
   auth: { user: process.env.EMAIL_USER, pass: process.env.EMAIL_PASS },
 });
 


### PR DESCRIPTION
## Summary
- set SMTP env vars in `.env` for gmail
- derive nodemailer `secure` flag from configured port

## Testing
- `npm install`
- `npm test`
- `timeout 5 node cron/gerarDarsMensais.js` *(no emails sent; only dotenv output)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ecc7691c8333b0810f7815514106