### PR TITLE
Restrict sidebar items for SALAS_ADMIN

### DIFF
--- a/public/admin/admin-sidebar.html
+++ b/public/admin/admin-sidebar.html
@@ -3,10 +3,10 @@
         <a href="/admin/dashboard.html"><img src="/images/painel-gestao.png" alt="Painel de Gestão"></a>
     </div>
     <ul class="nav flex-column sidebar-nav">
-        <li class="nav-item"><a class="nav-link" href="/admin/dashboard.html"><i class="bi bi-grid-1x2-fill"></i>Dashboard</a></li>
-        <li class="nav-item"><a class="nav-link" href="/admin/permissionarios.html"><i class="bi bi-people-fill"></i>Permissionários</a></li>
-        <li class="nav-item"><a class="nav-link" href="/admin/dars.html"><i class="bi bi-file-earmark-text-fill"></i>DARs</a></li>
-        <li class="nav-item menu-dropdown">
+        <li class="nav-item" data-roles="SUPER_ADMIN,FINANCE_ADMIN"><a class="nav-link" href="/admin/dashboard.html"><i class="bi bi-grid-1x2-fill"></i>Dashboard</a></li>
+        <li class="nav-item" data-roles="SUPER_ADMIN,FINANCE_ADMIN,SALAS_ADMIN"><a class="nav-link" href="/admin/permissionarios.html"><i class="bi bi-people-fill"></i>Permissionários</a></li>
+        <li class="nav-item" data-roles="SUPER_ADMIN,FINANCE_ADMIN"><a class="nav-link" href="/admin/dars.html"><i class="bi bi-file-earmark-text-fill"></i>DARs</a></li>
+        <li class="nav-item menu-dropdown" data-roles="SUPER_ADMIN,FINANCE_ADMIN">
             <a class="nav-link" href="#"><i class="bi bi-calendar-event-fill"></i>Eventos</a>
             <ul class="submenu" style="list-style: none; padding-left: 20px; display: none;">
                 <li><a class="nav-link" href="/admin/eventos-clientes.html"><i class="bi bi-person-lines-fill"></i>Clientes de Eventos</a></li>
@@ -15,13 +15,13 @@
                 <li><a class="nav-link" href="/admin/advertencias.html"><i class="bi bi-exclamation-triangle-fill"></i>Advertências</a></li>
 </ul>
         </li>
-        <li class="nav-item">
+        <li class="nav-item" data-roles="SUPER_ADMIN,SALAS_ADMIN">
             <a class="nav-link" href="/admin/salas.html">
                 <i class="bi bi-calendar-event"></i>Salas de reunião
             </a>
         </li>
-        <li class="nav-item"><a class="nav-link" href="/admin/relatorios.html"><i class="bi bi-file-earmark-bar-graph"></i>Relatórios</a></li>
-        <li class="nav-item"><a class="nav-link" href="/admin/admin-management.html"><i class="bi bi-person-badge-fill"></i>Administradores</a></li>
+        <li class="nav-item" data-roles="SUPER_ADMIN,FINANCE_ADMIN"><a class="nav-link" href="/admin/relatorios.html"><i class="bi bi-file-earmark-bar-graph"></i>Relatórios</a></li>
+        <li class="nav-item" data-roles="SUPER_ADMIN"><a class="nav-link" href="/admin/admin-management.html"><i class="bi bi-person-badge-fill"></i>Administradores</a></li>
         <li class="nav-item"><a id="logoutButton" class="nav-link" href="#" style="color: #ffc107;"><i class="bi bi-box-arrow-right"></i>Sair</a></li>
     </ul>
     <div class="sidebar-footer"><img src="/images/logo-secti-vertical.png" alt="Logo SECTI"></div>


### PR DESCRIPTION
## Summary
- Decode admin JWT to read role and filter sidebar items
- Mark sidebar links with role attributes and hide unauthorized entries for SALAS_ADMIN

## Testing
- `npm test` *(fails: Cannot find module 'public/js/templates/termoEventoPdfkitServiceContent.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b9e73feec08333b20bfcefd2768ddf