### PR TITLE
Log stack traces and bubble up server errors

### DIFF
--- a/public/js/gerar-oficio.js
+++ b/public/js/gerar-oficio.js
@@ -45,10 +45,9 @@
         const text = await res.text();
         try {
           const data = JSON.parse(text);
-          throw new Error(data.error || `Erro ${res.status} ao gerar ofício`);
+          throw new Error(data.error || `Erro ${res.status} ao gerar ofício.`);
         } catch {
-          // provavelmente HTML (ex.: login); evita "Unexpected token <"
-          throw new Error('Falha ao gerar ofício (possível sessão expirada ou erro no servidor).');
+          throw new Error(text || `Erro ${res.status} ao gerar ofício.`);
         }
       }
 
@@ -60,7 +59,7 @@
           const data = JSON.parse(text);
           throw new Error(data.error || 'Resposta inesperada (não-PDF).');
         } catch {
-          throw new Error('Resposta não é PDF (possível redirecionamento para login).');
+          throw new Error(text || 'Resposta inesperada (não-PDF).');
         }
       }
 

--- a/public/permissionarios/certidao.html
+++ b/public/permissionarios/certidao.html
@@ -177,25 +177,17 @@
         }
 
         if(!res.ok){
-          // tenta ler JSON de erro; se vier HTML, cai no catch
+          // tenta ler JSON de erro; se vier HTML, usa texto bruto
           const text = await res.text();
           try{
             const data = JSON.parse(text);
             throw new Error(data.error || `Erro ${res.status} ao gerar certidão.`);
           }catch{
-            throw new Error('Falha ao gerar certidão. Possível sessão expirada ou erro no servidor.');
+            throw new Error(text || `Erro ${res.status} ao gerar certidão.`);
           }
         }
 
       const ct = res.headers.get('content-type') || '';
-      if(!res.ok){
-        if(ct.includes('application/json')){
-          const data = await res.json();
-          throw new Error(`(${res.status}) ${data.error || 'Erro ao gerar certidão.'}`);
-        }
-        const text = await res.text();
-        throw new Error(`(${res.status}) ${text || 'Erro ao gerar certidão.'}`);
-      }
 
       if(!ct.includes('application/pdf')){
         // Se veio HTML (ex.: redirect login), trata como erro

--- a/src/api/adminOficiosRoutes.js
+++ b/src/api/adminOficiosRoutes.js
@@ -245,8 +245,8 @@ router.get(
         ['OFICIO', '', tokenDoc]
       );
     } catch (err) {
-      console.error('[adminOficios] erro:', err);
-      res.status(500).json({ error: 'Erro ao gerar ofício.' });
+      console.error('[adminOficios] erro:', err.stack || err);
+      res.status(500).json({ error: err.message || 'Erro ao gerar ofício.' });
     }
   }
 );

--- a/src/api/permissionariosRoutes.js
+++ b/src/api/permissionariosRoutes.js
@@ -245,12 +245,12 @@ router.get('/:id/certidao', authMiddleware, async (req, res) => {
       );
     }
 
-    // Finaliza
-    doc.end();
-  } catch (err) {
-    console.error('[permissionarios/certidao] erro:', err);
-    res.status(500).json({ error: 'Erro ao gerar certidão.' });
-  }
+  // Finaliza
+  doc.end();
+} catch (err) {
+    console.error('[permissionarios/certidao] erro:', err.stack || err);
+    res.status(500).json({ error: err.message || 'Erro ao gerar certidão.' });
+}
 });
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- Log full stack traces in adminOficios and permissionarios routes and return error messages to clients
- Surface backend error messages in gerar-oficio and certidao front-end handlers

## Testing
- `npm test` *(fails: tests 63, pass 58, fail 5)*

------
https://chatgpt.com/codex/tasks/task_e_68b9decc9ca48333a9b1f803e4d68cbc