### PR TITLE
fix: ajustar cálculo de atraso na cobrança

### DIFF
--- a/src/services/cobrancaService.js
+++ b/src/services/cobrancaService.js
@@ -38,10 +38,12 @@ async function calcularEncargosAtraso(dar) {
     }
 
     const dataVencimentoOriginal = new Date(dar.data_vencimento);
-    
-    const diffTempo = Math.abs(novaDataVencimento - dataVencimentoOriginal);
+
+    // Calcula a diferença de tempo preservando o sinal para identificar atrasos reais
+    const diffTempo = novaDataVencimento - dataVencimentoOriginal;
     const diasAtraso = Math.ceil(diffTempo / (1000 * 60 * 60 * 24));
 
+    // Se a nova data de vencimento for anterior ou igual à original, não há encargos
     if (diasAtraso <= 0) {
         return {
             valorOriginal: dar.valor, multa: 0, juros: 0, diasAtraso: 0,


### PR DESCRIPTION
## Summary
- consider sign when calculating diff between new and original due dates to avoid charging for future dates

## Testing
- `node - <<'NODE'\nconst { calcularEncargosAtraso } = require('./src/services/cobrancaService');\n\n(async () => {\n  const darFuture = {\n    valor: 100,\n    data_vencimento: new Date(Date.now() + 5*24*60*60*1000).toISOString().slice(0,10)\n  };\n  const darPast = {\n    valor: 100,\n    data_vencimento: new Date(Date.now() - 5*24*60*60*1000).toISOString().slice(0,10)\n  };\n  console.log('Future due:', await calcularEncargosAtraso(darFuture));\n  console.log('Past due:', await calcularEncargosAtraso(darPast));\n})();\nNODE`
- `npm test` *(fails: fail 4)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ff86d6f8833383569f8f94676f5e