### PR TITLE
Expose clause list on portal advertencias API

### DIFF
--- a/src/api/portalAdvertenciasRoutes.js
+++ b/src/api/portalAdvertenciasRoutes.js
@@ -4,9 +4,12 @@ const nodemailer = require('nodemailer');
 const authMiddleware = require('../middleware/authMiddleware');
 const authorizeRole = require('../middleware/roleMiddleware');
 const db = require('../database/db');
+const termoClausulas = require('../constants/termoClausulas');
 
 const router = express.Router();
 router.use(authMiddleware, authorizeRole(['CLIENTE_EVENTO']));
+
+router.get('/clausulas', (_req, res) => res.json(termoClausulas));
 
 // DB helpers
 const dbGet = (sql, params = []) => new Promise((resolve, reject) => {

--- a/tests/portalAdvertenciasClausulas.test.js
+++ b/tests/portalAdvertenciasClausulas.test.js
@@ -1,0 +1,33 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const fs = require('fs');
+const express = require('express');
+const supertest = require('supertest');
+
+test('portal retorna clausulas do termo', async () => {
+  const dbPath = path.resolve(__dirname, 'test-adv-clausulas.db');
+  try { fs.unlinkSync(dbPath); } catch {}
+  process.env.SQLITE_STORAGE = dbPath;
+
+  const authPath = path.resolve(__dirname, '../src/middleware/authMiddleware.js');
+  require.cache[authPath] = { exports: (req, _res, next) => { req.user = { id:1, role:'CLIENTE_EVENTO' }; next(); } };
+  const rolePath = path.resolve(__dirname, '../src/middleware/roleMiddleware.js');
+  require.cache[rolePath] = { exports: () => (req, _res, next) => next() };
+
+  delete require.cache[require.resolve('../src/api/portalAdvertenciasRoutes')];
+  const portalAdvertenciasRoutes = require('../src/api/portalAdvertenciasRoutes');
+  const app = express();
+  app.use('/api/portal/advertencias', portalAdvertenciasRoutes);
+
+  const termoClausulas = require('../src/constants/termoClausulas');
+
+  await supertest(app)
+    .get('/api/portal/advertencias/clausulas')
+    .expect(200)
+    .expect(res => assert.deepEqual(res.body, termoClausulas));
+
+  const db = require('../src/database/db');
+  await new Promise(resolve => db.close(resolve));
+  delete require.cache[require.resolve('../src/database/db')];
+});


### PR DESCRIPTION
## Summary
- serve `termoClausulas` through `GET /api/portal/advertencias/clausulas`
- test clause list endpoint for portal clients

## Testing
- `node --test tests/portalAdvertenciasClausulas.test.js`
- `npm test` *(fails: 45 passed, 6 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b86e16f1848333a83613b163b28102