### PR TITLE
Avoid JSON parse errors when DAR report is empty

### DIFF
--- a/public/js/admin-relatorios.js
+++ b/public/js/admin-relatorios.js
@@ -23,7 +23,6 @@ window.addEventListener('DOMContentLoaded', () => {
       try {
         const resp = await fetch('/api/admin/relatorios/dars');
         if (resp.status === 404 || resp.status === 204) {
-          await resp.json();
           alert('Nenhuma DAR encontrada.');
           return;
         }


### PR DESCRIPTION
## Summary
- prevent JSON parsing when DAR report endpoint returns 404/204

## Testing
- `node - <<'NODE'
global.alert = (msg) => console.log('alert:', msg);
// stub fetch returning 404
global.fetch = async () => ({ status: 404, ok: false });
// emulate DOM loaded
global.window = { addEventListener: (evt, cb) => cb() };
// provide button element with click event triggered once
global.document = { getElementById: (id) => id === 'btnRelatorioDars' ? { addEventListener: (evt, cb) => cb() } : null };
require('./public/js/admin-relatorios.js');
NODE`
- `npm test` (fails: expected 200 "OK", got 400 "Bad Request")

------
https://chatgpt.com/codex/tasks/task_e_68b82ed72a9c8333902bee2d866cc311