### PR TITLE
Exibir período das reservas com formato de hora brasileiro

### DIFF
--- a/public/js/admin-salas.js
+++ b/public/js/admin-salas.js
@@ -13,6 +13,12 @@ document.addEventListener('DOMContentLoaded', () => {
       locale: 'pt-br',
       editable: true,
       themeSystem: 'bootstrap5',
+      displayEventEnd: true,
+      eventTimeFormat: {
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false
+      },
       eventSources: [fetchReservas],
       eventClick: onEventClick,
       eventDrop: onEventChange,
@@ -49,6 +55,13 @@ document.addEventListener('DOMContentLoaded', () => {
   carregarSalas();
 });
 
+function formatRange(inicio, fim) {
+  const opcoes = { hour: '2-digit', minute: '2-digit', hour12: false };
+  const ini = new Date(inicio).toLocaleTimeString('pt-BR', opcoes);
+  const f = new Date(fim).toLocaleTimeString('pt-BR', opcoes);
+  return `${ini} - ${f}`;
+}
+
 async function fetchReservas(fetchInfo, successCallback, failureCallback) {
   try {
     const params = new URLSearchParams({
@@ -63,7 +76,7 @@ async function fetchReservas(fetchInfo, successCallback, failureCallback) {
       .filter(r => r.status !== 'cancelada')
       .map(r => ({
         id: r.id,
-        title: r.sala_nome,
+        title: `${r.sala_nome}: ${formatRange(r.inicio, r.fim)}`,
         start: r.inicio,
         end: r.fim
       }));


### PR DESCRIPTION
## Summary
- Mostrar horário de término e usar formato 24h no calendário de reservas
- Incluir faixa de horas no título dos eventos de sala

## Testing
- `npm test` *(falhou: Cannot find module 'sqlite3', fail 11)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c7db924083338452bb233425fd96