### PR TITLE
Add reservation reschedule and cancel flow

### DIFF
--- a/src/pages/AdminReservasPage.jsx
+++ b/src/pages/AdminReservasPage.jsx
@@ -1,8 +1,28 @@
 import React, { useState } from 'react';
 import CalendarioReservas from '../components/CalendarioReservas.jsx';
+import ReservaService from '../services/ReservaService.js';
+
+const modalStyle = {
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  background: 'rgba(0,0,0,0.3)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center'
+};
+
+const boxStyle = {
+  background: '#fff',
+  padding: '1rem',
+  borderRadius: '4px',
+  minWidth: '300px'
+};
 
 const AdminReservasPage = () => {
-  const [events] = useState([
+  const [events, setEvents] = useState([
     {
       id: 1,
       title: 'Reunião de planejamento',
@@ -11,19 +31,84 @@ const AdminReservasPage = () => {
     }
   ]);
 
+  const [selected, setSelected] = useState(null);
+  const [showReschedule, setShowReschedule] = useState(false);
+  const [showCancel, setShowCancel] = useState(false);
+  const [newStart, setNewStart] = useState('');
+  const [newEnd, setNewEnd] = useState('');
+
   const handleReschedule = (event) => {
-    // Implementar lógica real de remarcação
-    alert(`Remarcar: ${event.title}`);
+    setSelected(event);
+    setNewStart(event.start.toISOString().slice(0,16));
+    setNewEnd(event.end.toISOString().slice(0,16));
+    setShowReschedule(true);
   };
 
   const handleCancel = (event) => {
-    // Implementar lógica real de cancelamento
-    alert(`Cancelar: ${event.title}`);
+    setSelected(event);
+    setShowCancel(true);
+  };
+
+  const confirmReschedule = async () => {
+    try {
+      await ReservaService.updateReserva(selected.id, { start: newStart, end: newEnd });
+      setEvents(prev => prev.map(ev => ev.id === selected.id ? { ...ev, start: new Date(newStart), end: new Date(newEnd) } : ev));
+    } catch (err) {
+      console.error(err);
+    }
+    setShowReschedule(false);
+    setSelected(null);
+  };
+
+  const confirmCancel = async () => {
+    try {
+      await ReservaService.deleteReserva(selected.id);
+      setEvents(prev => prev.filter(ev => ev.id !== selected.id));
+    } catch (err) {
+      console.error(err);
+    }
+    setShowCancel(false);
+    setSelected(null);
   };
 
   return (
     <div style={{ height: '80vh', padding: '1rem' }}>
       <CalendarioReservas events={events} onReschedule={handleReschedule} onCancel={handleCancel} />
+
+      {showReschedule && (
+        <div style={modalStyle}>
+          <div style={boxStyle}>
+            <h3>Remarcar Reserva</h3>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+              <label>
+                Início:
+                <input type="datetime-local" value={newStart} onChange={e => setNewStart(e.target.value)} />
+              </label>
+              <label>
+                Fim:
+                <input type="datetime-local" value={newEnd} onChange={e => setNewEnd(e.target.value)} />
+              </label>
+            </div>
+            <div style={{ marginTop: '1rem', display: 'flex', justifyContent: 'flex-end', gap: '0.5rem' }}>
+              <button onClick={() => { setShowReschedule(false); setSelected(null); }}>Cancelar</button>
+              <button onClick={confirmReschedule} disabled={!newStart || !newEnd}>Salvar</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {showCancel && (
+        <div style={modalStyle}>
+          <div style={boxStyle}>
+            <h3>Cancelar Reserva</h3>
+            <p>Tem certeza que deseja cancelar "{selected?.title}"?</p>
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.5rem' }}>
+              <button onClick={() => { setShowCancel(false); setSelected(null); }}>Não</button>
+              <button onClick={confirmCancel}>Sim</button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/pages/PermissionarioReservasPage.jsx
+++ b/src/pages/PermissionarioReservasPage.jsx
@@ -1,8 +1,28 @@
 import React, { useState } from 'react';
 import CalendarioReservas from '../components/CalendarioReservas.jsx';
+import ReservaService from '../services/ReservaService.js';
+
+const modalStyle = {
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  background: 'rgba(0,0,0,0.3)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center'
+};
+
+const boxStyle = {
+  background: '#fff',
+  padding: '1rem',
+  borderRadius: '4px',
+  minWidth: '300px'
+};
 
 const PermissionarioReservasPage = () => {
-  const [events] = useState([
+  const [events, setEvents] = useState([
     {
       id: 1,
       title: 'Evento do permissionário',
@@ -11,17 +31,84 @@ const PermissionarioReservasPage = () => {
     }
   ]);
 
+  const [selected, setSelected] = useState(null);
+  const [showReschedule, setShowReschedule] = useState(false);
+  const [showCancel, setShowCancel] = useState(false);
+  const [newStart, setNewStart] = useState('');
+  const [newEnd, setNewEnd] = useState('');
+
   const handleReschedule = (event) => {
-    alert(`Remarcar: ${event.title}`);
+    setSelected(event);
+    setNewStart(event.start.toISOString().slice(0,16));
+    setNewEnd(event.end.toISOString().slice(0,16));
+    setShowReschedule(true);
   };
 
   const handleCancel = (event) => {
-    alert(`Cancelar: ${event.title}`);
+    setSelected(event);
+    setShowCancel(true);
+  };
+
+  const confirmReschedule = async () => {
+    try {
+      await ReservaService.updateReserva(selected.id, { start: newStart, end: newEnd });
+      setEvents(prev => prev.map(ev => ev.id === selected.id ? { ...ev, start: new Date(newStart), end: new Date(newEnd) } : ev));
+    } catch (err) {
+      console.error(err);
+    }
+    setShowReschedule(false);
+    setSelected(null);
+  };
+
+  const confirmCancel = async () => {
+    try {
+      await ReservaService.deleteReserva(selected.id);
+      setEvents(prev => prev.filter(ev => ev.id !== selected.id));
+    } catch (err) {
+      console.error(err);
+    }
+    setShowCancel(false);
+    setSelected(null);
   };
 
   return (
     <div style={{ height: '80vh', padding: '1rem' }}>
       <CalendarioReservas events={events} onReschedule={handleReschedule} onCancel={handleCancel} />
+
+      {showReschedule && (
+        <div style={modalStyle}>
+          <div style={boxStyle}>
+            <h3>Remarcar Reserva</h3>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+              <label>
+                Início:
+                <input type="datetime-local" value={newStart} onChange={e => setNewStart(e.target.value)} />
+              </label>
+              <label>
+                Fim:
+                <input type="datetime-local" value={newEnd} onChange={e => setNewEnd(e.target.value)} />
+              </label>
+            </div>
+            <div style={{ marginTop: '1rem', display: 'flex', justifyContent: 'flex-end', gap: '0.5rem' }}>
+              <button onClick={() => { setShowReschedule(false); setSelected(null); }}>Cancelar</button>
+              <button onClick={confirmReschedule} disabled={!newStart || !newEnd}>Salvar</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {showCancel && (
+        <div style={modalStyle}>
+          <div style={boxStyle}>
+            <h3>Cancelar Reserva</h3>
+            <p>Tem certeza que deseja cancelar "{selected?.title}"?</p>
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.5rem' }}>
+              <button onClick={() => { setShowCancel(false); setSelected(null); }}>Não</button>
+              <button onClick={confirmCancel}>Sim</button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/services/ReservaService.js
+++ b/src/services/ReservaService.js
@@ -1,0 +1,33 @@
+export default class ReservaService {
+  static baseUrl = process.env.RESERVAS_API_URL || '';
+
+  static async updateReserva(id, dados) {
+    const response = await fetch(`${this.baseUrl}/reservas/${id}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(dados)
+    });
+
+    if (!response.ok) {
+      const message = await response.text();
+      throw new Error(message || 'Erro ao atualizar reserva');
+    }
+
+    return response.status !== 204 ? response.json() : undefined;
+  }
+
+  static async deleteReserva(id) {
+    const response = await fetch(`${this.baseUrl}/reservas/${id}`, {
+      method: 'DELETE'
+    });
+
+    if (!response.ok) {
+      const message = await response.text();
+      throw new Error(message || 'Erro ao cancelar reserva');
+    }
+
+    return true;
+  }
+}


### PR DESCRIPTION
## Summary
- add ReservaService with PUT and DELETE endpoints for reservas
- allow admin and permissionário to remarc or cancel via modals

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9811ae5a08333a4bfd1746f2c7b6f