### PR TITLE
Handle client inaptitude for reservations and warnings

### DIFF
--- a/src/api/salasRoutes.js
+++ b/src/api/salasRoutes.js
@@ -127,6 +127,7 @@ router.post('/reservas', async (req, res) => {
     );
 
     const permissionarioId = req.user.id;
+    await reservaSalaService.verificarClienteInapto(permissionarioId);
     await reservaSalaService.verificarDiasConsecutivos(permissionarioId, sala_id, data);
     const result = await runAsync(
       `INSERT INTO reservas_salas (sala_id, permissionario_id, data, hora_inicio, hora_fim, participantes, status, checkin)

--- a/src/services/reservaSalaService.js
+++ b/src/services/reservaSalaService.js
@@ -78,9 +78,28 @@ async function verificarDiasConsecutivos(permissionarioId, salaId, data) {
   }
 }
 
+async function verificarClienteInapto(permissionarioId) {
+  try {
+    const row = await getAsync(
+      `SELECT inapto_ate FROM Clientes_Eventos WHERE id = ?`,
+      [permissionarioId]
+    );
+    if (row && row.inapto_ate) {
+      const ate = new Date(row.inapto_ate);
+      if (!isNaN(ate) && ate > new Date()) {
+        throw validationError(`Cliente inapto até ${row.inapto_ate}`);
+      }
+    }
+  } catch (e) {
+    if (/(no such table)/i.test(e.message || '')) return;
+    throw e;
+  }
+}
+
 module.exports = {
   validarSalaECapacidade,
   validarHorarios,
   verificarConflito,
   verificarDiasConsecutivos,
+  verificarClienteInapto,
 };


### PR DESCRIPTION
## Summary
- sync warning-issued inaptitude with Clientes_Eventos and allow clearing on appeal
- prevent reservations by clients flagged as inapto until date lapses
- test reservation blocking for inapt clients

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b85d6d1aa0833389c1b6266262a022