### PR TITLE
feat: compose term data from event

### DIFF
--- a/src/services/TermoService.js
+++ b/src/services/TermoService.js
@@ -13,8 +13,25 @@ export default class TermoService {
     return new Intl.DateTimeFormat('pt-BR', {
       day: '2-digit',
       month: 'long',
-      year: 'numeric'
+      year: 'numeric',
+      timeZone: 'America/Sao_Paulo'
     }).format(new Date(date));
+  }
+
+  static composeDataFromEvent(evento) {
+    const vigenciaFim = new Date(evento.dataDesmontagem);
+    vigenciaFim.setDate(vigenciaFim.getDate() + 1);
+    return {
+      valor: evento.valor,
+      data: evento.dataRealizacaoInicio,
+      vigencia: {
+        inicio: evento.dataMontagem,
+        fim: vigenciaFim.toISOString()
+      },
+      saldoPagamento: evento.saldoPagamento,
+      clausulas: evento.clausulas,
+      dars: Array.isArray(evento.dars) ? evento.dars.map(d => ({ ...d })) : []
+    };
   }
 
   static populateTemplate(template, data) {

--- a/test/TermoService.test.js
+++ b/test/TermoService.test.js
@@ -13,16 +13,32 @@ const template = `
     <p>Evento em {{data}} com valor de {{valor}}. Vigência: {{vigenciaInicio}} a {{vigenciaFim}}. Saldo: {{saldoPagamento}}. Cláusulas: {{clausulas}}.</p>
   </body>
 </html>`;
-const dados = {
-  data: '2025-08-12',
+
+const evento = {
   valor: 2495,
-  vigencia: { inicio: '2025-01-01', fim: '2025-12-31' },
+  dataRealizacaoInicio: '2025-08-12T03:00:00Z',
+  dataRealizacaoFim: '2025-08-12T15:00:00Z',
+  dataMontagem: '2025-08-10T03:00:00Z',
+  dataDesmontagem: '2025-08-13T03:00:00Z',
   saldoPagamento: 3000,
-  clausulas: ['Cláusula 1', 'Cláusula 2']
+  clausulas: ['Cláusula 1', 'Cláusula 2'],
+  dars: [
+    { dataVencimento: '2025-08-01T03:00:00Z' },
+    { dataVencimento: '2025-08-20T03:00:00Z' }
+  ]
 };
+
+const dados = TermoService.composeDataFromEvent(evento);
+assert.strictEqual(dados.vigencia.inicio, evento.dataMontagem);
+const vigenciaEsperada = new Date(evento.dataDesmontagem);
+vigenciaEsperada.setDate(vigenciaEsperada.getDate() + 1);
+assert.strictEqual(dados.vigencia.fim, vigenciaEsperada.toISOString());
+assert.deepStrictEqual(dados.dars, evento.dars);
 
 const resultado = TermoService.populateTemplate(template, dados);
 assert.ok(resultado.includes('12 de agosto de 2025'));
+assert.ok(resultado.includes('10 de agosto de 2025'));
+assert.ok(resultado.includes('14 de agosto de 2025'));
 assert.ok(resultado.includes('R$ 2.495,00'));
 
 assert.deepStrictEqual(TermoService.getEspacoInfo('default'), ESPACOS_INFO.default);


### PR DESCRIPTION
## Summary
- handle dates using America/Sao_Paulo timezone
- derive term data from event fields including vigência and DARs
- expand tests for event-derived dates and vigência

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b87067dfe483338dde196f392229a1