### PR TITLE
Decode portal token on advertencias page

### DIFF
--- a/public/advertencias.html
+++ b/public/advertencias.html
@@ -89,10 +89,29 @@
               <button type="submit" class="btn btn-primary">Gerar Advertência</button>
             </form>
           </div>
-        </div>
-      </main>
-    </div>
   </div>
+</main>
+</div>
+</div>
+  <script>
+    (function() {
+      const token = localStorage.getItem('token');
+      const userNameEl = document.getElementById('userName');
+
+      if (!token) {
+        userNameEl.textContent = 'Visitante';
+        window.location.href = '/login.html';
+        return;
+      }
+
+      try {
+        const payload = JSON.parse(atob(token.split('.')[1]));
+        userNameEl.textContent = payload.nome_empresa || payload.nome_razao_social || payload.nome || payload.name || 'Cliente';
+      } catch (err) {
+        userNameEl.textContent = 'Cliente';
+      }
+    })();
+  </script>
 
   <script>
     const clausulas = {


### PR DESCRIPTION
## Summary
- Decode stored portal token and display company/user name on advertências page
- Redirect to login page when token is missing

## Testing
- `npm test` *(fails: Cannot find module errors, 5 passing, 21 failing)*

------
https://chatgpt.com/codex/tasks/task_e_68b8aab359c48333a8327f6a52634ded