### PR TITLE
Include user type in /me endpoint

### DIFF
--- a/src/api/userRoutes.js
+++ b/src/api/userRoutes.js
@@ -33,11 +33,11 @@ ensureColumn('permissionarios', 'telefone_cobranca', 'TEXT').catch(()=>{});
 // Rota GET /me (agora busca também o email_notificacao)
 router.get('/me', authMiddleware, (req, res) => {
     const userId = req.user.id;
-    const sql = `SELECT id, nome_empresa, cnpj, email, telefone, telefone_cobranca, email_financeiro, responsavel_financeiro, website, email_notificacao, numero_sala, valor_aluguel FROM permissionarios WHERE id = ?`;
+    const sql = `SELECT id, nome_empresa, cnpj, email, telefone, telefone_cobranca, email_financeiro, responsavel_financeiro, website, email_notificacao, numero_sala, valor_aluguel, tipo FROM permissionarios WHERE id = ?`;
     db.get(sql, [userId], (err, user) => {
         if (err) { return res.status(500).json({ error: 'Erro de banco de dados.' }); }
         if (!user) { return res.status(404).json({ error: 'Usuário não encontrado.' }); }
-        res.status(200).json(user);
+        res.status(200).json({ ...user, tipo: user.tipo });
     });
 });
 


### PR DESCRIPTION
## Summary
- include user type in `/me` query and response

## Testing
- `npm test` *(fails: Cannot find module 'fs/promises' etc. 22 failing)*

------
https://chatgpt.com/codex/tasks/task_e_68b98a5cf3b08333bf325890e8c3ac66