### PR TITLE
refactor: streamline code verification

### DIFF
--- a/src/api/authRoutes.js
+++ b/src/api/authRoutes.js
@@ -122,31 +122,27 @@ router.post('/verificar-codigo', (req, res) => {
 
     const user = users.find((u) => u.id === Number(permissionarioId));
     if (!user) {
-
       return res.status(400).json({
         error: 'Código inválido, expirado ou dados incorretos. Tente novamente.'
       });
     }
 
     try {
+      // Compara o código fornecido com o token armazenado para o permissionário
       const match = await bcrypt.compare(codigo, user.senha_reset_token || '');
       if (!match) {
         return res.status(400).json({
           error: 'Código inválido, expirado ou dados incorretos. Tente novamente.'
         });
-      for (const user of users) {
-        const match = await bcrypt.compare(codigo, user.senha_reset_token || '');
-        if (match) {
-          const payload = { id: user.id, reset: true };
-          const token = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: '15m' });
-          return res.status(200).json({
-            message: 'Código verificado com sucesso!',
-            token
-          });
-        }
       }
-      return res.status(400).json({
-        error: 'Código inválido, expirado ou CNPJ incorreto. Tente novamente.'
+
+      // Código válido: gera token temporário para redefinição de senha
+      const payload = { id: user.id, reset: true };
+      const token = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: '15m' });
+
+      return res.status(200).json({
+        message: 'Código verificado com sucesso!',
+        token
       });
     } catch (cmpErr) {
       console.error('[verificar-codigo] compare error:', cmpErr);


### PR DESCRIPTION
## Summary
- remove user loop in `/verificar-codigo`
- compare code against selected permissionário and issue reset token on match

## Testing
- `npm test` *(fails: Cannot find module 'express'; SyntaxError: Unexpected identifier 'texto51')*

------
https://chatgpt.com/codex/tasks/task_e_68b9876eebd8833397685afa46b133ea