### PR TITLE
Add script to backfill client addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,17 @@ Para registrar uma advertência:
    - Indique o número de **dias para recurso**.
 
 Após o envio, as sanções previstas para as cláusulas selecionadas serão aplicadas, incluindo a cobrança da multa e a inaptidão a partir da data informada.
+
+## Backfill de endereços de clientes
+
+Preenche automaticamente os campos de endereço nas tabelas `Clientes_Eventos` e `Clientes` a partir do CEP.
+
+```bash
+# execução direta
+node scripts/backfillClienteEnderecos.js
+
+# via npm
+npm run backfill-clientes-enderecos
+```
+
+O script consulta a API de CEP e atualiza apenas registros sem logradouro preenchido. Ele pode ser reexecutado com segurança e, se desejado, agendado periodicamente via `cron` ou ferramenta similar.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "main": "index.js",
   "scripts": {
     "start": "node src/index.js",
-    "test": "node --test"
+    "test": "node --test",
+    "backfill-clientes-enderecos": "node scripts/backfillClienteEnderecos.js"
   },
   "dependencies": {
     "@google-cloud/storage": "^7.16.0",

--- a/scripts/backfillClienteEnderecos.js
+++ b/scripts/backfillClienteEnderecos.js
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/**
+ * Preenche campos de endereço (logradouro/bairro/cidade/uf) nas tabelas
+ * `Clientes_Eventos` e `Clientes` usando o CEP informado.
+ * Seleciona apenas registros sem logradouro e com CEP válido.
+ *
+ * Uso:
+ *   node scripts/backfillClienteEnderecos.js
+ *
+ * É seguro reexecutar: registros já preenchidos serão ignorados.
+ */
+
+const path = require('path');
+try {
+  require('dotenv').config({ path: path.resolve(__dirname, '../.env') });
+} catch {}
+const sqlite3 = require('sqlite3').verbose();
+const { fetchCepAddress } = require('../src/services/cepLookupService');
+
+const DB_PATH = process.env.SQLITE_STORAGE
+  ? path.resolve(process.env.SQLITE_STORAGE)
+  : path.resolve(__dirname, '../sistemacipt.db');
+
+const db = new sqlite3.Database(DB_PATH);
+
+const qAll = (sql, params = []) => new Promise((resolve, reject) => {
+  db.all(sql, params, (err, rows) => (err ? reject(err) : resolve(rows || [])));
+});
+const qRun = (sql, params = []) => new Promise((resolve, reject) => {
+  db.run(sql, params, function (err) {
+    if (err) return reject(err);
+    resolve(this);
+  });
+});
+
+async function backfill(table) {
+  const cols = await qAll(`PRAGMA table_info('${table}')`);
+  const has = name => cols.some(c => c.name === name);
+  const cidadeCol = has('cidade') ? 'cidade' : (has('localidade') ? 'localidade' : null);
+
+  const rows = await qAll(
+    `SELECT id, cep FROM ${table} WHERE (cep IS NOT NULL AND TRIM(cep) <> '') AND (logradouro IS NULL OR TRIM(logradouro) = '')`
+  );
+  console.log(`[INFO] ${table}: ${rows.length} registros candidatos`);
+
+  let ok = 0, fail = 0;
+  for (const r of rows) {
+    try {
+      const addr = await fetchCepAddress(r.cep);
+      const setParts = [];
+      const params = [];
+      if (has('logradouro')) { setParts.push('logradouro = ?'); params.push(addr.logradouro || null); }
+      if (has('bairro')) { setParts.push('bairro = ?'); params.push(addr.bairro || null); }
+      if (cidadeCol) { setParts.push(`${cidadeCol} = ?`); params.push(addr.localidade || null); }
+      if (has('uf')) { setParts.push('uf = ?'); params.push(addr.uf || null); }
+      if (has('endereco')) { setParts.push('endereco = COALESCE(endereco, ?)'); params.push(addr.logradouro || null); }
+      if (setParts.length === 0) continue;
+      params.push(r.id);
+      const sql = `UPDATE ${table} SET ${setParts.join(', ')} WHERE id = ?`;
+      await qRun(sql, params);
+      ok++;
+    } catch (e) {
+      console.error(`[ERRO] ${table} id=${r.id} cep=${r.cep}: ${e.message}`);
+      fail++;
+    }
+  }
+  console.log(`[RESUMO] ${table}: atualizados=${ok} falhas=${fail}`);
+  return { ok, fail };
+}
+
+(async () => {
+  try {
+    const a = await backfill('Clientes_Eventos');
+    const b = await backfill('Clientes');
+    console.log(`[DONE] totalAtualizados=${a.ok + b.ok} totalFalhas=${a.fail + b.fail}`);
+  } catch (err) {
+    console.error('Erro geral:', err.message);
+  } finally {
+    db.close();
+  }
+})();


### PR DESCRIPTION
## Summary
- add backfillClienteEnderecos script to populate client and event addresses via CEP lookup
- document script usage and npm shortcut in README
- expose npm run command for address backfill

## Testing
- `npm test` *(fails: MODULE_NOT_FOUND: Cannot find module 'sqlite3')*


------
https://chatgpt.com/codex/tasks/task_e_68b9d0ea0c8c83339032cbd59d60c3e7