### PR TITLE
Fix callback flow in solicitar-acesso route

### DIFF
--- a/src/api/authRoutes.js
+++ b/src/api/authRoutes.js
@@ -86,11 +86,9 @@ router.post('/solicitar-acesso', (req, res) => {
         }
       }
 
-        return res.status(200).json({
-          message: 'Se um CNPJ correspondente for encontrado, um e-mail será enviado.',
-          permissionarioId: user.id
-        });
-
+      return res.status(200).json({
+        message: 'Se um CNPJ correspondente for encontrado, um e-mail será enviado.',
+        permissionarioId: user.id
       });
     } catch (hashErr) {
       console.error('[solicitar-acesso] hash error:', hashErr);


### PR DESCRIPTION
## Summary
- return success response after processing users in `/solicitar-acesso`
- move catch block to follow try and remove extra callback closure

## Testing
- `npm test` *(fails: SyntaxError: Unexpected identifier 'texto51', Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68b986d68c948333b537f38c4c9f464a