### PR TITLE
Include new DAR statuses and adjust notification logic

### DIFF
--- a/public/admin/dars.html
+++ b/public/admin/dars.html
@@ -171,14 +171,18 @@
           Pendente: 'bg-warning text-dark',
           Pago: 'bg-success text-white',
           Vencido: 'bg-danger text-white',
-          Vencida: 'bg-danger text-white'
+          Vencida: 'bg-danger text-white',
+          Emitido: 'bg-primary text-white',
+          Reemitido: 'bg-primary text-white'
         };
         const rows = dars.map(dar=>{
           const statusColor = statusColors[dar.status] || 'bg-secondary text-white';
           const acaoBotao =
-            (dar.status==='Pendente' || dar.status==='Vencido' || dar.status==='Vencida')
+            (dar.status==='Pendente' || dar.status==='Vencido' || dar.status==='Vencida' || dar.status==='Emitido' || dar.status==='Reemitido')
             ? `<button class="btn btn-sm btn-outline-info enviar-notificacao-btn" data-id="${esc(dar.id)}" title="Enviar notificação por e-mail"><i class="bi bi-envelope-fill"></i> Notificar</button>`
-            : `<span class="text-muted"><i class="bi bi-check-circle-fill text-success"></i> Pago</span>`;
+            : (dar.status==='Pago'
+              ? `<span class="text-muted"><i class="bi bi-check-circle-fill text-success"></i> Pago</span>`
+              : '');
           return `
             <tr>
               <td>


### PR DESCRIPTION
## Summary
- Display 'Emitido' and 'Reemitido' DARs with primary badges
- Allow notifications for Emitido and Reemitido statuses
- Show paid indicator only for DARs marked as Pago

## Testing
- `npm test` *(fails: Cannot find module 'express', SyntaxError: Unexpected identifier 'texto51')*


------
https://chatgpt.com/codex/tasks/task_e_68b8aff76258833390266541b420d039