### PR TITLE
Safeguard ensureColumn when tables are missing

### DIFF
--- a/src/api/botRoutes.js
+++ b/src/api/botRoutes.js
@@ -100,6 +100,10 @@ const qRun = (sql, params=[]) => new Promise((resolve,reject)=>db.run(sql, param
 async function ensureColumn(table, column, type) {
   try {
     const rows = await qAll(`PRAGMA table_info(${table})`);
+    if (!rows.length) {
+      console.warn(`[DB] Tabela ${table} inexistente; pulando ${column}.`);
+      return;
+    }
     if (!rows.some(r => r.name === column)) {
       await qRun(`ALTER TABLE ${table} ADD COLUMN ${column} ${type}`);
       console.log(`[DB] ALTER TABLE ${table} ADD COLUMN ${column} ${type}`);

--- a/src/api/darsRoutes.js
+++ b/src/api/darsRoutes.js
@@ -64,6 +64,10 @@ async function getTableColumns(table) {
 }
 async function ensureColumn(table, column, type) {
   const cols = await getTableColumns(table);
+  if (!cols.length) {
+    console.warn(`[MIGRATE] Tabela ${table} ausente; pulando ${column}.`);
+    return;
+  }
   const exists = cols.some(c => String(c.name).toLowerCase() === String(column).toLowerCase());
   if (!exists) {
     console.log(`[MIGRATE] Criando coluna ${table}.${column} ${type}...`);

--- a/src/api/userRoutes.js
+++ b/src/api/userRoutes.js
@@ -16,6 +16,10 @@ const dbRun = (sql, params=[]) => new Promise((resolve, reject) => {
 async function ensureColumn(table, column, type) {
   try {
     const rows = await dbAll(`PRAGMA table_info(${table})`);
+    if (!rows.length) {
+      console.warn(`[DB] Tabela ${table} inexistente; pulando ${column}.`);
+      return;
+    }
     if (!rows.some(r => r.name === column)) {
       await dbRun(`ALTER TABLE ${table} ADD COLUMN ${column} ${type}`);
       console.log(`[DB] ALTER TABLE ${table} ADD COLUMN ${column} ${type}`);


### PR DESCRIPTION
## Summary
- Skip column migrations when PRAGMA table_info shows an absent table
- Warn concisely instead of throwing when tables are missing
- Apply safeguard across DAR, bot, and user routes

## Testing
- `npm test`
- `tail -n 20 /tmp/start.log`

------
https://chatgpt.com/codex/tasks/task_e_68b6148783748333b1a2a4ae0cbe51df