### PR TITLE
Add bcrypt login verification and JWT issuance

### DIFF
--- a/src/api/authRoutes.js
+++ b/src/api/authRoutes.js
@@ -251,7 +251,18 @@ router.post('/login', async (req, res) => {
         });
       }
 
-      return res.status(401).json({ error: 'Credenciais inválidas.' });
+      const senhaValida = await bcrypt.compare(senha, user.senha);
+      if (!senhaValida) {
+        return res.status(401).json({ error: 'Credenciais inválidas.' });
+      }
+
+      const payload = { id: user.id };
+      const token = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: '8h' });
+
+      return res.status(200).json({
+        message: 'Login bem-sucedido!',
+        token
+      });
     });
   } catch (e) {
     console.error('[login] unexpected:', e);


### PR DESCRIPTION
## Summary
- Verify login password using bcrypt and issue JWT tokens for permissionários

## Testing
- `npm test` *(fails: 22, passes: 5)*

------
https://chatgpt.com/codex/tasks/task_e_68b98873a5a883339e1af66ace1a4e0d