### PR TITLE
Defer index creation until after migrations

### DIFF
--- a/src/api/adminRoutes.js
+++ b/src/api/adminRoutes.js
@@ -45,14 +45,24 @@ async function ensureIndexes() {
   try {
     await dbRun(`PRAGMA journal_mode = WAL;`);
   } catch {}
+
+  const tableInfo = await dbAll(`PRAGMA table_info(dars);`);
+  if (!tableInfo || tableInfo.length === 0) {
+    console.warn('[ensureIndexes] Tabela "dars" não encontrada; índices não serão criados.');
+    return;
+  }
+
   await dbRun(`CREATE INDEX IF NOT EXISTS idx_dars_status             ON dars(status);`);
   await dbRun(`CREATE INDEX IF NOT EXISTS idx_dars_data_vencimento    ON dars(data_vencimento);`);
   await dbRun(`CREATE INDEX IF NOT EXISTS idx_dars_status_venc        ON dars(status, data_vencimento);`);
   await dbRun(`CREATE INDEX IF NOT EXISTS idx_dars_permissionario     ON dars(permissionario_id);`);
   await dbRun(`CREATE INDEX IF NOT EXISTS idx_perm_nome               ON permissionarios(nome_empresa);`);
   await dbRun(`CREATE INDEX IF NOT EXISTS idx_perm_cnpj               ON permissionarios(cnpj);`);
+
+  console.log('[ensureIndexes] Índices criados/verificados.');
 }
-ensureIndexes().catch(e => console.error('[adminRoutes] ensureIndexes error:', e.message));
+
+// export for external invocation
 
 // Status em aberto (considera masculino e feminino)
 const OPEN_STATUSES = `('Pendente','Emitido','Emitida','Vencido','Vencida')`;
@@ -804,3 +814,4 @@ function printToken(doc, token) {
 }
 
 module.exports = router;
+module.exports.ensureIndexes = ensureIndexes;


### PR DESCRIPTION
## Summary
- make index creation conditional on the presence of `dars` table and log outcome
- export `ensureIndexes` for deferred invocation after migrations
- await migrations in bootstrap and run `ensureIndexes` before starting the server

## Testing
- `npm test` *(fails: Cannot find module)*
- `SQLITE_STORAGE=./tmp1.sqlite node -e "const db=require('./src/database/db'); db.run('CREATE TABLE IF NOT EXISTS dars(id INTEGER);', [], ()=>{const admin=require('./src/api/adminRoutes'); admin.ensureIndexes().then(()=>console.log('done')).catch(e=>console.error(e));});"`
- `SQLITE_STORAGE=./tmp2.sqlite node -e "const admin=require('./src/api/adminRoutes'); admin.ensureIndexes().then(()=>console.log('done')).catch(e=>console.error(e));"`


------
https://chatgpt.com/codex/tasks/task_e_68b6148516308333a0d98e2f57966b27