### PR TITLE
Ajusta cálculo e persistência de data de vigência final de eventos

### DIFF
--- a/src/api/eventosRoutes.js
+++ b/src/api/eventosRoutes.js
@@ -90,7 +90,8 @@ router.post('/', async (req, res) => {
 
     // Ordena as datas para garantir que a primeira é a correta
     const datasOrdenadas = datasEvento.sort((a, b) => new Date(a) - new Date(b));
-    const dataVigenciaFinal = datasOrdenadas[datasOrdenadas.length - 1];
+    const dataVigenciaFinal = new Date(datasOrdenadas.at(-1));
+    dataVigenciaFinal.setDate(dataVigenciaFinal.getDate() + 1);
     const primeiraDataEvento = new Date(datasOrdenadas[0]);
     
     const ultimaDataVencimento = new Date(parcelas.sort((a, b) => new Date(b.vencimento) - new Date(a.vencimento))[0].vencimento);
@@ -113,7 +114,7 @@ router.post('/', async (req, res) => {
                 JSON.stringify(espacosUtilizados || []),
                 areaM2 || null,
                 datasEvento.join(','),
-                dataVigenciaFinal,
+                dataVigenciaFinal.toISOString().slice(0,10),
                 totalDiarias,
                 valorBruto,
                 tipoDescontoAuto,

--- a/src/services/eventoDarService.js
+++ b/src/services/eventoDarService.js
@@ -92,7 +92,10 @@ async function criarEventoComDars(db, data, helpers) {
     }
   }
   const datasOrdenadas = Array.isArray(datasEvento) ? [...datasEvento].sort((a,b)=> new Date(a)-new Date(b)) : [];
-  const dataVigenciaFinal = datasOrdenadas.length ? datasOrdenadas[datasOrdenadas.length-1] : null;
+  const dataVigenciaFinal = datasOrdenadas.length ? new Date(datasOrdenadas.at(-1)) : null;
+  if (dataVigenciaFinal) {
+    dataVigenciaFinal.setDate(dataVigenciaFinal.getDate() + 1);
+  }
 
   await dbRun(db, 'BEGIN TRANSACTION');
   try {
@@ -115,7 +118,7 @@ async function criarEventoComDars(db, data, helpers) {
           areaM2 != null ? Number(areaM2) : null,
           datasEventoStr,
           datasEventoStr,
-          dataVigenciaFinal,
+          dataVigenciaFinal ? dataVigenciaFinal.toISOString().slice(0,10) : null,
           Number(totalDiarias || 0),
           Number(valorBruto || 0),
           String(tipoDescontoAuto || 'Geral'),
@@ -265,7 +268,10 @@ async function atualizarEventoComDars(db, id, data, helpers) {
     }
   }
   const datasOrdenadas = Array.isArray(datasEvento) ? [...datasEvento].sort((a,b)=> new Date(a)-new Date(b)) : [];
-  const dataVigenciaFinal = datasOrdenadas.length ? datasOrdenadas[datasOrdenadas.length-1] : null;
+  const dataVigenciaFinal = datasOrdenadas.length ? new Date(datasOrdenadas.at(-1)) : null;
+  if (dataVigenciaFinal) {
+    dataVigenciaFinal.setDate(dataVigenciaFinal.getDate() + 1);
+  }
 
   await dbRun(db, 'BEGIN TRANSACTION');
   try {
@@ -300,7 +306,7 @@ async function atualizarEventoComDars(db, id, data, helpers) {
         JSON.stringify(espacosUtilizados || []),
         areaM2 != null ? Number(areaM2) : null,
         JSON.stringify(datasEvento || []),
-        dataVigenciaFinal,
+        dataVigenciaFinal ? dataVigenciaFinal.toISOString().slice(0,10) : null,
         Number(totalDiarias || 0),
         Number(valorBruto || 0),
         String(tipoDescontoAuto || 'Geral'),


### PR DESCRIPTION
## Summary
- Calcula data_vigencia_final como dia após a última data de evento e salva em formato ISO
- Aplica lógica consistente ao criar e atualizar eventos via serviços

## Testing
- `npm test` *(fails: 21 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b8627786788333af5930b5487b1d92