### PR TITLE
Handle empty sala responses in meeting room booking

### DIFF
--- a/public/js/salas.js
+++ b/public/js/salas.js
@@ -26,18 +26,30 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     // Carrega salas disponíveis para o select
     const salaSelect = document.getElementById('sala');
+    const submitBtn = document.querySelector('#reserveForm button[type="submit"]');
+    submitBtn.disabled = true;
     try {
         const respSalas = await fetch('/api/salas', { headers });
-        if (respSalas.ok) {
-            const salas = await respSalas.json();
+        if (!respSalas.ok) throw new Error(`Status ${respSalas.status}`);
+        const salas = await respSalas.json();
+        if (!salas.length) {
+            salaSelect.innerHTML = '<option value="">Nenhuma sala disponível</option>';
+            alert('Nenhuma sala disponível');
+            console.warn('Nenhuma sala disponível');
+        } else {
             salas.forEach(s => {
                 const opt = document.createElement('option');
                 opt.value = s.id;
                 opt.textContent = s.nome;
                 salaSelect.appendChild(opt);
             });
+            submitBtn.disabled = false;
         }
-    } catch {}
+    } catch (err) {
+        console.error('Erro ao carregar salas', err);
+        salaSelect.innerHTML = '<option value="">Nenhuma sala disponível</option>';
+        alert('Erro ao carregar salas');
+    }
 
     const calendarEl = document.getElementById('calendar');
     const calendar = new FullCalendar.Calendar(calendarEl, {

--- a/public/salas.html
+++ b/public/salas.html
@@ -82,7 +82,7 @@
                                 <input type="number" id="qtd_pessoas" class="form-control" required min="1" step="1">
                             </div>
                             <div class="col-12 text-end">
-                                <button type="submit" class="btn btn-primary">Reservar</button>
+                                <button type="submit" class="btn btn-primary" disabled>Reservar</button>
                             </div>
                         </form>
                     </div>


### PR DESCRIPTION
## Summary
- Disable reserve submission until rooms load
- Show message and log errors when sala fetch fails or returns empty

## Testing
- `npm test` *(fails: Function._resolveFilename..., 5 passed, 11 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b60d5044a88333923b9b0c882f1dc6