### PR TITLE
Check for confirmation before emitting expired DAR

### DIFF
--- a/src/api/darsRoutes.js
+++ b/src/api/darsRoutes.js
@@ -286,11 +286,11 @@ router.post('/:id/emitir', authMiddleware, async (req, res) => {
 
     if (['Vencido', 'Vencida'].includes(dar.status)) {
       const calculo = await calcularEncargosAtraso(dar);
+      if (!forcar) {
+        return res.status(200).json({ darVencido: true, calculo });
+      }
       guiaSource.valor = calculo.valorAtualizado;
-      // se houver nova data de vencimento, utiliza-a
       guiaSource.data_vencimento = calculo.novaDataVencimento || guiaSource.data_vencimento;
-      // anteriormente retornava { darVencido: true }, impedindo a emissão;
-      // agora prossegue normalmente com os valores atualizados.
     }
 
     const payload = buildSefazPayloadPermissionario({ perm, darLike: guiaSource });


### PR DESCRIPTION
## Summary
- Require explicit `force` confirmation before reissuing expired DARs
- Return recalculation info without emission when confirmation missing
- Add regression test for expired DAR emission flow

## Testing
- `node --test tests/darsRoutesEmitirVencido.test.js`
- `npm test` *(fails: 60 passed, 7 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0735dc9c8333b907f987729b4cba