### PR TITLE
fix(admin-salas): hide cancelled reservations

### DIFF
--- a/public/js/admin-salas.js
+++ b/public/js/admin-salas.js
@@ -59,12 +59,14 @@ async function fetchReservas(fetchInfo, successCallback, failureCallback) {
     const resp = await fetch(`/api/admin/salas/reservas?${params.toString()}`);
     if (!resp.ok) throw new Error('Falha ao carregar reservas');
     const dados = await resp.json();
-    const eventos = dados.map(r => ({
-      id: r.id,
-      title: r.sala_nome,
-      start: r.inicio,
-      end: r.fim
-    }));
+    const eventos = dados
+      .filter(r => r.status !== 'cancelada')
+      .map(r => ({
+        id: r.id,
+        title: r.sala_nome,
+        start: r.inicio,
+        end: r.fim
+      }));
     successCallback(eventos);
   } catch (err) {
     console.error(err);
@@ -83,6 +85,7 @@ async function cancelarReserva() {
     const resp = await fetch(`/api/admin/salas/reservas/${eventoSelecionado.id}`, { method: 'DELETE' });
     if (!resp.ok) throw new Error('Falha ao cancelar reserva');
     eventoSelecionado.remove();
+    window._salasCalendar.refetchEvents();
     mostrarMensagem('Reserva cancelada com sucesso', 'success');
   } catch (err) {
     console.error(err);

--- a/src/api/adminSalasRoutes.js
+++ b/src/api/adminSalasRoutes.js
@@ -37,7 +37,7 @@ router.get(
         SELECT r.*, s.numero AS sala_nome
           FROM reservas_salas r
           JOIN salas_reuniao s ON s.id = r.sala_id
-         WHERE 1=1`;
+         WHERE 1=1 AND r.status != 'cancelada'`;
       const params = [];
 
       if (salaId) {


### PR DESCRIPTION
## Summary
- ignore cancelled reservations on admin room list
- refresh calendar events after cancelling

## Testing
- `npm test` *(fails: 5 passed, 22 failed)*
- `node - <<'NODE'...NODE`

------
https://chatgpt.com/codex/tasks/task_e_68b9a4ef72f88333b935d22b753a993f