### PR TITLE
Add mobile tweaks to email consult page

### DIFF
--- a/public/consultar-email-cadastrado.html
+++ b/public/consultar-email-cadastrado.html
@@ -8,8 +8,9 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/css/mobile-tweaks.css">
     <style>
-        :root { 
+        :root {
             --cor-primaria: #0056a0;
             --cor-footer: #004480;
             --raio-borda: 0.5rem;
@@ -188,6 +189,9 @@
             });
         });
     </script>
+
+    <script defer src="/js/mobile-adapter.js"></script>
+    <script defer src="/js/mobile-tweaks.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load `/css/mobile-tweaks.css` in consultar-email-cadastrado
- include mobile adapter and tweaks scripts

## Testing
- `npm test` *(fails: Cannot find module 'express')*
- `node -e "const puppeteer=require('puppeteer');..."` *(fails: Browser was not found at the configured executablePath (chromium-browser))*

------
https://chatgpt.com/codex/tasks/task_e_68b97f1547388333a71bf1b459d765b4