### PR TITLE
Ignore exempt permissionários in billing and reports

### DIFF
--- a/cron/gerarDarsMensais.js
+++ b/cron/gerarDarsMensais.js
@@ -85,11 +85,11 @@ async function gerarDarsEEnviarNotificacoes() {
       .toISOString()
       .slice(0, 10);
 
-    // Busca permissionários (filtrando se TEST_PERMISSIONARIO_ID estiver setado)
-    let sql = `SELECT * FROM permissionarios`;
-    let params = [];
+    // Busca permissionários (filtrando Isentos ou valor_aluguel zerado)
+    let sql = `SELECT * FROM permissionarios WHERE (tipo IS NULL OR tipo != 'Isento') AND COALESCE(valor_aluguel,0) > 0`;
+    const params = [];
     if (Number.isInteger(TEST_PERMISSIONARIO_ID)) {
-      sql += ` WHERE id = ?`;
+      sql += ` AND id = ?`;
       params.push(TEST_PERMISSIONARIO_ID);
     }
 

--- a/gerarDarsMensais.js
+++ b/gerarDarsMensais.js
@@ -36,12 +36,16 @@ async function gerarDarsEEnviarNotificacoes() {
         const dataVencimento = getUltimoDiaUtil(anoReferencia, mesReferencia);
         const dataVencimentoStr = dataVencimento.toISOString().split('T')[0]; // Formato AAAA-MM-DD
 
-        // 1. Busca todos os permissionários no banco
+        // 1. Busca permissionários ativos (ignora isentos ou com valor_aluguel zerado)
         const permissionarios = await new Promise((resolve, reject) => {
-            db.all(`SELECT * FROM permissionarios`, [], (err, rows) => {
-                if (err) reject(err);
-                resolve(rows);
-            });
+            db.all(
+                `SELECT * FROM permissionarios WHERE (tipo IS NULL OR tipo != 'Isento') AND COALESCE(valor_aluguel,0) > 0`,
+                [],
+                (err, rows) => {
+                    if (err) reject(err);
+                    resolve(rows);
+                }
+            );
         });
 
         console.log(`[ROBÔ] Encontrados ${permissionarios.length} permissionários. Gerando DARs para ${mesReferencia}/${anoReferencia}...`);

--- a/tests/adminDashboardStatsFilter.test.js
+++ b/tests/adminDashboardStatsFilter.test.js
@@ -11,10 +11,10 @@ test('dashboard-stats respects tipo filter', async () => {
   const db = new sqlite3.Database(':memory:');
   const run = (sql, params=[]) => new Promise((res, rej) => db.run(sql, params, err => err ? rej(err) : res()));
 
-  await run(`CREATE TABLE permissionarios (id INTEGER PRIMARY KEY, nome_empresa TEXT);`);
+  await run(`CREATE TABLE permissionarios (id INTEGER PRIMARY KEY, nome_empresa TEXT, tipo TEXT, valor_aluguel REAL);`);
   await run(`CREATE TABLE dars (id INTEGER PRIMARY KEY, permissionario_id INTEGER, tipo_permissionario TEXT, valor REAL, data_vencimento TEXT, status TEXT, mes_referencia INTEGER, ano_referencia INTEGER);`);
 
-  await run(`INSERT INTO permissionarios (id, nome_empresa) VALUES (1, 'Perm A');`);
+  await run(`INSERT INTO permissionarios (id, nome_empresa, tipo, valor_aluguel) VALUES (1, 'Perm A', 'Normal', 100);`);
   await run(`INSERT INTO dars (id, permissionario_id, tipo_permissionario, valor, data_vencimento, status, mes_referencia, ano_referencia) VALUES (1, 1, 'Permissionario', 100, '2030-01-01', 'Pendente', 1, 2030);`);
   await run(`INSERT INTO dars (id, permissionario_id, tipo_permissionario, valor, data_vencimento, status, mes_referencia, ano_referencia) VALUES (2, NULL, 'Evento', 200, '2030-02-01', 'Pendente', 2, 2030);`);
 

--- a/tests/adminRelatorioDars.test.js
+++ b/tests/adminRelatorioDars.test.js
@@ -26,13 +26,13 @@ test('relatorio de dars inclui guias emitidas mesmo sem emitido_por_id ou permis
   const db = require('../src/database/db');
   const run = (sql, params = []) => new Promise((res, rej) => db.run(sql, params, err => err ? rej(err) : res()));
 
-  await run(`CREATE TABLE permissionarios (id INTEGER PRIMARY KEY, nome_empresa TEXT, cnpj TEXT)`);
+  await run(`CREATE TABLE permissionarios (id INTEGER PRIMARY KEY, nome_empresa TEXT, cnpj TEXT, tipo TEXT, valor_aluguel REAL)`);
   await run(`CREATE TABLE dars (id INTEGER PRIMARY KEY, permissionario_id INTEGER, data_vencimento TEXT, mes_referencia INTEGER,
  ano_referencia INTEGER, valor REAL, status TEXT, numero_documento TEXT, pdf_url TEXT, linha_digitavel TEXT, data_emissao TEXT,
  emitido_por_id INTEGER)`);
   await run(`CREATE TABLE documentos (id INTEGER PRIMARY KEY, tipo TEXT, caminho TEXT, token TEXT UNIQUE)`);
 
-  await run(`INSERT INTO permissionarios (id, nome_empresa, cnpj) VALUES (1, 'Perm', '12345678000199')`);
+  await run(`INSERT INTO permissionarios (id, nome_empresa, cnpj, tipo, valor_aluguel) VALUES (1, 'Perm', '12345678000199', 'Normal', 100)`);
   await run(`INSERT INTO dars (id, permissionario_id, data_vencimento, mes_referencia, ano_referencia, valor, status, numero_documento, pdf_url, data_emissao, emitido_por_id) VALUES (10,1,'2025-12-31',12,2025,100,'Emitido','DOC123','PDF','2025-08-15',1)`);
   await run(`INSERT INTO dars (id, permissionario_id, data_vencimento, mes_referencia, ano_referencia, valor, status, numero_documento, pdf_url, data_emissao, emitido_por_id) VALUES (12,NULL,'2025-12-31',12,2025,200,'Emitido','DOC_EVENTO','PDF','2025-08-16',NULL)`);
   await run(`INSERT INTO dars (id, permissionario_id, data_vencimento, mes_referencia, ano_referencia, valor, status, numero_documento) VALUES (11,1,'2025-12-31',12,2025,100,'Novo','DOCNOVO')`);
@@ -74,7 +74,7 @@ test('retorna 204 quando nao existem dars emitidas', async () => {
   const db = require('../src/database/db');
   const run = (sql, params = []) => new Promise((res, rej) => db.run(sql, params, err => err ? rej(err) : res()));
 
-  await run(`CREATE TABLE permissionarios (id INTEGER PRIMARY KEY, nome_empresa TEXT, cnpj TEXT)`);
+  await run(`CREATE TABLE permissionarios (id INTEGER PRIMARY KEY, nome_empresa TEXT, cnpj TEXT, tipo TEXT, valor_aluguel REAL)`);
   await run(`CREATE TABLE dars (id INTEGER PRIMARY KEY, permissionario_id INTEGER, data_vencimento TEXT, mes_referencia INTEGER,
  ano_referencia INTEGER, valor REAL, status TEXT, numero_documento TEXT, pdf_url TEXT, linha_digitavel TEXT, data_emissao TEXT,
  emitido_por_id INTEGER)`);

--- a/tests/isentoFilterBilling.test.js
+++ b/tests/isentoFilterBilling.test.js
@@ -1,0 +1,46 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const express = require('express');
+const supertest = require('supertest');
+const sqlite3 = require('sqlite3').verbose();
+
+test('dashboard and pagamentos ignore isentos ou valor zero', async () => {
+  const db = new sqlite3.Database(':memory:');
+  const run = (sql, params=[]) => new Promise((res, rej) => db.run(sql, params, err => err?rej(err):res()));
+
+  await run(`CREATE TABLE permissionarios (id INTEGER PRIMARY KEY, nome_empresa TEXT, cnpj TEXT, tipo TEXT, valor_aluguel REAL);`);
+  await run(`CREATE TABLE dars (id INTEGER PRIMARY KEY, permissionario_id INTEGER, tipo_permissionario TEXT, valor REAL, data_vencimento TEXT, status TEXT, mes_referencia INTEGER, ano_referencia INTEGER);`);
+
+  await run(`INSERT INTO permissionarios (id,nome_empresa,cnpj,tipo,valor_aluguel) VALUES (1,'Normal','1','Normal',100);`);
+  await run(`INSERT INTO permissionarios (id,nome_empresa,cnpj,tipo,valor_aluguel) VALUES (2,'Isento','2','Isento',100);`);
+  await run(`INSERT INTO permissionarios (id,nome_empresa,cnpj,tipo,valor_aluguel) VALUES (3,'Zero','3','Normal',0);`);
+
+  await run(`INSERT INTO dars (permissionario_id,tipo_permissionario,valor,data_vencimento,status,mes_referencia,ano_referencia) VALUES (1,'Permissionario',100,'2030-01-01','Pendente',1,2030);`);
+  await run(`INSERT INTO dars (permissionario_id,tipo_permissionario,valor,data_vencimento,status,mes_referencia,ano_referencia) VALUES (2,'Permissionario',100,'2030-01-01','Pendente',1,2030);`);
+  await run(`INSERT INTO dars (permissionario_id,tipo_permissionario,valor,data_vencimento,status,mes_referencia,ano_referencia) VALUES (3,'Permissionario',100,'2030-01-01','Pendente',1,2030);`);
+
+  const dbModulePath = path.resolve(__dirname, '../src/database/db.js');
+  require.cache[dbModulePath] = { exports: db };
+  const authPath = path.resolve(__dirname, '../src/middleware/authMiddleware.js');
+  require.cache[authPath] = { exports: (req,_res,next) => { req.user = { id:1 }; next(); } };
+  const rolePath = path.resolve(__dirname, '../src/middleware/roleMiddleware.js');
+  require.cache[rolePath] = { exports: () => (_req,_res,next) => next() };
+
+  const adminRoutes = require('../src/api/adminRoutes');
+  const app = express();
+  app.use('/api/admin', adminRoutes);
+  const request = supertest(app);
+
+  const dash = await request.get('/api/admin/dashboard-stats').expect(200);
+  assert.equal(dash.body.darsPendentes, 1);
+
+  const rel = await request.get('/api/admin/relatorios/pagamentos?mes=1&ano=2030').expect(200);
+  assert.equal(rel.body.devedores.length, 1);
+  assert.equal(rel.body.devedores[0].permissionario_id, 1);
+
+  db.close();
+  delete require.cache[dbModulePath];
+  delete require.cache[authPath];
+  delete require.cache[rolePath];
+});


### PR DESCRIPTION
## Summary
- skip DAR generation for permissionários marked as `Isento` or with zero rent
- treat such clients as free events in eventoDarService
- exclude exempt tenants from dashboard stats and admin reports

## Testing
- `npm test` *(fails: tests/adminAdvertenciasRoutes.test.js syntax error)*
- `node --test tests/isentoFilterBilling.test.js`
- `node --test tests/eventoDarService.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b98493147c8333937902b7e1422dc5