### PR TITLE
Add remarcacao request columns to Eventos

### DIFF
--- a/src/api/eventosRoutes.js
+++ b/src/api/eventosRoutes.js
@@ -106,7 +106,7 @@ router.post('/', async (req, res) => {
         try {
             // 1. Insere o evento principal na tabela Eventos
 
-            const eventoSql = `INSERT INTO Eventos (id_cliente, nome_evento, espaco_utilizado, area_m2, datas_evento, data_vigencia_final, total_diarias, valor_bruto, tipo_desconto, desconto_manual, valor_final, numero_oficio_sei, hora_inicio, hora_fim, hora_montagem, hora_desmontagem, numero_processo, numero_termo) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
+            const eventoSql = `INSERT INTO Eventos (id_cliente, nome_evento, espaco_utilizado, area_m2, datas_evento, data_vigencia_final, total_diarias, valor_bruto, tipo_desconto, desconto_manual, valor_final, numero_oficio_sei, hora_inicio, hora_fim, hora_montagem, hora_desmontagem, numero_processo, numero_termo, remarcacao_solicitada, datas_evento_solicitada, data_aprovacao_remarcacao) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
             const eventoParams = [
                 idCliente,
                 nomeEvento,
@@ -125,7 +125,10 @@ router.post('/', async (req, res) => {
                 horaMontagem || null,
                 horaDesmontagem || null,
                 numeroProcesso || null,
-                numeroTermo || null
+                numeroTermo || null,
+                0,
+                null,
+                null
             ];
             const eventoId = await new Promise((resolve, reject) => {
                 db.run(eventoSql, eventoParams, function(err) {

--- a/src/index.js
+++ b/src/index.js
@@ -172,6 +172,15 @@ function ensureEventosColumns(db) {
     if (!names.has('data_pedido_remarcacao')) {
       adds.push(`ALTER TABLE Eventos ADD COLUMN data_pedido_remarcacao TEXT`);
     }
+    if (!names.has('remarcacao_solicitada')) {
+      adds.push(`ALTER TABLE Eventos ADD COLUMN remarcacao_solicitada INTEGER DEFAULT 0`);
+    }
+    if (!names.has('datas_evento_solicitada')) {
+      adds.push(`ALTER TABLE Eventos ADD COLUMN datas_evento_solicitada TEXT`);
+    }
+    if (!names.has('data_aprovacao_remarcacao')) {
+      adds.push(`ALTER TABLE Eventos ADD COLUMN data_aprovacao_remarcacao TEXT`);
+    }
     (function runNext(i = 0) {
       if (i >= adds.length) return;
       db.run(adds[i], [], e => {

--- a/src/migrations/20250907140000-add-remarcacao-solicitada-to-eventos.js
+++ b/src/migrations/20250907140000-add-remarcacao-solicitada-to-eventos.js
@@ -1,0 +1,33 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const table = await queryInterface.describeTable('Eventos');
+    if (!table['remarcacao_solicitada']) {
+      await queryInterface.addColumn('Eventos', 'remarcacao_solicitada', {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        defaultValue: 0,
+      });
+    }
+    if (!table['datas_evento_solicitada']) {
+      await queryInterface.addColumn('Eventos', 'datas_evento_solicitada', {
+        type: Sequelize.TEXT,
+        allowNull: true,
+      });
+    }
+    if (!table['data_aprovacao_remarcacao']) {
+      await queryInterface.addColumn('Eventos', 'data_aprovacao_remarcacao', {
+        type: Sequelize.TEXT,
+        allowNull: true,
+      });
+    }
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('Eventos', 'remarcacao_solicitada');
+    await queryInterface.removeColumn('Eventos', 'datas_evento_solicitada');
+    await queryInterface.removeColumn('Eventos', 'data_aprovacao_remarcacao');
+  }
+};
+

--- a/src/services/eventoDarService.js
+++ b/src/services/eventoDarService.js
@@ -70,21 +70,17 @@ async function criarEventoComDars(db, data, helpers) {
   await dbRun(db, 'BEGIN TRANSACTION');
   try {
     const datasEventoStr = JSON.stringify(datasEvento || []);
+    const colsEvento = [
+      'id_cliente', 'nome_evento', 'espaco_utilizado', 'area_m2', 'datas_evento',
+      'datas_evento_original', 'data_vigencia_final', 'total_diarias', 'valor_bruto',
+      'tipo_desconto', 'desconto_manual', 'valor_final', 'numero_oficio_sei',
+      'hora_inicio', 'hora_fim', 'hora_montagem', 'hora_desmontagem',
+      'numero_processo', 'numero_termo', 'remarcacao_solicitada', 'datas_evento_solicitada', 'data_aprovacao_remarcacao',
+      'evento_gratuito', 'justificativa_gratuito', 'status'
+    ];
     const eventoStmt = await dbRun(
       db,
-      `INSERT INTO Eventos (
-         id_cliente, nome_evento, espaco_utilizado, area_m2, datas_evento,
-         datas_evento_original, data_vigencia_final, total_diarias, valor_bruto,
-         tipo_desconto, desconto_manual, valor_final, numero_oficio_sei,
-         hora_inicio, hora_fim, hora_montagem, hora_desmontagem,
-         numero_processo, numero_termo, evento_gratuito, justificativa_gratuito, status
-       ) VALUES (
-         ?, ?, ?, ?, ?,
-         ?, ?, ?,
-         ?, ?, ?, ?,
-         ?, ?, ?, ?,
-         ?, ?, ?, ?, ?
-       )`,
+      `INSERT INTO Eventos (${colsEvento.join(', ')}) VALUES (${colsEvento.map(() => '?').join(', ')})`,
       [
         idCliente,
         nomeEvento,
@@ -105,6 +101,9 @@ async function criarEventoComDars(db, data, helpers) {
         horaDesmontagem || null,
         numeroProcesso || null,
         numeroTermo || null,
+        0,
+        null,
+        null,
         eventoGratuito ? 1 : 0,
         justificativaGratuito || null,
         'Pendente'


### PR DESCRIPTION
## Summary
- add migration for `remarcacao_solicitada`, `datas_evento_solicitada` and `data_aprovacao_remarcacao`
- ensure Eventos columns on boot
- default new fields during event creation

## Testing
- `npm test` *(fails: Module.require ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b83963533483338e0635923add02b9