### PR TITLE
Style admin rooms table and calendar

### DIFF
--- a/public/admin/salas.html
+++ b/public/admin/salas.html
@@ -34,7 +34,17 @@
         .main-content { flex-grow: 1; display: flex; flex-direction: column; }
         .topbar { background-color: #ffffff; padding: 1rem 2rem; box-shadow: 0 1px 3px rgba(0,0,0,0.1); display: flex; justify-content: flex-end; align-items: center; }
         .content { padding: 2rem; }
-        #calendar { max-width: 900px; margin: 0 auto; }
+        #calendar {
+            max-width: 900px;
+            margin: 0 auto;
+            border-radius: var(--raio-borda);
+            overflow: hidden;
+        }
+
+        #tabelaSalas {
+            border-radius: var(--raio-borda);
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+        }
     </style>
 </head>
 <body>
@@ -79,12 +89,14 @@
                             </div>
                             <div class="tab-pane fade" id="salas" role="tabpanel" aria-labelledby="salas-tab">
                                 <button class="btn btn-primary mb-3" onclick="abrirModalNovaSala()">Nova sala</button>
-                                <table class="table" id="tabelaSalas">
-                                    <thead>
-                                        <tr><th>Nome</th><th>Disponível</th><th>Manutenção</th><th>Indisponível</th></tr>
-                                    </thead>
-                                    <tbody></tbody>
-                                </table>
+                                <div class="table-responsive">
+                                    <table class="table table-striped table-hover" id="tabelaSalas">
+                                        <thead>
+                                            <tr><th>Nome</th><th>Disponível</th><th>Manutenção</th><th>Indisponível</th></tr>
+                                        </thead>
+                                        <tbody></tbody>
+                                    </table>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/public/js/admin-salas.js
+++ b/public/js/admin-salas.js
@@ -12,6 +12,7 @@ document.addEventListener('DOMContentLoaded', () => {
       initialView: 'dayGridMonth',
       locale: 'pt-br',
       editable: true,
+      themeSystem: 'bootstrap5',
       eventSources: [fetchReservas],
       eventClick: onEventClick,
       eventDrop: onEventChange,


### PR DESCRIPTION
## Summary
- style salas admin table with bootstrap classes and rounded shadowed design
- enable Bootstrap 5 theme for FullCalendar and round calendar edges

## Testing
- `npm test` *(fails: tests 16, pass 5, fail 11)*

------
https://chatgpt.com/codex/tasks/task_e_68b8309bc4c48333bd04af8f7aa7c982