### PR TITLE
Refine mobile sidebar behavior

### DIFF
--- a/public/css/app-shell.css
+++ b/public/css/app-shell.css
@@ -51,13 +51,13 @@ body{
 /* Sidebar */
 .sidebar{width:260px}
 @media (max-width: 768px){
-  body.mobile .sidebar{
+  .sidebar{
     position:fixed; left:-260px; top:0; bottom:0; width:260px;
     background:#0b4b83; color:#fff; z-index:var(--z-sidebar);
     transition:left .22s ease; box-shadow:2px 0 12px rgba(0,0,0,.22)
   }
-  body.mobile .sidebar.open{left:0}
-  body.mobile .main-content{padding-left:0!important}
+  .sidebar.open{left:0}
+  .main-content{padding-left:0!important}
 }
 
 /* Padding/espaçamento em mobile */

--- a/public/css/mobile-tweaks.css
+++ b/public/css/mobile-tweaks.css
@@ -3,6 +3,7 @@ html, body {
   overscroll-behavior-y: contain;           /* evita pull-to-refresh em browsers compatíveis */
   -webkit-text-size-adjust: 100%;           /* evita zoom involuntário ao focar inputs */
   background: #f5f7f9;
+  overflow-x:hidden;
 }
 :root {
   --cipt-primary: #0056a0;


### PR DESCRIPTION
## Summary
- Decouple mobile sidebar positioning from `body.mobile` and keep main content flush on small screens
- Block horizontal scrolling on mobile tweaks stylesheet

## Testing
- `node verifySidebar.js` *(sidebar toggle verified on dars.html)*
- `npm test` *(fails: Cannot find module 'express', other missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b99dae0f848333b009d46ec53a73f5