### PR TITLE
Corrige visibilidade da sidebar para administradores de Salas

### DIFF
--- a/public/admin/admin-sidebar.html
+++ b/public/admin/admin-sidebar.html
@@ -3,7 +3,7 @@
         <a href="/admin/dashboard.html"><img src="/images/painel-gestao.png" alt="Painel de Gestão"></a>
     </div>
     <ul class="nav flex-column sidebar-nav">
-        <li class="nav-item" data-roles="SUPER_ADMIN,FINANCE_ADMIN"><a class="nav-link" href="/admin/dashboard.html"><i class="bi bi-grid-1x2-fill"></i>Dashboard</a></li>
+        <li class="nav-item" data-roles="SUPER_ADMIN,FINANCE_ADMIN,SALAS_ADMIN"><a class="nav-link" href="/admin/dashboard.html"><i class="bi bi-grid-1x2-fill"></i>Dashboard</a></li>
         <li class="nav-item" data-roles="SUPER_ADMIN,FINANCE_ADMIN,SALAS_ADMIN"><a class="nav-link" href="/admin/permissionarios.html"><i class="bi bi-people-fill"></i>Permissionários</a></li>
         <li class="nav-item" data-roles="SUPER_ADMIN,FINANCE_ADMIN"><a class="nav-link" href="/admin/dars.html"><i class="bi bi-file-earmark-text-fill"></i>DARs</a></li>
         <li class="nav-item menu-dropdown" data-roles="SUPER_ADMIN,FINANCE_ADMIN">

--- a/public/js/admin-sidebar.js
+++ b/public/js/admin-sidebar.js
@@ -55,6 +55,7 @@ function applyRoleToSidebar(role) {
     // fallback específico para SALAS_ADMIN usando href/classes
     if (role === 'SALAS_ADMIN') {
         const allowedSelectors = [
+            '.nav-link[href*="dashboard.html"]',
             '.nav-link[href*="permissionarios.html"]',
             '.nav-link[href*="salas.html"]',
             '#logoutButton'


### PR DESCRIPTION
## Summary
- Exibe o item Dashboard no menu lateral para usuários SALAS_ADMIN
- Restringe o menu lateral de SALAS_ADMIN apenas a Dashboard, Permissionários e Salas de Reunião

## Testing
- `npm test` *(falhou: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68b9f850d4f0833382524c2191c654b7