### PR TITLE
Emit DAR for advertências

### DIFF
--- a/src/migrations/20250907153000-create-advertencias.js
+++ b/src/migrations/20250907153000-create-advertencias.js
@@ -56,7 +56,7 @@ module.exports = {
         type: Sequelize.INTEGER,
         allowNull: true,
         references: {
-          model: 'Dars',
+          model: 'dars',
           key: 'id',
         },
         onUpdate: 'SET NULL',

--- a/src/services/eventoDarService.js
+++ b/src/services/eventoDarService.js
@@ -24,6 +24,33 @@ const dbAll = (db, sql, p = []) =>
     });
   });
 
+const feriadosFixos = [
+  '01/01', '21/04', '01/05', '24/06', '07/09',
+  '16/09', '12/10', '02/11', '15/11', '25/12'
+];
+
+function isFeriado(date) {
+  const dia = String(date.getDate()).padStart(2, '0');
+  const mes = String(date.getMonth() + 1).padStart(2, '0');
+  return feriadosFixos.includes(`${dia}/${mes}`);
+}
+
+function isDiaUtil(date) {
+  const dow = date.getDay();
+  if (dow === 0 || dow === 6) return false;
+  return !isFeriado(date);
+}
+
+function addDiasUteis(data, dias) {
+  const d = new Date(data);
+  let added = 0;
+  while (added < dias) {
+    d.setDate(d.getDate() + 1);
+    if (isDiaUtil(d)) added++;
+  }
+  return d;
+}
+
 async function criarEventoComDars(db, data, helpers) {
   const {
     emitirGuiaSefaz,
@@ -80,19 +107,6 @@ async function criarEventoComDars(db, data, helpers) {
     ];
     const eventoStmt = await dbRun(
       db,
-      `INSERT INTO Eventos (
-         id_cliente, nome_evento, espaco_utilizado, area_m2, datas_evento,
-         datas_evento_original, data_vigencia_final, total_diarias, valor_bruto,
-         tipo_desconto, desconto_manual, valor_final, numero_oficio_sei,
-         hora_inicio, hora_fim, hora_montagem, hora_desmontagem,
-       numero_processo, numero_termo, evento_gratuito, justificativa_gratuito, status
-      ) VALUES (
-        ?, ?, ?, ?, ?,
-        ?, ?, ?, ?,
-        ?, ?, ?, ?,
-        ?, ?, ?, ?,
-        ?, ?, ?, ?, ?
-      )`,
       `INSERT INTO Eventos (${colsEvento.join(', ')}) VALUES (${colsEvento.map(() => '?').join(', ')})`,
       [
         idCliente,
@@ -412,8 +426,96 @@ async function atualizarEventoComDars(db, id, data, helpers) {
   }
 }
 
+async function emitirDarAdvertencia(evento, valorMulta, { db, helpers = {}, hoje = new Date() } = {}) {
+  const {
+    emitirGuiaSefaz = require('./sefazService').emitirGuiaSefaz,
+    gerarTokenDocumento = require('../utils/token').gerarTokenDocumento,
+    imprimirTokenEmPdf = require('../utils/token').imprimirTokenEmPdf,
+  } = helpers;
+
+  if (!db) throw new Error('Banco de dados não fornecido');
+  if (!evento || !evento.id || !evento.cliente_id) {
+    throw new Error('Advertência inválida.');
+  }
+
+  const cliente = await dbGet(
+    db,
+    `SELECT nome_razao_social, documento, endereco, cep FROM Clientes WHERE id = ?`,
+    [evento.cliente_id]
+  );
+  if (!cliente) throw new Error('Cliente não encontrado.');
+
+  const receitaCod = Number(String(process.env.RECEITA_CODIGO_EVENTO).replace(/\D/g, ''));
+  if (!receitaCod) throw new Error('RECEITA_CODIGO_EVENTO inválido.');
+
+  const vencimento = addDiasUteis(hoje, 5);
+  const vencimentoISO = vencimento.toISOString().slice(0, 10);
+  const [ano, mes] = vencimentoISO.split('-');
+
+  await dbRun(db, 'BEGIN TRANSACTION');
+  try {
+    const darStmt = await dbRun(
+      db,
+      `INSERT INTO dars (valor, data_vencimento, status, mes_referencia, ano_referencia, permissionario_id, tipo_permissionario, data_emissao)
+       VALUES (?, ?, 'Pendente', ?, ?, NULL, 'Advertencia', ?)`,
+      [Number(valorMulta), vencimentoISO, Number(mes), Number(ano), hoje.toISOString()]
+    );
+    const darId = darStmt.lastID;
+
+    const payloadSefaz = {
+      versao: '1.0',
+      contribuinteEmitente: {
+        codigoTipoInscricao: onlyDigits(cliente.documento).length === 11 ? 3 : 4,
+        numeroInscricao: onlyDigits(cliente.documento),
+        nome: cliente.nome_razao_social,
+        codigoIbgeMunicipio: Number(process.env.COD_IBGE_MUNICIPIO),
+        descricaoEndereco: cliente.endereco,
+        numeroCep: onlyDigits(cliente.cep),
+      },
+      receitas: [{
+        codigo: receitaCod,
+        competencia: { mes: Number(mes), ano: Number(ano) },
+        valorPrincipal: Number(valorMulta),
+        valorDesconto: 0,
+        dataVencimento: vencimentoISO,
+      }],
+      dataLimitePagamento: vencimentoISO,
+      observacao: `CIPT Advertência: ${evento.nome_evento || ''}`,
+    };
+
+    const retorno = await emitirGuiaSefaz(payloadSefaz);
+    const tokenDoc = await gerarTokenDocumento('DAR_ADVERTENCIA', null, db);
+    const pdf = await imprimirTokenEmPdf(retorno.pdfBase64, tokenDoc);
+
+    const extraCols = [];
+    const extraVals = [];
+    if (retorno.linhaDigitavel) {
+      extraCols.push('linha_digitavel = ?');
+      extraVals.push(retorno.linhaDigitavel);
+    }
+    if (retorno.codigoBarras) {
+      extraCols.push('codigo_barras = ?');
+      extraVals.push(retorno.codigoBarras);
+    }
+    await dbRun(
+      db,
+      `UPDATE dars SET numero_documento = ?, pdf_url = ?, status = 'Emitido'${extraCols.length ? ', ' + extraCols.join(', ') : ''} WHERE id = ?`,
+      [retorno.numeroGuia, pdf, ...extraVals, darId]
+    );
+
+    await dbRun(db, `UPDATE Advertencias SET dar_id = ?, valor_multa = ? WHERE id = ?`, [darId, Number(valorMulta), evento.id]);
+
+    await dbRun(db, 'COMMIT');
+    return darId;
+  } catch (err) {
+    try { await dbRun(db, 'ROLLBACK'); } catch {}
+    throw err;
+  }
+}
+
 module.exports = {
   criarEventoComDars,
   atualizarEventoComDars,
+  emitirDarAdvertencia,
 };
 

--- a/tests/advertenciaDarService.test.js
+++ b/tests/advertenciaDarService.test.js
@@ -1,0 +1,79 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const sqlite3 = require('sqlite3').verbose();
+
+process.env.COD_IBGE_MUNICIPIO = process.env.COD_IBGE_MUNICIPIO || '0000000';
+process.env.RECEITA_CODIGO_EVENTO = process.env.RECEITA_CODIGO_EVENTO || '12345';
+
+const { emitirDarAdvertencia } = require('../src/services/eventoDarService');
+
+function run(db, sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.run(sql, params, function (err) {
+      if (err) reject(err); else resolve(this);
+    });
+  });
+}
+function get(db, sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.get(sql, params, (err, row) => {
+      if (err) reject(err); else resolve(row);
+    });
+  });
+}
+
+test('emitirDarAdvertencia cria dar e vincula à advertencia', async () => {
+  const db = new sqlite3.Database(':memory:');
+
+  await run(db, `CREATE TABLE Clientes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    nome_razao_social TEXT,
+    documento TEXT,
+    endereco TEXT,
+    cep TEXT
+  );`);
+  await run(db, `CREATE TABLE dars (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    valor REAL,
+    data_vencimento TEXT,
+    status TEXT,
+    mes_referencia INTEGER,
+    ano_referencia INTEGER,
+    permissionario_id INTEGER,
+    tipo_permissionario TEXT,
+    numero_documento TEXT,
+    pdf_url TEXT,
+    linha_digitavel TEXT,
+    codigo_barras TEXT,
+    data_emissao TEXT
+  );`);
+  await run(db, `CREATE TABLE Advertencias (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    evento_id INTEGER,
+    cliente_id INTEGER,
+    valor_multa REAL,
+    dar_id INTEGER
+  );`);
+
+  await run(db, `INSERT INTO Clientes (nome_razao_social, documento, endereco, cep) VALUES ('Cliente', '12345678901', 'Rua A', '12345000');`);
+  await run(db, `INSERT INTO Advertencias (evento_id, cliente_id) VALUES (1, 1);`);
+
+  const helpers = {
+    emitirGuiaSefaz: async () => ({ numeroGuia: '999', pdfBase64: 'PDF', linhaDigitavel: 'LD', codigoBarras: 'CB' }),
+    gerarTokenDocumento: async () => 'TK',
+    imprimirTokenEmPdf: async (pdf, token) => `${pdf}-${token}`,
+  };
+
+  const advertencia = { id: 1, cliente_id: 1, nome_evento: 'Show' };
+  await emitirDarAdvertencia(advertencia, 150, { db, helpers, hoje: new Date('2025-03-03') });
+
+  const adv = await get(db, 'SELECT * FROM Advertencias WHERE id = 1');
+  assert.ok(adv.dar_id);
+  const dar = await get(db, 'SELECT * FROM dars WHERE id = ?', [adv.dar_id]);
+  assert.strictEqual(dar.valor, 150);
+  assert.strictEqual(dar.data_vencimento, '2025-03-10');
+  assert.strictEqual(dar.status, 'Emitido');
+  assert.strictEqual(dar.numero_documento, '999');
+  await new Promise(res => db.close(res));
+});
+


### PR DESCRIPTION
## Summary
- add emitirDarAdvertencia to issue DAR fines and associate with Advertências
- fix Advertências migration to reference dars.id
- test DAR emission for advertência including due date

## Testing
- `node --test tests/advertenciaDarService.test.js`
- `npm test` *(fails: lista reservas por intervalo)*

------
https://chatgpt.com/codex/tasks/task_e_68b85c2178ac8333b565b866349ca199