### PR TITLE
Include approval date in remarcacao clause

### DIFF
--- a/src/services/termoEventoPdfkitService.js
+++ b/src/services/termoEventoPdfkitService.js
@@ -394,7 +394,14 @@ async function gerarTermoEventoPdfkitEIndexar(eventoId) {
     const novaStr = datasArr.map(fmtDataExtenso).join(', ');
     const origStr = origArr.map(fmtDataExtenso).join(', ');
     const pedidoStr = fmtDataExtenso(ev.data_pedido_remarcacao);
-    paragrafo(doc, `Parágrafo Único - Evento remarcado. Data original: ${origStr || '-'}; pedido em: ${pedidoStr || '-'}; nova data: ${novaStr || '-'}.`);
+    const aprovadoStr = fmtDataExtenso(ev.data_aprovacao_remarcacao);
+    let clausula = `Parágrafo Único - Evento remarcado. Data original: ${origStr || '-'}`;
+    clausula += `; pedido em: ${pedidoStr || '-'}`;
+    if (ev.data_aprovacao_remarcacao) {
+      clausula += `; aprovado em: ${aprovadoStr || '-'}`;
+    }
+    clausula += `; nova data: ${novaStr || '-'}.`;
+    paragrafo(doc, clausula);
   }
 
   // CLÁUSULA 2 – (texto inteiro em uma única chamada, sem quebras manuais)


### PR DESCRIPTION
## Summary
- add formatted approval date to remarcado clause after table

## Testing
- `npm test` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_68b83981b2f883339b8c4694eaadee6c