### PR TITLE
Add Advertencias table and client ineligibility fields

### DIFF
--- a/src/database/init.js
+++ b/src/database/init.js
@@ -54,6 +54,20 @@ module.exports = new Promise((resolve, reject) => {
       }
       console.log('Tabela "certidoes_quitacao" verificada/criada com sucesso.');
     });
+
+    // Garantir colunas de inelegibilidade na tabela Clientes_Eventos
+    db.all(`PRAGMA table_info('Clientes_Eventos')`, (err, columns) => {
+      if (err) {
+        return console.error('Erro ao inspecionar a tabela "Clientes_Eventos":', err.message);
+      }
+      const colNames = columns.map((c) => c.name);
+      if (!colNames.includes('inapto_ate')) {
+        db.run(`ALTER TABLE Clientes_Eventos ADD COLUMN inapto_ate TEXT;`);
+      }
+      if (!colNames.includes('status_cliente')) {
+        db.run(`ALTER TABLE Clientes_Eventos ADD COLUMN status_cliente TEXT;`);
+      }
+    });
   });
 
   db.close((err) => {

--- a/src/migrations/20250907153000-create-advertencias.js
+++ b/src/migrations/20250907153000-create-advertencias.js
@@ -1,0 +1,95 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('Advertencias', {
+      id: {
+        type: Sequelize.INTEGER,
+        autoIncrement: true,
+        primaryKey: true,
+      },
+      evento_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'Eventos',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      cliente_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'Clientes',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      texto_fatos: {
+        type: Sequelize.TEXT,
+        allowNull: true,
+      },
+      clausulas_json: {
+        type: Sequelize.TEXT,
+        allowNull: true,
+      },
+      gera_multa: {
+        type: Sequelize.BOOLEAN,
+        allowNull: true,
+      },
+      valor_multa: {
+        type: Sequelize.REAL,
+        allowNull: true,
+      },
+      inapto_ate: {
+        type: Sequelize.DATE,
+        allowNull: true,
+      },
+      prazo_recurso_dias: {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+      },
+      dar_id: {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+        references: {
+          model: 'Dars',
+          key: 'id',
+        },
+        onUpdate: 'SET NULL',
+        onDelete: 'SET NULL',
+      },
+      token: {
+        type: Sequelize.STRING,
+        allowNull: true,
+        unique: true,
+      },
+      pdf_url: {
+        type: Sequelize.TEXT,
+        allowNull: true,
+      },
+      status: {
+        type: Sequelize.STRING,
+        allowNull: true,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      }
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('Advertencias');
+  }
+};
+

--- a/src/migrations/20250907154000-add-inapto-status-to-clientes-eventos.js
+++ b/src/migrations/20250907154000-add-inapto-status-to-clientes-eventos.js
@@ -1,0 +1,25 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const table = await queryInterface.describeTable('Clientes_Eventos');
+    if (!table['inapto_ate']) {
+      await queryInterface.addColumn('Clientes_Eventos', 'inapto_ate', {
+        type: Sequelize.DATE,
+        allowNull: true,
+      });
+    }
+    if (!table['status_cliente']) {
+      await queryInterface.addColumn('Clientes_Eventos', 'status_cliente', {
+        type: Sequelize.STRING,
+        allowNull: true,
+      });
+    }
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('Clientes_Eventos', 'inapto_ate');
+    await queryInterface.removeColumn('Clientes_Eventos', 'status_cliente');
+  }
+};
+


### PR DESCRIPTION
## Summary
- create Advertencias table for event warnings with multa support
- track client ineligibility via inapto_ate and status_cliente fields
- ensure init script adds new columns if missing

## Testing
- `node src/database/init.js` *(fails: No description found for "Eventos" table)*
- `npm test` *(fails: 1 failing test)*

------
https://chatgpt.com/codex/tasks/task_e_68b85add941c8333a0f19a1b48dd0a12