### PR TITLE
Show monthly DAR chart on mobile and table on desktop

### DIFF
--- a/public/admin/dashboard.html
+++ b/public/admin/dashboard.html
@@ -80,6 +80,7 @@
                                 <hr>
                                 <div class="chart-container">
                                     <canvas id="resumoMensalChart" class="w-100 h-100"></canvas>
+                                    <table id="resumoMensalTable" class="table table-striped table-sm"></table>
                                 </div>
                             </div>
                         </div>
@@ -187,6 +188,23 @@ window.onload = async () => {
         }
       });
 
+      const resumoTable = document.getElementById('resumoMensalTable');
+      resumoTable.innerHTML = `
+        <thead>
+          <tr><th>Mês</th><th>Emitidas</th><th>Pagas</th><th>Vencidas</th></tr>
+        </thead>
+        <tbody>
+          ${resumoMensal.map((item, idx) => `
+            <tr>
+              <td>${labels[idx]}</td>
+              <td>${emitidas[idx].toLocaleString('pt-BR')}</td>
+              <td>${pagas[idx].toLocaleString('pt-BR')}</td>
+              <td>${vencidas[idx].toLocaleString('pt-BR')}</td>
+            </tr>
+          `).join('')}
+        </tbody>
+      `;
+
       const devedoresList = document.getElementById('maiores-devedores-list');
       if (stats.maioresDevedores && stats.maioresDevedores.length > 0) {
         const lista = (stats.maioresDevedores || []).filter(item => Number(item.total_vencido ?? item.total_devido ?? 0) > 0);
@@ -211,6 +229,10 @@ window.onload = async () => {
   };
 
   await fetchStats();
+
+  const isMobile = window.__isMobile && window.__isMobile();
+  document.getElementById('resumoMensalChart').style.display = isMobile ? 'block' : 'none';
+  document.getElementById('resumoMensalTable').style.display = isMobile ? 'none' : 'table';
 
   document.getElementById('dars-filter').addEventListener('change', (e) => fetchStats(e.target.value));
 };

--- a/public/css/mobile-tweaks.css
+++ b/public/css/mobile-tweaks.css
@@ -181,3 +181,6 @@ input, select, textarea, button { font-size: 16px; }
 
 #lastDarCard { display: none; }
 body.mobile #lastDarCard { display: block; }
+
+body.mobile #resumoMensalTable { display: none; }
+body:not(.mobile) #resumoMensalChart { display: none; }


### PR DESCRIPTION
## Summary
- add monthly summary table after chart in dashboard
- hide table on mobile and chart on desktop
- populate table with fetched resumoMensal data

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68b9d77fd14c8333828e2da207cfcf09