### PR TITLE
Fix dashboard stats query param handling

### DIFF
--- a/public/admin/dashboard.html
+++ b/public/admin/dashboard.html
@@ -153,7 +153,10 @@ window.onload = async () => {
   const fetchStats = async (tipo = '') => {
     try {
       console.log("Iniciando busca de dados do dashboard com o token:", token);
-      const url = `/api/admin/dashboard-stats${tipo ? `?tipo=${tipo}` : ''}&t=${Date.now()}`;
+      const params = new URLSearchParams();
+      if (tipo) params.set('tipo', tipo);
+      params.set('t', Date.now());
+      const url = `/api/admin/dashboard-stats?${params.toString()}`;
       const response = await fetch(url, {
         headers: { 'Authorization': `Bearer ${token}` }
       });


### PR DESCRIPTION
## Summary
- Build dashboard stats request URL with `URLSearchParams` to avoid malformed query strings

## Testing
- `node -e "const tipo=''; const params=new URLSearchParams(); if (tipo) params.set('tipo', tipo); params.set('t', Date.now()); const url='/api/admin/dashboard-stats?'+params.toString(); console.log(url);"`
- `npm test tests/adminDashboardStatsFilter.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b840cd24348333a02513cc7aa787bb