### PR TITLE
Refactor event insertion to single SQL statement

### DIFF
--- a/src/services/eventoDarService.js
+++ b/src/services/eventoDarService.js
@@ -80,19 +80,6 @@ async function criarEventoComDars(db, data, helpers) {
     ];
     const eventoStmt = await dbRun(
       db,
-      `INSERT INTO Eventos (
-         id_cliente, nome_evento, espaco_utilizado, area_m2, datas_evento,
-         datas_evento_original, data_vigencia_final, total_diarias, valor_bruto,
-         tipo_desconto, desconto_manual, valor_final, numero_oficio_sei,
-         hora_inicio, hora_fim, hora_montagem, hora_desmontagem,
-       numero_processo, numero_termo, evento_gratuito, justificativa_gratuito, status
-      ) VALUES (
-        ?, ?, ?, ?, ?,
-        ?, ?, ?, ?,
-        ?, ?, ?, ?,
-        ?, ?, ?, ?,
-        ?, ?, ?, ?, ?
-      )`,
       `INSERT INTO Eventos (${colsEvento.join(', ')}) VALUES (${colsEvento.map(() => '?').join(', ')})`,
       [
         idCliente,


### PR DESCRIPTION
## Summary
- simplify event creation by using a single parameterized INSERT for Eventos
- ensure the number of placeholders matches the column list

## Testing
- `npm test`
- `npm test -- tests/eventoDarService.test.js`
- `node -e "/* placeholder test */"` (via script verifying 25 placeholders)
- `node ...` (POST /api/admin/eventos route integration)

------
https://chatgpt.com/codex/tasks/task_e_68b85c3029f88333883bedc4ca2bc768