### PR TITLE
Fix parcela value fallback in admin event details

### DIFF
--- a/src/api/adminEventosRoutes.js
+++ b/src/api/adminEventosRoutes.js
@@ -604,7 +604,7 @@ router.get('/:id', async (req, res) => {
     const parcelasSql = `
         SELECT
             de.numero_parcela,
-            de.valor_parcela            AS valor,
+            COALESCE(de.valor_parcela, d.valor) AS valor,
             de.data_vencimento          AS vencimento,
             d.id                        AS dar_id,
             d.status                    AS dar_status,


### PR DESCRIPTION
## Summary
- ensure parcelas query falls back to DAR value when valor_parcela is null

## Testing
- `sqlite3 :memory: "CREATE TABLE dars (id INTEGER PRIMARY KEY, valor REAL); CREATE TABLE DARs_Eventos (id_evento INTEGER, numero_parcela INTEGER, valor_parcela REAL, id_dar INTEGER); INSERT INTO dars (id, valor) VALUES (1, 123.45); INSERT INTO DARs_Eventos (id_evento, numero_parcela, valor_parcela, id_dar) VALUES (10, 1, NULL, 1); SELECT de.numero_parcela, COALESCE(de.valor_parcela, d.valor) AS valor FROM DARs_Eventos de JOIN dars d ON d.id = de.id_dar WHERE de.id_evento = 10;"`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b89fdc89a48333b546f72550afb9d3