### PR TITLE
feat: sanitize documento verification response

### DIFF
--- a/public/verificar-token.html
+++ b/public/verificar-token.html
@@ -99,12 +99,13 @@
 
             try {
                 const response = await fetch(`/api/documentos/verify/${encodeURIComponent(token)}`);
-                if (!response.ok) {
-                    throw new Error('Documento inválido ou não encontrado.');
-                }
                 const data = await response.json();
+                if (!response.ok || !data.valid) {
+                    throw new Error(data.message || 'Documento inválido ou não encontrado.');
+                }
+                const { valid, message, ...info } = data;
                 let html = '<h4 class="mb-3">Documento válido</h4><ul class="list-group">';
-                for (const [key, value] of Object.entries(data)) {
+                for (const [key, value] of Object.entries(info)) {
                     html += `<li class="list-group-item d-flex justify-content-between"><strong>${key}</strong><span>${value}</span></li>`;
                 }
                 html += '</ul>';

--- a/tests/adminAdvertenciasRoutes.test.js
+++ b/tests/adminAdvertenciasRoutes.test.js
@@ -148,10 +148,11 @@ test('GET /api/documentos/verify/:token retorna metadados', async () => {
     token TEXT,
     evento_id INTEGER,
     pdf_public_url TEXT,
-    created_at TEXT
+    created_at TEXT,
+    status TEXT
   )`);
 
-  await run(`INSERT INTO documentos (tipo, token, evento_id, pdf_public_url, created_at) VALUES ('advertencia','TOK-VER',10,'/documentos/adv.pdf', datetime('now'))`);
+  await run(`INSERT INTO documentos (tipo, token, evento_id, pdf_public_url, created_at, status) VALUES ('advertencia','TOK-VER',10,'/documentos/adv.pdf', datetime('now'), 'gerado')`);
   const assinafyPath = path.resolve(__dirname, '../src/services/assinafyClient.js');
   require.cache[assinafyPath] = { exports: { uploadPdf: async () => {}, getDocumentStatus: async () => ({}), downloadSignedPdf: async () => Buffer.from('') } };
   const documentosRoutes = require('../src/api/documentosRoutes.js');
@@ -159,8 +160,12 @@ test('GET /api/documentos/verify/:token retorna metadados', async () => {
   app.use('/api/documentos', documentosRoutes);
 
   const res = await supertest(app).get('/api/documentos/verify/TOK-VER').expect(200);
-  assert.equal(res.body.token, 'TOK-VER');
+  assert.equal(res.body.valid, true);
   assert.equal(res.body.tipo, 'advertencia');
+  assert.equal(res.body.tipo_titulo, 'Advertência');
   assert.equal(res.body.pdf_public_url, '/documentos/adv.pdf');
+  assert.equal(res.body.status, 'gerado');
+  assert.ok(res.body.created_at);
+  assert.ok(!('token' in res.body));
 });
 


### PR DESCRIPTION
## Summary
- sanitize /verify token response to expose only essential metadata
- return validity flag and humanized document type title
- document new response shape in verification page and tests

## Testing
- `npm test` *(fails: 4 failed, 60 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0337e9648333b2ff376ebe9bd53b