### PR TITLE
refactor: simplify clausulas mapping

### DIFF
--- a/src/api/adminAdvertenciasRoutes.js
+++ b/src/api/adminAdvertenciasRoutes.js
@@ -94,24 +94,9 @@ router.post('/eventos/:id/advertencias', async (req, res) => {
                                   FROM Eventos e JOIN Clientes_Eventos ce ON ce.id = e.id_cliente WHERE e.id = ?`, [id]);
     if (!evento) return res.status(404).json({ error: 'Evento não encontrado.' });
 
-    const clausulasDetalhadas = clausulas
-      .map(c => ({ numero: String(c?.numero || '').trim(), texto: String(c?.texto || '').trim() }))
-      .filter(c => c.numero && c.texto);
-    if (clausulasDetalhadas.length !== clausulas.length) {
     const clausulasDetalhadas = (clausulas || [])
-      .map((c) => {
-        if (typeof c === "string" || typeof c === "number") {
-          const num = String(c);
-          return { numero: num, texto: termoClausulas[num] };
-        }
-        if (c && typeof c === "object") {
-          const num = String(c.numero || c.num || c.id || "");
-          const texto = c.texto || termoClausulas[num];
-          return { numero: num, texto };
-        }
-        return null;
-      })
-      .filter((c) => c && c.texto);
+      .map(c => ({ numero: String(c.numero).trim(), texto: String(c.texto).trim() }))
+      .filter(c => c.numero && c.texto);
 
     if (!clausulasDetalhadas.length) {
       return res.status(400).json({ error: 'Cláusulas inválidas.' });


### PR DESCRIPTION
## Summary
- remove duplicate clause mapping and `termoClausulas` reliance
- ensure clausulas mapping simply trims numero/texto and validates non-empty

## Testing
- `npm test` *(fails: Function._resolveFilename setup / tests: pass 5, fail 21)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a64f6078833390e16d5201a9a5ea