### PR TITLE
Corrige visibilidade da sidebar para administradores de Salas

### DIFF
--- a/public/admin/admin-sidebar.html
+++ b/public/admin/admin-sidebar.html
@@ -3,7 +3,7 @@
         <a href="/admin/dashboard.html"><img src="/images/painel-gestao.png" alt="Painel de Gestão"></a>
     </div>
     <ul class="nav flex-column sidebar-nav">
-        <li class="nav-item" data-roles="SUPER_ADMIN,FINANCE_ADMIN"><a class="nav-link" href="/admin/dashboard.html"><i class="bi bi-grid-1x2-fill"></i>Dashboard</a></li>
+        <li class="nav-item" data-roles="SUPER_ADMIN,FINANCE_ADMIN,SALAS_ADMIN"><a class="nav-link" href="/admin/dashboard.html"><i class="bi bi-grid-1x2-fill"></i>Dashboard</a></li>
         <li class="nav-item" data-roles="SUPER_ADMIN,FINANCE_ADMIN,SALAS_ADMIN"><a class="nav-link" href="/admin/permissionarios.html"><i class="bi bi-people-fill"></i>Permissionários</a></li>
         <li class="nav-item" data-roles="SUPER_ADMIN,FINANCE_ADMIN"><a class="nav-link" href="/admin/dars.html"><i class="bi bi-file-earmark-text-fill"></i>DARs</a></li>
         <li class="nav-item menu-dropdown" data-roles="SUPER_ADMIN,FINANCE_ADMIN">

--- a/public/js/admin-sidebar.js
+++ b/public/js/admin-sidebar.js
@@ -33,7 +33,9 @@ document.addEventListener('DOMContentLoaded', () => {
 function decodeRoleFromToken(token) {
     if (!token) return null;
     try {
-        const payload = JSON.parse(atob(token.split('.')[1]));
+        const base64Url = token.split('.')[1] || '';
+        const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/').padEnd(Math.ceil(base64Url.length / 4) * 4, '=');
+        const payload = JSON.parse(atob(base64));
         return payload.role;
     } catch (err) {
         console.error('Erro ao decodificar token:', err);
@@ -55,6 +57,7 @@ function applyRoleToSidebar(role) {
     // fallback específico para SALAS_ADMIN usando href/classes
     if (role === 'SALAS_ADMIN') {
         const allowedSelectors = [
+            '.nav-link[href*="dashboard.html"]',
             '.nav-link[href*="permissionarios.html"]',
             '.nav-link[href*="salas.html"]',
             '#logoutButton'

--- a/src/api/adminRoutes.js
+++ b/src/api/adminRoutes.js
@@ -186,7 +186,7 @@ router.get(
 // GET /api/admin/permissionarios
 router.get(
   '/permissionarios',
-  [authMiddleware, authorizeRole(['SUPER_ADMIN', 'FINANCE_ADMIN'])],
+  [authMiddleware, authorizeRole(['SUPER_ADMIN', 'FINANCE_ADMIN', 'SALAS_ADMIN'])],
   async (req, res) => {
     try {
       const { search = '', page = 1, limit = 10 } = req.query;
@@ -230,7 +230,7 @@ router.get(
 // GET /api/admin/permissionarios/:id
 router.get(
   '/permissionarios/:id',
-  [authMiddleware, authorizeRole(['SUPER_ADMIN', 'FINANCE_ADMIN'])],
+  [authMiddleware, authorizeRole(['SUPER_ADMIN', 'FINANCE_ADMIN', 'SALAS_ADMIN'])],
   async (req, res) => {
     try {
       const { id } = req.params;
@@ -253,7 +253,7 @@ router.get(
 // PUT /api/admin/permissionarios/:id
 router.put(
   '/permissionarios/:id',
-  [authMiddleware, authorizeRole(['SUPER_ADMIN', 'FINANCE_ADMIN'])],
+  [authMiddleware, authorizeRole(['SUPER_ADMIN', 'FINANCE_ADMIN', 'SALAS_ADMIN'])],
   async (req, res) => {
     const { id } = req.params;
     const {
@@ -305,7 +305,7 @@ router.put(
 // POST /api/admin/permissionarios
 router.post(
   '/permissionarios',
-  [authMiddleware, authorizeRole(['SUPER_ADMIN', 'FINANCE_ADMIN'])],
+  [authMiddleware, authorizeRole(['SUPER_ADMIN', 'FINANCE_ADMIN', 'SALAS_ADMIN'])],
   async (req, res) => {
     const {
       nome_empresa,
@@ -363,7 +363,7 @@ router.post(
    =========================================================== */
 router.get(
   '/permissionarios/export/:format',
-  [authMiddleware, authorizeRole(['SUPER_ADMIN', 'FINANCE_ADMIN'])],
+  [authMiddleware, authorizeRole(['SUPER_ADMIN', 'FINANCE_ADMIN', 'SALAS_ADMIN'])],
   async (req, res) => {
     try {
       const { format } = req.params;


### PR DESCRIPTION
## Summary
- Exibe o item Dashboard no menu lateral para usuários SALAS_ADMIN
- Restringe o menu lateral de SALAS_ADMIN apenas a Dashboard, Permissionários e Salas de Reunião
- Decodifica tokens JWT em base64url para determinar a role corretamente
- Autoriza SALAS_ADMIN nas rotas de Permissionários

## Testing
- `npm test` *(falhou: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68b9f850d4f0833382524c2191c654b7