### PR TITLE
Hide last DAR chart on desktop

### DIFF
--- a/public/css/mobile-tweaks.css
+++ b/public/css/mobile-tweaks.css
@@ -178,3 +178,6 @@ input, select, textarea, button { font-size: 16px; }
   width: 100%;
   max-width: 100%;
 }
+
+#lastDarCard { display: none; }
+body.mobile #lastDarCard { display: block; }

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -98,7 +98,7 @@
                     </div>
                 </div>
 
-                <div class="card">
+                <div id="lastDarCard" class="card">
                     <div class="card-body p-4">
                         <h5 class="card-title">MEU ÚLTIMO DAR</h5>
                         <hr>
@@ -200,9 +200,14 @@
             try {
                 await Promise.all([
                     fetchUserData(),
-                    fetchDashboardStats(),
-                    renderLastDarChart()
+                    fetchDashboardStats()
                 ]);
+
+                if (window.__isMobile && window.__isMobile()) {
+                    await renderLastDarChart();
+                } else {
+                    document.getElementById('lastDarCard').style.display = 'none';
+                }
             } catch (error) {
                 console.error('Erro ao carregar dados do dashboard:', error);
                 localStorage.removeItem('authToken');


### PR DESCRIPTION
## Summary
- Give the Last DAR card an id for DOM access
- Hide the card by default and show only on mobile via CSS
- Render the Last DAR chart only on mobile clients

## Testing
- `npm test` *(fails: tests 63, pass 59, fail 4)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d328f754833394cba7d827fba8ac