### PR TITLE
refactor: move schema enforcement to migrations

### DIFF
--- a/src/migrations/20250907150000-ensure-eventos-columns.js
+++ b/src/migrations/20250907150000-ensure-eventos-columns.js
@@ -1,0 +1,69 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const table = await queryInterface.describeTable('Eventos');
+
+    if (!table['data_vigencia_final']) {
+      await queryInterface.addColumn('Eventos', 'data_vigencia_final', {
+        type: Sequelize.TEXT,
+        allowNull: true,
+      });
+    }
+
+    if (!table['remarcado']) {
+      await queryInterface.addColumn('Eventos', 'remarcado', {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        defaultValue: 0,
+      });
+    }
+
+    if (!table['datas_evento_original']) {
+      await queryInterface.addColumn('Eventos', 'datas_evento_original', {
+        type: Sequelize.TEXT,
+        allowNull: true,
+      });
+    }
+
+    if (!table['data_pedido_remarcacao']) {
+      await queryInterface.addColumn('Eventos', 'data_pedido_remarcacao', {
+        type: Sequelize.TEXT,
+        allowNull: true,
+      });
+    }
+
+    if (!table['remarcacao_solicitada']) {
+      await queryInterface.addColumn('Eventos', 'remarcacao_solicitada', {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        defaultValue: 0,
+      });
+    }
+
+    if (!table['datas_evento_solicitada']) {
+      await queryInterface.addColumn('Eventos', 'datas_evento_solicitada', {
+        type: Sequelize.TEXT,
+        allowNull: true,
+      });
+    }
+
+    if (!table['data_aprovacao_remarcacao']) {
+      await queryInterface.addColumn('Eventos', 'data_aprovacao_remarcacao', {
+        type: Sequelize.TEXT,
+        allowNull: true,
+      });
+    }
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('Eventos', 'data_vigencia_final');
+    await queryInterface.removeColumn('Eventos', 'remarcado');
+    await queryInterface.removeColumn('Eventos', 'datas_evento_original');
+    await queryInterface.removeColumn('Eventos', 'data_pedido_remarcacao');
+    await queryInterface.removeColumn('Eventos', 'remarcacao_solicitada');
+    await queryInterface.removeColumn('Eventos', 'datas_evento_solicitada');
+    await queryInterface.removeColumn('Eventos', 'data_aprovacao_remarcacao');
+  }
+};
+

--- a/src/migrations/20250907151000-add-address-fields-to-clientes-eventos.js
+++ b/src/migrations/20250907151000-add-address-fields-to-clientes-eventos.js
@@ -1,0 +1,38 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const table = await queryInterface.describeTable('Clientes_Eventos');
+    const columns = [
+      'cep',
+      'logradouro',
+      'numero',
+      'complemento',
+      'bairro',
+      'cidade',
+      'uf',
+      'endereco'
+    ];
+
+    for (const name of columns) {
+      if (!table[name]) {
+        await queryInterface.addColumn('Clientes_Eventos', name, {
+          type: Sequelize.TEXT,
+          allowNull: true,
+        });
+      }
+    }
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('Clientes_Eventos', 'cep');
+    await queryInterface.removeColumn('Clientes_Eventos', 'logradouro');
+    await queryInterface.removeColumn('Clientes_Eventos', 'numero');
+    await queryInterface.removeColumn('Clientes_Eventos', 'complemento');
+    await queryInterface.removeColumn('Clientes_Eventos', 'bairro');
+    await queryInterface.removeColumn('Clientes_Eventos', 'cidade');
+    await queryInterface.removeColumn('Clientes_Eventos', 'uf');
+    await queryInterface.removeColumn('Clientes_Eventos', 'endereco');
+  }
+};
+


### PR DESCRIPTION
## Summary
- add migrations ensuring Eventos and Clientes_Eventos columns
- drop runtime schema alteration logic from index.js

## Testing
- `npm test`
- `node - <<'NODE'
const { Sequelize } = require('sequelize');
const path = require('path');
const sequelize = new Sequelize({ dialect: 'sqlite', storage: path.join(process.cwd(), 'test_migrate.db'), logging: false });
(async () => {
  const qi = sequelize.getQueryInterface();
  const migr1 = require('./src/migrations/20250907150000-ensure-eventos-columns.js');
  const migr2 = require('./src/migrations/20250907151000-add-address-fields-to-clientes-eventos.js');
  await migr1.up(qi, Sequelize);
  await migr2.up(qi, Sequelize);
  // run again to ensure idempotency
  await migr1.up(qi, Sequelize);
  await migr2.up(qi, Sequelize);
  console.log('migrations executed twice without error');
})().catch(e => { console.error('migration error:', e); process.exit(1); }).finally(() => sequelize.close());
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68b84056711c8333b1b4ac25ca528b66