### PR TITLE
fix: reapply mobile detection after dashboard stats fetch

### DIFF
--- a/public/admin/dashboard.html
+++ b/public/admin/dashboard.html
@@ -221,6 +221,10 @@ window.onload = async () => {
       } else {
         devedoresList.innerHTML = '<li class="list-group-item text-muted text-center">Nenhum devedor encontrado.</li>';
       }
+
+      const isMobile = window.__isMobile && window.__isMobile();
+      document.getElementById('resumoMensalChart').style.display = isMobile ? 'block' : 'none';
+      document.getElementById('resumoMensalTable').style.display = isMobile ? 'none' : 'table';
     } catch (error) {
       console.error('--- ERRO DETALHADO AO CARREGAR DASHBOARD ---');
       console.error(error);
@@ -229,11 +233,6 @@ window.onload = async () => {
   };
 
   await fetchStats();
-
-  const isMobile = window.__isMobile && window.__isMobile();
-  document.getElementById('resumoMensalChart').style.display = isMobile ? 'block' : 'none';
-  document.getElementById('resumoMensalTable').style.display = isMobile ? 'none' : 'table';
-
   document.getElementById('dars-filter').addEventListener('change', (e) => fetchStats(e.target.value));
 };
 </script>


### PR DESCRIPTION
## Summary
- ensure chart/table toggle runs every time `fetchStats` executes by moving mobile detection inside the function
- drop redundant toggle after initial fetch

## Testing
- `npm test` *(fails: 60 passed, 4 failed)*
- `node puppeteer` *(fails: Failed to launch the browser process: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e60b88f08333b44d00857e2547c6