### PR TITLE
feat: add remarcacao justification

### DIFF
--- a/public/admin/eventos-remarcacoes.html
+++ b/public/admin/eventos-remarcacoes.html
@@ -90,6 +90,7 @@
                     <th>Cliente</th>
                     <th>Data Original</th>
                     <th>Data Solicitada</th>
+                    <th>Justificativa</th>
                     <th class="text-center">Ações</th>
                   </tr>
                 </thead>
@@ -102,11 +103,26 @@
     </div>
   </div>
 
+  <div class="modal fade" id="justificativaModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Justificativa</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+        </div>
+        <div class="modal-body">
+          <p id="justificativaTexto" class="mb-0"></p>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <script src="/js/admin-sidebar.js"></script>
   <script src="/js/admin-guard.js"></script>
   <script defer src="/js/mobile-adapter.js"></script>
   <script defer src="/js/ui-kit.js"></script>
   <script defer src="/js/mobile-tweaks.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 
   <script>
   window.onload = () => {
@@ -114,6 +130,8 @@
     const AUTH_HEADERS = { Authorization: `Bearer ${token}` };
 
     const remarcacoesTableBody = document.getElementById('remarcacoes-table-body');
+    const justificativaTexto = document.getElementById('justificativaTexto');
+    const justificativaModal = new bootstrap.Modal(document.getElementById('justificativaModal'));
 
     const formatDateBR = iso => {
       if (!iso) return '';
@@ -133,24 +151,27 @@
 
     async function fetchRemarcacoes(){
       try {
-        const r = await fetch('/api/admin/eventos?remarcacao_solicitada=1', { headers: AUTH_HEADERS });
+        const r = await fetch('/api/admin/eventos/remarcacoes', { headers: AUTH_HEADERS });
         if (!r.ok) throw new Error('Falha ao buscar remarcações');
         const data = await r.json();
-        renderRemarcacoes(data.eventos || data);
+        renderRemarcacoes(data.eventos || []);
       } catch (e) {
-        remarcacoesTableBody.innerHTML = `<tr><td colspan="6" class="text-center text-danger">${e.message}</td></tr>`;
+        remarcacoesTableBody.innerHTML = `<tr><td colspan="7" class="text-center text-danger">${e.message}</td></tr>`;
       }
     }
 
     function renderRemarcacoes(eventos){
       if (!Array.isArray(eventos) || eventos.length === 0){
-        remarcacoesTableBody.innerHTML = '<tr><td colspan="6" class="text-center">Nenhuma solicitação.</td></tr>';
+        remarcacoesTableBody.innerHTML = '<tr><td colspan="7" class="text-center">Nenhuma solicitação.</td></tr>';
         return;
       }
       remarcacoesTableBody.innerHTML = eventos.map(ev => {
         const id = evIdOf(ev);
         const original = formatDateBR(parseFirstDate(ev.datas_evento_original));
         const solicitada = formatDateBR(parseFirstDate(ev.datas_evento));
+        const justificativa = ev.justificativa_remarcacao || '';
+        const curta = justificativa.length > 30 ? justificativa.slice(0,30)+'...' : justificativa;
+        const btn = justificativa.length > 30 ? ` <button class="btn btn-link btn-sm p-0 ver-justificativa" data-just="${encodeURIComponent(justificativa)}">ver mais</button>` : '';
         return `
           <tr>
             <td>${id}</td>
@@ -158,6 +179,7 @@
             <td class="text-capitalize">${ev.nome_cliente || ''}</td>
             <td>${original}</td>
             <td>${solicitada}</td>
+            <td>${curta}${btn}</td>
             <td class="text-center">
               <div class="btn-group">
                 <button class="btn btn-sm btn-success btn-aprovar-rem" data-id="${id}">Aprovar</button>
@@ -172,6 +194,12 @@
     async function carregarRemarcacoes(){ return fetchRemarcacoes(); }
 
     remarcacoesTableBody.addEventListener('click', async (e)=>{
+      const verJust = e.target.closest('.ver-justificativa');
+      if (verJust){
+        justificativaTexto.textContent = decodeURIComponent(verJust.dataset.just || '');
+        justificativaModal.show();
+        return;
+      }
       const btnAprovar = e.target.closest('.btn-aprovar-rem');
       const btnRejeitar = e.target.closest('.btn-rejeitar-rem');
       const btnDireto = e.target.closest('.btn-remarcar-direto');

--- a/public/eventos/meus-eventos.html
+++ b/public/eventos/meus-eventos.html
@@ -247,9 +247,12 @@
             blocoRemarcar = `<div class="mt-3"><span class="badge bg-warning text-dark">Remarcado</span><div class="mt-2">Nova data: ${dataNovaFmt}</div></div>`;
           } else if (ev.remarcacao_solicitada) {
             blocoRemarcar = `<div class="mt-3"><span class="badge bg-secondary">Remarcação pendente</span><div class="input-group input-group-sm mt-2" style="max-width:240px;"><input type="date" class="form-control" disabled value="${ev.nova_data || ''}"><button class="btn btn-outline-secondary" disabled>Pendente</button></div></div>`;
-          } else {
-            blocoRemarcar = `<div class="mt-3" id="remarcar-${evId}"><div class="input-group input-group-sm" style="max-width:240px;"><input type="date" class="form-control" id="nova-data-${evId}"><button class="btn btn-outline-primary" data-remarcar="${evId}">Remarcar</button></div></div>`;
-          }
+        } else {
+            blocoRemarcar = `<div class="mt-3" id="remarcar-${evId}">
+              <div class="mb-2"><textarea class="form-control form-control-sm" id="justificativa-${evId}" placeholder="Justificativa" rows="2"></textarea></div>
+              <div class="input-group input-group-sm" style="max-width:240px;"><input type="date" class="form-control" id="nova-data-${evId}"><button class="btn btn-outline-primary" data-remarcar="${evId}">Remarcar</button></div>
+            </div>`;
+        }
 
           return `
           <div class="accordion-item ${(ev.remarcado ? 'border border-warning' : (ev.remarcacao_solicitada ? 'border border-secondary' : ''))}">
@@ -309,11 +312,17 @@
                 alert('Selecione a nova data.');
                 return;
               }
+              const textarea = document.getElementById(`justificativa-${eventoId}`);
+              const justificativa = textarea?.value.trim();
+              if (!justificativa) {
+                alert('Informe a justificativa.');
+                return;
+              }
               try {
                 const r = await fetch(`/api/portal/eventos/${eventoId}/remarcar`, {
                   method: 'PUT',
                   headers,
-                  body: JSON.stringify({ nova_data: novaData, remarcacao_solicitada: 1 })
+                  body: JSON.stringify({ nova_data: novaData, justificativa })
                 });
                 if (r.ok) {
                   location.reload();

--- a/src/api/adminEventosRoutes.js
+++ b/src/api/adminEventosRoutes.js
@@ -468,7 +468,7 @@ router.get('/', async (req, res) => {
 router.get('/remarcacoes', async (req, res) => {
   try {
     const sql = `
-      SELECT e.*, c.nome_razao_social AS nome_cliente
+      SELECT e.*, e.justificativa_remarcacao, c.nome_razao_social AS nome_cliente
         FROM Eventos e
         JOIN Clientes_Eventos c ON c.id = e.id_cliente
        WHERE e.remarcacao_solicitada = 1
@@ -499,7 +499,7 @@ router.put('/:id/remarcar', async (req, res) => {
     }
 
     const ev = await dbGet(
-      `SELECT datas_evento, datas_evento_original, datas_evento_solicitada, remarcacao_solicitada
+      `SELECT datas_evento, datas_evento_original, datas_evento_solicitada, remarcacao_solicitada, justificativa_remarcacao
          FROM Eventos WHERE id = ?`,
       [id],
       'remarcar/get-evento'
@@ -515,7 +515,8 @@ router.put('/:id/remarcar', async (req, res) => {
         `UPDATE Eventos
             SET remarcacao_solicitada = 0,
                 datas_evento_solicitada = NULL,
-                data_pedido_remarcacao = NULL
+                data_pedido_remarcacao = NULL,
+                justificativa_remarcacao = NULL
           WHERE id = ?`,
         [id],
         'remarcar/rejeitar'
@@ -539,7 +540,8 @@ router.put('/:id/remarcar', async (req, res) => {
               remarcado = 1,
               remarcacao_solicitada = 0,
               data_aprovacao_remarcacao = datetime('now'),
-              datas_evento_solicitada = NULL
+              datas_evento_solicitada = NULL,
+              justificativa_remarcacao = NULL
         WHERE id = ?`,
       [datasOrig, datasNovas, novaDataFinal, id],
       'remarcar/aprovar'

--- a/src/api/eventosClientesRoutes.js
+++ b/src/api/eventosClientesRoutes.js
@@ -152,8 +152,11 @@ clientRouter.post('/:id/termo/assinafy/link', async (req, res) => {
 clientRouter.put('/:id/remarcar', async (req, res) => {
   try {
     const eventoId = req.params.id;
-    const { nova_data } = req.body || {};
+    const { nova_data, justificativa } = req.body || {};
     if (!nova_data) return res.status(400).json({ error: 'Nova data é obrigatória.' });
+    if (!justificativa || !String(justificativa).trim()) {
+      return res.status(400).json({ error: 'Justificativa é obrigatória.' });
+    }
 
     const ev = await dbGet(
       `SELECT remarcado, remarcacao_solicitada FROM Eventos WHERE id = ? AND id_cliente = ?`,
@@ -172,9 +175,10 @@ clientRouter.put('/:id/remarcar', async (req, res) => {
          SET remarcacao_solicitada = 1,
              data_pedido_remarcacao = ?,
              datas_evento_solicitada = ?,
+             justificativa_remarcacao = ?,
              remarcado = 0
        WHERE id = ?`,
-      [agora, datasNovas, eventoId]
+      [agora, datasNovas, justificativa, eventoId]
     );
 
     res.json({ ok: true, pending: true });

--- a/src/migrations/20250907152000-add-justificativa-remarcacao-to-eventos.js
+++ b/src/migrations/20250907152000-add-justificativa-remarcacao-to-eventos.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const table = await queryInterface.describeTable('Eventos');
+    if (!table['justificativa_remarcacao']) {
+      await queryInterface.addColumn('Eventos', 'justificativa_remarcacao', {
+        type: Sequelize.TEXT,
+        allowNull: true,
+      });
+    }
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('Eventos', 'justificativa_remarcacao');
+  }
+};


### PR DESCRIPTION
## Summary
- track justification when clients request event rescheduling
- expose justification in admin queries and UI
- allow clients to submit remarcacao justification via portal

## Testing
- `npm test` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_68b852798a908333bfcef422146105d2