### PR TITLE
Allow reissue of expired DARs with recalculated charges

### DIFF
--- a/public/dars.html
+++ b/public/dars.html
@@ -327,7 +327,7 @@
                 confirmarEmissaoBtn.innerHTML = `<span class="spinner-border spinner-border-sm"></span> Gerando...`;
                 
                 try {
-                    const response = await fetch(`/api/dars/${darIdParaEmitir}/emitir`, {
+                    const response = await fetch(`/api/dars/${darIdParaEmitir}/emitir?force=1`, {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json', ...headers }
                     });


### PR DESCRIPTION
## Summary
- Recalculate charges for expired DARs and continue SEFAZ emission
- Accept optional force flag and send it from DAR modal confirmation
- Cover expired DAR reissue path with test

## Testing
- `npm test`
- `node --test tests/darsRoutesEmitirVencido.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba047a4bf083339e69e1e3cbc26e5f