### PR TITLE
Aceita cláusulas com texto ao criar advertência

### DIFF
--- a/src/api/adminAdvertenciasRoutes.js
+++ b/src/api/adminAdvertenciasRoutes.js
@@ -100,8 +100,8 @@ router.post('/eventos/:id/advertencias', async (req, res) => {
     if (!evento) return res.status(404).json({ error: 'Evento não encontrado.' });
 
     const clausulasDetalhadas = clausulas
-      .map((n) => ({ numero: String(n), texto: termoClausulas[String(n)] }))
-      .filter((c) => c.texto);
+      .map((c) => ({ numero: String(c.numero), texto: String(c.texto) }))
+      .filter((c) => c.numero && c.texto);
     if (!clausulasDetalhadas.length) {
       return res.status(400).json({ error: 'Cláusulas inválidas.' });
     }

--- a/tests/adminAdvertenciasRoutes.test.js
+++ b/tests/adminAdvertenciasRoutes.test.js
@@ -15,7 +15,7 @@ function prepDb(dbPath) {
   return { db, run, get };
 }
 
-test('POST cria advertencia mapeia clausulas e envia email', async () => {
+test('POST cria advertencia usa clausulas do payload e envia email', async () => {
   const dbPath = path.resolve(__dirname, 'test-advertencia-post.db');
   const { run, get } = prepDb(dbPath);
 
@@ -33,7 +33,6 @@ test('POST cria advertencia mapeia clausulas e envia email', async () => {
   process.env.SMTP_USER = 'u';
   process.env.SMTP_PASS = 'p';
 
-  const termoClausulas = require('../src/constants/termoClausulas');
   const pdfSvcPath = path.resolve(__dirname, '../src/services/advertenciaPdfService.js');
   let pdfArgs;
   const fakePath = path.resolve(__dirname, 'adv.pdf');
@@ -57,9 +56,14 @@ test('POST cria advertencia mapeia clausulas e envia email', async () => {
   app.use(express.json());
   app.use('/api/admin', routes);
 
+  const texto51 = 'Texto da clausula 5.1';
+  const texto73 = 'Texto da clausula 7.3';
   const payload = {
     fatos: 'F',
-    clausulas: ['5.1', '7.3'],
+    clausulas: [
+      { numero: '5.1', texto: texto51 },
+      { numero: '7.3', texto: texto73 }
+    ],
     multa: 50,
     gera_multa: true,
     inapto: false,
@@ -74,12 +78,12 @@ test('POST cria advertencia mapeia clausulas e envia email', async () => {
   assert.equal(row.gera_multa, 1);
   assert.equal(row.inapto, 0);
   const saved = JSON.parse(row.clausulas);
-  assert.equal(saved[0].texto, termoClausulas['5.1']);
-  assert.ok(saved.some(c => c.texto === termoClausulas['7.3']));
+  assert.equal(saved[0].texto, texto51);
+  assert.ok(saved.some(c => c.texto === texto73));
 
-  assert.ok(pdfArgs.clausulas.some(c => c.texto === termoClausulas['7.3']));
+  assert.ok(pdfArgs.clausulas.some(c => c.texto === texto73));
   const pdfContent = fs.readFileSync(fakePath, 'utf8');
-  assert.ok(pdfContent.includes(termoClausulas['7.3']));
+  assert.ok(pdfContent.includes(texto73));
 
   assert.ok(logs.some(l => l.includes('gerar DAR')));
   assert.equal(mailSent, true);


### PR DESCRIPTION
## Summary
- Aceita número e texto das cláusulas no endpoint de criação de advertências
- Ajusta testes para validar textos enviados e gerados

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8a22c3afc8333b6017b99307c6a3d