### PR TITLE
Fix viewport settings for public pages

### DIFF
--- a/public/admin/admin-management.html
+++ b/public/admin/admin-management.html
@@ -2,7 +2,7 @@
 <html lang="pt-br">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
     <title>Gestão de Administradores - Painel de Gestão</title>
     
     <link rel="icon" type="image/png" href="/images/logo-cipt.png">

--- a/public/admin/advertencias.html
+++ b/public/admin/advertencias.html
@@ -2,7 +2,7 @@
 <html lang="pt-br">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
   <title>Advertências - CIPT</title>
 
   <link rel="icon" type="image/png" href="/images/logo-cipt.png">

--- a/public/admin/dars.html
+++ b/public/admin/dars.html
@@ -2,7 +2,7 @@
 <html lang="pt-br">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
   <title>Gestão de DARs - Painel de Gestão</title>
 
   <link rel="icon" type="image/png" href="/images/logo-cipt.png">

--- a/public/admin/dashboard.html
+++ b/public/admin/dashboard.html
@@ -2,7 +2,7 @@
 <html lang="pt-br">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
     <title>Dashboard - Painel de Gestão</title>
     
     <link rel="icon" type="image/png" href="/images/logo-cipt.png">

--- a/public/admin/definir-senha.html
+++ b/public/admin/definir-senha.html
@@ -2,7 +2,7 @@
 <html lang="pt-br">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
     <title>Definir Nova Senha - Gestão CIPT</title>
     <link rel="icon" type="image/png" href="/images/logo-cipt.png">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">

--- a/public/admin/eventos-clientes.html
+++ b/public/admin/eventos-clientes.html
@@ -2,7 +2,7 @@
 <html lang="pt-br">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
   <title>Clientes de Eventos - Painel de Gestão</title>
 
   <link rel="icon" type="image/png" href="/images/logo-cipt.png">

--- a/public/admin/eventos-dars.html
+++ b/public/admin/eventos-dars.html
@@ -2,7 +2,7 @@
 <html lang="pt-br">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
   <title>Gestão de DARs de Eventos - CIPT</title>
   
   <link rel="icon" type="image/png" href="/images/logo-cipt.png">

--- a/public/admin/eventos-remarcacoes.html
+++ b/public/admin/eventos-remarcacoes.html
@@ -2,7 +2,7 @@
 <html lang="pt-br">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
   <title>Remarcações de Eventos - CIPT</title>
 
   <link rel="icon" type="image/png" href="/images/logo-cipt.png">

--- a/public/admin/permissionario-form.html
+++ b/public/admin/permissionario-form.html
@@ -2,7 +2,7 @@
 <html lang="pt-br">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
     <title id="pageTitle">Dados do Permissionário - Painel de Gestão</title>
 
     <link rel="icon" type="image/png" href="/images/logo-cipt.png">

--- a/public/admin/permissionarios.html
+++ b/public/admin/permissionarios.html
@@ -2,7 +2,7 @@
 <html lang="pt-br">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
     <title>Permissionários - Painel de Gestão</title>
     
     <link rel="icon" type="image/png" href="/images/logo-cipt.png">

--- a/public/admin/relatorios.html
+++ b/public/admin/relatorios.html
@@ -2,7 +2,7 @@
 <html lang="pt-br">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
     <title>Relatórios - Painel de Gestão</title>
 
     <link rel="icon" type="image/png" href="/images/logo-cipt.png">

--- a/public/admin/salas.html
+++ b/public/admin/salas.html
@@ -2,7 +2,7 @@
 <html lang="pt-br">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
     <title>Salas de Reunião - Painel de Gestão</title>
 
     <link rel="icon" type="image/png" href="/images/logo-cipt.png">

--- a/public/admin/solicitar-redefinicao.html
+++ b/public/admin/solicitar-redefinicao.html
@@ -2,7 +2,7 @@
 <html lang="pt-br">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
     <title>Redefinir Senha - Gestão CIPT</title>
     
     <link rel="icon" type="image/png" href="/images/logo-cipt.png">

--- a/public/advertencias.html
+++ b/public/advertencias.html
@@ -2,7 +2,7 @@
 <html lang="pt-br">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
   <title>Advertências - Portal do Permissionário</title>
 
   <link rel="icon" type="image/png" href="/images/logo-cipt.png">

--- a/public/consultar-email-cadastrado.html
+++ b/public/consultar-email-cadastrado.html
@@ -2,7 +2,7 @@
 <html lang="pt-br">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
     <title>Consultar E-mail Cadastrado - Portal CIPT</title>
     <link rel="icon" type="image/png" href="/images/logo-cipt.png">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">

--- a/public/dars.html
+++ b/public/dars.html
@@ -2,7 +2,7 @@
 <html lang="pt-br">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
     <title>Meus DAR's - Portal do Permissionário</title>
     
     <link rel="icon" type="image/png" href="/images/logo-cipt.png">

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -2,7 +2,7 @@
 <html lang="pt-br">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
     <title>Painel - Portal do Permissionário</title>
     
     <link rel="icon" type="image/png" href="/images/logo-cipt.png">

--- a/public/definir-senha-evento.html
+++ b/public/definir-senha-evento.html
@@ -2,7 +2,7 @@
 <html lang="pt-br">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
     <title>Definir Senha - Portal de Eventos</title>
     <link rel="icon" type="image/png" href="/images/logo-cipt.png">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">

--- a/public/definir-senha.html
+++ b/public/definir-senha.html
@@ -2,7 +2,7 @@
 <html lang="pt-br">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
     <title>Definir Nova Senha - Gestão CIPT</title>
     
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">

--- a/public/eventos/dashboard-eventos.html
+++ b/public/eventos/dashboard-eventos.html
@@ -2,7 +2,7 @@
 <html lang="pt-br">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
   <title>Painel - Cliente de Eventos</title>
 
   <link rel="icon" type="image/png" href="/images/logo-cipt.png">

--- a/public/eventos/meus-eventos.html
+++ b/public/eventos/meus-eventos.html
@@ -2,7 +2,7 @@
 <html lang="pt-br">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
   <title>Meus Eventos - Portal de Eventos</title>
 
   <link rel="icon" type="image/png" href="/images/logo-cipt.png">

--- a/public/eventos/perfil.html
+++ b/public/eventos/perfil.html
@@ -2,7 +2,7 @@
 <html lang="pt-br">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
   <title>Meu Perfil - Portal de Eventos</title>
   
   <link rel="icon" type="image/png" href="/images/logo-cipt.png">

--- a/public/eventos/solicitar-redefinicao-evento.html
+++ b/public/eventos/solicitar-redefinicao-evento.html
@@ -2,7 +2,7 @@
 <html lang="pt-br">
 <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
     <title>Redefinir Senha - Portal de Eventos</title>
 
     <link rel="icon" type="image/png" href="/images/logo-cipt.png">

--- a/public/eventos/termo.html
+++ b/public/eventos/termo.html
@@ -2,6 +2,7 @@
 <html lang="pt-br">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
   <title>Termo do Evento</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>

--- a/public/perfil.html
+++ b/public/perfil.html
@@ -2,7 +2,7 @@
 <html lang="pt-br">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
     <title>Meu Perfil - Portal do Permissionário</title>
     
     <link rel="icon" type="image/png" href="/images/logo-cipt.png">

--- a/public/permissionarios/certidao.html
+++ b/public/permissionarios/certidao.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <title>Certidão de Quitação • Portal do Permissionário</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
 
   <link rel="icon" type="image/png" href="/images/logo-cipt.png">
   <!-- Bootstrap + Icons + Montserrat (igual ao admin) -->

--- a/public/salas.html
+++ b/public/salas.html
@@ -2,7 +2,7 @@
 <html lang="pt-br">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
     <title>Salas de Reunião - Portal do Permissionário</title>
 
     <link rel="icon" type="image/png" href="/images/logo-cipt.png">

--- a/public/solicitar-redefinicao.html
+++ b/public/solicitar-redefinicao.html
@@ -2,7 +2,7 @@
 <html lang="pt-br">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
     <title>Redefinir Senha - Gestão CIPT</title>
     
     <link rel="icon" type="image/png" href="/images/logo-cipt.png">

--- a/public/termo-permisao.html
+++ b/public/termo-permisao.html
@@ -2,6 +2,7 @@
 <html lang="pt-BR">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
   <title>Termo de Permissão de Uso</title>
 
   <style>

--- a/public/verificar-codigo.html
+++ b/public/verificar-codigo.html
@@ -2,7 +2,7 @@
 <html lang="pt-br">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
     <title>Verificar Código - Gestão CIPT</title>
     
     <link rel="icon" type="image/png" href="/images/logo-cipt.png">

--- a/public/verificar-token.html
+++ b/public/verificar-token.html
@@ -2,7 +2,7 @@
 <html lang="pt-br">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
     <title>Verificar Documento - Gestão CIPT</title>
 
     <link rel="icon" type="image/png" href="/images/logo-cipt.png">


### PR DESCRIPTION
## Summary
- prevent mobile zoom by standardizing `<meta name="viewport">` across public pages
- add missing viewport tags where absent

## Testing
- `npm test` *(fails: SyntaxError in adminAdvertenciasRoutes.test.js and database errors in other tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a0a1f1548333ab3f97975f76c800