### PR TITLE
Rebuild dars table with nullable data_emissao and emitido_por_id foreign key

### DIFF
--- a/src/migrations/20250818120000-add-emitido-por-id-to-dars.js
+++ b/src/migrations/20250818120000-add-emitido-por-id-to-dars.js
@@ -15,42 +15,6 @@ module.exports = {
         onDelete: 'SET NULL',
       });
     }
-    if (table['data_emissao']) {
-      await queryInterface.changeColumn('dars', 'data_emissao', {
-        type: Sequelize.DATE,
-        allowNull: true,
-        defaultValue: null,
-      });
-
-      const [dars] = await queryInterface.sequelize.query(
-        "SELECT id, data_emissao FROM dars"
-      );
-
-      for (const dar of dars) {
-        if (dar.data_emissao) {
-          const date = new Date(dar.data_emissao);
-          if (isNaN(date.getTime())) {
-            await queryInterface.bulkUpdate(
-              'dars',
-              { data_emissao: null },
-              { id: dar.id }
-            );
-          } else {
-            await queryInterface.bulkUpdate(
-              'dars',
-              { data_emissao: date.toISOString() },
-              { id: dar.id }
-            );
-          }
-        }
-      }
-
-      await queryInterface.changeColumn('dars', 'data_emissao', {
-        type: Sequelize.DATE,
-        allowNull: true,
-        defaultValue: null,
-      });
-    }
   },
 
   async down(queryInterface, Sequelize) {
@@ -63,14 +27,6 @@ module.exports = {
 
     if (table.emitido_por_id) {
       await queryInterface.removeColumn('dars', 'emitido_por_id');
-    }
-
-    if (table.data_emissao) {
-      await queryInterface.changeColumn('dars', 'data_emissao', {
-        type: Sequelize.DATE,
-        allowNull: false,
-        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
-      });
     }
   }
 };

--- a/src/migrations/20250818121000-rebuild-dars-data-emissao-emitido-por-id.js
+++ b/src/migrations/20250818121000-rebuild-dars-data-emissao-emitido-por-id.js
@@ -1,0 +1,89 @@
+'use strict';
+
+/**
+ * Recria a tabela `dars` para ajustar o tipo da coluna `data_emissao`
+ * e garantir a existência de `emitido_por_id` com chave estrangeira.
+ *
+ * - `data_emissao` passa a ser `DATE NULL DEFAULT NULL`.
+ * - `emitido_por_id` referencia `permissionarios(id)` com
+ *   `ON UPDATE CASCADE` e `ON DELETE SET NULL`.
+ * - Dados existentes são copiados com `data_emissao` convertido para
+ *   ISO 8601 ou `NULL` quando inválido.
+ */
+module.exports = {
+  async up(queryInterface) {
+    const sequelize = queryInterface.sequelize;
+
+    await sequelize.query('PRAGMA foreign_keys = OFF;');
+
+    const [rows] = await sequelize.query(`
+      SELECT sql FROM sqlite_master
+      WHERE type='table' AND name='dars'
+    `);
+    if (!rows || !rows[0] || !rows[0].sql) {
+      throw new Error('Tabela dars não encontrada no sqlite_master.');
+    }
+
+    let createSql = rows[0].sql;
+
+    // Garantir definição desejada para data_emissao
+    createSql = createSql.replace(
+      /data_emissao\s+[^,]+/i,
+      'data_emissao DATE NULL DEFAULT NULL'
+    );
+
+    // Garantir coluna emitido_por_id com chave estrangeira adequada
+    if (/emitido_por_id/i.test(createSql)) {
+      createSql = createSql.replace(
+        /emitido_por_id\s+[^,\n]+/i,
+        'emitido_por_id INTEGER REFERENCES permissionarios(id) ON UPDATE CASCADE ON DELETE SET NULL'
+      );
+    } else {
+      createSql = createSql.replace(
+        /(\n\s*)(FOREIGN KEY|CONSTRAINT)/i,
+        ',\n  emitido_por_id INTEGER REFERENCES permissionarios(id) ON UPDATE CASCADE ON DELETE SET NULL\n$1$2'
+      );
+      if (!/emitido_por_id/i.test(createSql)) {
+        createSql = createSql.replace(
+          /\)\s*;?$/,
+          ',\n  emitido_por_id INTEGER REFERENCES permissionarios(id) ON UPDATE CASCADE ON DELETE SET NULL\n)'
+        );
+      }
+    }
+
+    const createNewSql = createSql.replace(
+      /CREATE\s+TABLE\s+("?dars"?)/i,
+      'CREATE TABLE dars_new'
+    );
+    await sequelize.query(createNewSql);
+
+    const [oldCols] = await sequelize.query(`PRAGMA table_info(dars);`);
+    const [newCols] = await sequelize.query(`PRAGMA table_info(dars_new);`);
+    const common = newCols
+      .map(c => c.name)
+      .filter(name => oldCols.find(o => o.name === name));
+
+    const colList = common.map(c => `"${c}"`).join(', ');
+    const selectCols = common
+      .map(c =>
+        c === 'data_emissao'
+          ? `CASE WHEN julianday(data_emissao) IS NOT NULL THEN strftime('%Y-%m-%dT%H:%M:%fZ', data_emissao) ELSE NULL END AS data_emissao`
+          : `"${c}"`
+      )
+      .join(', ');
+
+    await sequelize.query(
+      `INSERT INTO dars_new (${colList}) SELECT ${selectCols} FROM dars;`
+    );
+
+    await sequelize.query('DROP TABLE dars;');
+    await sequelize.query('ALTER TABLE dars_new RENAME TO dars;');
+
+    await sequelize.query('PRAGMA foreign_keys = ON;');
+  },
+
+  async down() {
+    console.log('[down] rebuild-dars-data-emissao-emitido-por-id: sem ação');
+  }
+};
+


### PR DESCRIPTION
## Summary
- simplify existing migration to only add `emitido_por_id`
- rebuild `dars` table to cast `data_emissao` to ISO, add `emitido_por_id` FK, and re-enable foreign keys

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6124fa6f483338c3f754adff38a03