### PR TITLE
Propagate backend DAR errors in admin events UI

### DIFF
--- a/public/admin/eventos-dars.html
+++ b/public/admin/eventos-dars.html
@@ -1218,6 +1218,7 @@ function normalizarEvento(payload){
       body: JSON.stringify({ evento_id: eventoId, ...extra })
     });
     const json = await resp.json().catch(() => ({}));
+    if (json.error) throw new Error(json.error);
     if (resp.ok) return json;
     throw new Error('Não foi possível reemitir a DAR.');
   }
@@ -1372,7 +1373,7 @@ function normalizarEvento(payload){
           await abrirModalDARs(eventoId); // recarrega lista
           await carregarEventos();        // atualiza status geral
         }catch(err){
-          alert(err.message || 'Não foi possível reemitir.');
+          alert(err.message);
         }finally{
           btnReem.disabled = false; btnReem.innerHTML = original;
         }


### PR DESCRIPTION
## Summary
- Surface backend-provided error messages when reissuing event DARs
- Pass backend error messages to users from the DAR reissuance handler

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b61276f644833384ea74884439c56c