### PR TITLE
Log report errors and surface backend messages in admin reports UI

### DIFF
--- a/public/js/admin-relatorios.js
+++ b/public/js/admin-relatorios.js
@@ -20,14 +20,17 @@ window.addEventListener('DOMContentLoaded', () => {
       toggleLoading(btnDevedores, true);
       try {
         const resp = await fetch('/api/admin/relatorios/devedores');
-        if (!resp.ok) throw new Error('Falha ao gerar relatório');
+        if (!resp.ok) {
+          const errData = await resp.json().catch(() => ({}));
+          throw new Error(errData.error || 'Erro ao gerar relatório de devedores.');
+        }
         const blob = await resp.blob();
         const url = URL.createObjectURL(blob);
         window.open(url, '_blank');
         setTimeout(() => URL.revokeObjectURL(url), 1000);
       } catch (err) {
         console.error(err);
-        alert('Erro ao gerar relatório de devedores.');
+        alert(err.message);
       } finally {
         toggleLoading(btnDevedores, false);
       }
@@ -44,14 +47,17 @@ window.addEventListener('DOMContentLoaded', () => {
           alert('Nenhuma DAR encontrada.');
           return;
         }
-        if (!resp.ok) throw new Error('Falha ao gerar relatório');
+        if (!resp.ok) {
+          const errData = await resp.json().catch(() => ({}));
+          throw new Error(errData.error || 'Erro ao gerar relatório de DARs.');
+        }
         const blob = await resp.blob();
         const url = URL.createObjectURL(blob);
         window.open(url, '_blank');
         setTimeout(() => URL.revokeObjectURL(url), 1000);
       } catch (err) {
         console.error(err);
-        alert('Erro ao gerar relatório de DARs.');
+        alert(err.message);
       } finally {
         toggleLoading(btnDars, false);
       }
@@ -74,14 +80,17 @@ window.addEventListener('DOMContentLoaded', () => {
           alert('Nenhuma DAR encontrada.');
           return;
         }
-        if (!resp.ok) throw new Error('Falha ao gerar relatório');
+        if (!resp.ok) {
+          const errData = await resp.json().catch(() => ({}));
+          throw new Error(errData.error || 'Erro ao gerar relatório de DARs de eventos.');
+        }
         const blob = await resp.blob();
         const url = URL.createObjectURL(blob);
         window.open(url, '_blank');
         setTimeout(() => URL.revokeObjectURL(url), 1000);
       } catch (err) {
         console.error(err);
-        alert('Erro ao gerar relatório de DARs de eventos.');
+        alert(err.message);
       } finally {
         toggleLoading(btnEventosDars, false);
       }
@@ -115,8 +124,8 @@ window.addEventListener('DOMContentLoaded', () => {
       toggleLoading(btnPagamentos, true);
       try {
         const resp = await fetch(`/api/admin/relatorios/pagamentos?mes=${mes}&ano=${ano}`);
-        if (!resp.ok) throw new Error('Falha ao buscar relatório');
         const dados = await resp.json();
+        if (!resp.ok) throw new Error(dados.error || 'Erro ao buscar relatório de pagamentos.');
 
         dados.pagos.forEach((item) => {
           const tr = document.createElement('tr');
@@ -133,7 +142,7 @@ window.addEventListener('DOMContentLoaded', () => {
         if (dados.devedores.length) secaoDevedores.style.display = 'block';
       } catch (err) {
         console.error(err);
-        alert('Erro ao buscar relatório de pagamentos.');
+        alert(err.message);
       } finally {
         toggleLoading(btnPagamentos, false);
       }

--- a/src/api/adminRoutes.js
+++ b/src/api/adminRoutes.js
@@ -502,8 +502,8 @@ router.get(
 
       res.status(200).json({ pagos, devedores });
     } catch (error) {
-      console.error('Erro ao gerar relatório de pagamentos:', error);
-      res.status(500).json({ error: 'Erro ao gerar relatório de pagamentos.' });
+      console.error('Erro ao gerar relatório de pagamentos:', error.stack);
+      res.status(500).json({ error: error.message || 'Erro ao gerar relatório.' });
     }
   }
 );
@@ -596,8 +596,8 @@ router.get(
         });
       });
     } catch (error) {
-      console.error('Erro ao gerar relatório devedores:', error);
-      res.status(500).json({ error: 'Erro ao gerar o relatório de devedores.' });
+      console.error('Erro ao gerar relatório devedores:', error.stack);
+      res.status(500).json({ error: error.message || 'Erro ao gerar relatório.' });
     }
   }
 );
@@ -689,8 +689,8 @@ router.get(
         });
       });
     } catch (error) {
-      console.error('Erro ao gerar relatório de DARs:', error);
-      res.status(500).json({ error: 'Erro ao gerar o relatório de DARs.' });
+      console.error('Erro ao gerar relatório de DARs:', error.stack);
+      res.status(500).json({ error: error.message || 'Erro ao gerar relatório.' });
     }
   }
 );
@@ -766,8 +766,8 @@ router.get(
         });
       });
     } catch (error) {
-      console.error('Erro ao gerar relatório de DARs de eventos:', error);
-      res.status(500).json({ error: 'Erro ao gerar o relatório de DARs de eventos.' });
+      console.error('Erro ao gerar relatório de DARs de eventos:', error.stack);
+      res.status(500).json({ error: error.message || 'Erro ao gerar relatório.' });
     }
   }
 );


### PR DESCRIPTION
## Summary
- log full stack traces and return standard error JSON from report routes
- show backend error messages in admin reports UI when requests fail

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68b9e1ac72f48333b3afbd573e8edb37