### PR TITLE
Retorna 422 para certidão com pendências

### DIFF
--- a/public/permissionarios/certidao.html
+++ b/public/permissionarios/certidao.html
@@ -163,24 +163,29 @@
     }
 
     async function baixarCertidao(token, user){
-      const res = await fetch(`/api/permissionarios/${encodeURIComponent(user.id)}/certidao`, {
-        headers: {
-          'Authorization':'Bearer '+token,
-          'Accept':'application/pdf',
-          'X-Requested-With': 'XMLHttpRequest'
-        }
-      });
+        const res = await fetch(`/api/permissionarios/${encodeURIComponent(user.id)}/certidao`, {
+          headers: {
+            'Authorization':'Bearer '+token,
+            'Accept':'application/pdf',
+            'X-Requested-With': 'XMLHttpRequest'
+          }
+        });
 
-      if(!res.ok){
-        // tenta ler JSON de erro; se vier HTML, cai no catch
-        const text = await res.text();
-        try{
-          const data = JSON.parse(text);
-          throw new Error(data.error || `Erro ${res.status} ao gerar certidão.`);
-        }catch{
-          throw new Error('Falha ao gerar certidão. Possível sessão expirada ou erro no servidor.');
+        if(res.status === 422){
+          const data = await res.json().catch(()=>({}));
+          throw new Error(data.error || 'Existem pendências financeiras que impedem a emissão da certidão.');
         }
-      }
+
+        if(!res.ok){
+          // tenta ler JSON de erro; se vier HTML, cai no catch
+          const text = await res.text();
+          try{
+            const data = JSON.parse(text);
+            throw new Error(data.error || `Erro ${res.status} ao gerar certidão.`);
+          }catch{
+            throw new Error('Falha ao gerar certidão. Possível sessão expirada ou erro no servidor.');
+          }
+        }
 
       const ct = res.headers.get('content-type') || '';
       if(!ct.includes('application/pdf')){

--- a/src/api/permissionariosRoutes.js
+++ b/src/api/permissionariosRoutes.js
@@ -82,7 +82,9 @@ router.get('/:id/certidao', authMiddleware, async (req, res) => {
       [id]
     );
     if ((pend?.count || 0) > 0) {
-      return res.status(400).json({ error: 'Existem pendências financeiras; não é possível emitir a certidão de quitação.' });
+      return res
+        .status(422)
+        .json({ error: 'Existem pendências financeiras; não é possível processar a certidão de quitação.' });
     }
 
     // Garante tabela de certidões (persistir histórico)


### PR DESCRIPTION
## Summary
- Ajusta `permissionariosRoutes` para usar HTTP 422 quando houver pendências financeiras
- Exibe mensagem adequada no frontend ao receber status 422

## Testing
- `npm test` (1 failing test: lista reservas por intervalo)

------
https://chatgpt.com/codex/tasks/task_e_68b8322993308333a1b9af9de22cd37f