### PR TITLE
fix: preserve event dates array and include parcels

### DIFF
--- a/public/admin/eventos-dars.html
+++ b/public/admin/eventos-dars.html
@@ -1084,7 +1084,7 @@ function normalizarEvento(payload){
     // 2. Se estiver vazia, calcula a partir da maior data em datas_evento.
     if (!data_vigencia_final && datas_evento.length > 0) {
         // Ordena as datas e pega a última (a maior)
-        const ultimaData = datas_evento.sort().pop();
+        const ultimaData = [...datas_evento].sort().pop();
         data_vigencia_final = ultimaData;
     }
     
@@ -1123,7 +1123,8 @@ function normalizarEvento(payload){
       area_m2,
       numero_oficio_sei,
       valor_final,
-      evento_gratuito
+      evento_gratuito,
+      parcelas: payload.parcelas || ev.parcelas || []
     };
   }
     async function editarEvento(eventoId){


### PR DESCRIPTION
## Summary
- avoid mutating dates array when deriving final date
- return parcelas from event normalization to prefill edit form

## Testing
- `npm test` *(fails: Cannot find module errors etc. 5 passing, 21 failing)*
- `node -e <snippet>` verifying `normalizarEvento` returns parcelas

------
https://chatgpt.com/codex/tasks/task_e_68b8b0b62cbc833392ec684e960dd919