### PR TITLE
Use searchable multi-select for advertências

### DIFF
--- a/public/admin/advertencias.html
+++ b/public/admin/advertencias.html
@@ -11,6 +11,9 @@
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/css/app-shell.css">
   <link rel="stylesheet" href="/css/mobile-tweaks.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css">
+
+  <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
 
   <style>
     :root {
@@ -57,7 +60,7 @@
               </div>
               <div class="mb-3">
                 <label class="form-label">Cláusulas infringidas</label>
-                <div id="clausulas-container"></div>
+                <select id="clausulasSelect" class="form-select" multiple></select>
               </div>
               <div class="row">
                 <div class="col-md-4 mb-3">
@@ -86,29 +89,19 @@
     fetch('/api/admin/advertencias/clausulas')
       .then(r => r.json())
       .then(data => {
-        const container = document.getElementById('clausulas-container');
+        const select = document.getElementById('clausulasSelect');
         Object.entries(data).forEach(([num, texto]) => {
-          const div = document.createElement('div');
-          div.className = 'form-check';
-          const input = document.createElement('input');
-          input.className = 'form-check-input';
-          input.type = 'checkbox';
-          input.value = num;
-          input.id = `clausula_${num.replace(/\./g, '_')}`;
-          const label = document.createElement('label');
-          label.className = 'form-check-label';
-          label.htmlFor = input.id;
-          const breve = texto.length > 60 ? texto.slice(0, 60) + '...' : texto;
-          label.textContent = `Cláusula ${num} - ${breve}`;
-          div.appendChild(input);
-          div.appendChild(label);
-          container.appendChild(div);
+          const option = document.createElement('option');
+          option.value = num;
+          option.textContent = `Cláusula ${num} – ${texto}`;
+          select.appendChild(option);
         });
+        new Choices(select, { removeItemButton: true, searchEnabled: true, shouldSort: false });
       });
 
     document.getElementById('advertencia-form').addEventListener('submit', function(e){
       e.preventDefault();
-      const selecionadas = Array.from(document.querySelectorAll('#clausulas-container input:checked')).map(i => i.value);
+      const selecionadas = Array.from(document.getElementById('clausulasSelect').selectedOptions).map(o => o.value);
       console.log('Cláusulas selecionadas:', selecionadas);
       alert('Advertência montada com sucesso.');
     });


### PR DESCRIPTION
## Summary
- Replace checkboxes with a multi-select for selecting cláusulas
- Load and initialize Choices.js for searchable multi-select
- Collect selected cláusulas from the multi-select on form submission

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68b897320c34833387e23d29dc7e5196