### PR TITLE
Decode admin name from JWT on eventos-remarcacoes page

### DIFF
--- a/public/admin/eventos-remarcacoes.html
+++ b/public/admin/eventos-remarcacoes.html
@@ -101,6 +101,17 @@
   <script>
   window.onload = () => {
     const token = localStorage.getItem('adminToken') || localStorage.getItem('token') || '';
+
+    // Mostra o nome do admin a partir do JWT armazenado
+    try {
+      const base64url = token.split('.')[1] || '';
+      const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/').padEnd(Math.ceil(base64url.length / 4) * 4, '=');
+      const payload = JSON.parse(atob(base64));
+      document.getElementById('adminName').innerText = payload?.nome || 'Administrador';
+    } catch (e) {
+      document.getElementById('adminName').innerText = 'Administrador';
+    }
+
     const AUTH_HEADERS = { Authorization: `Bearer ${token}` };
 
     const remarcacoesTableBody = document.getElementById('remarcacoes-table-body');


### PR DESCRIPTION
## Summary
- Show admin display name on eventos-remarcacoes page by decoding stored JWT before other scripts run

## Testing
- `node <<'NODE'
const {JSDOM}=require('jsdom');
const token=[Buffer.from(JSON.stringify({alg:'HS256',typ:'JWT'})).toString('base64url'),Buffer.from(JSON.stringify({nome:'Alice Admin'})).toString('base64url'),'sig'].join('.');
JSDOM.fromFile('public/admin/eventos-remarcacoes.html',{
 runScripts:'dangerously',
 resources:'usable',
 url:'https://example.org/',
 beforeParse(win){
  win.localStorage.setItem('adminToken',token);
  win.fetch=()=>Promise.resolve({ok:true,json:async()=>({eventos:[]})});
  win.bootstrap={Modal: function(){return {show:()=>{}};}};
 }
}).then(async dom=>{
 await new Promise(res=>dom.window.addEventListener('load',res));
 console.log('AdminName innerText:',dom.window.document.getElementById('adminName').innerText);
 console.log('AdminName textContent:',dom.window.document.getElementById('adminName').textContent);
});
NODE`
- `npm test` *(fails: SyntaxError in tests/adminAdvertenciasRoutes.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a9f8488483339296db6f1256be2d