### PR TITLE
feat: add authenticity notice to token footer

### DIFF
--- a/src/api/adminOficiosRoutes.js
+++ b/src/api/adminOficiosRoutes.js
@@ -26,20 +26,29 @@ const dbRun = (sql, params = []) =>
 /* ========= Util: imprime token sem mexer no cursor do conteúdo ========= */
 async function printToken(doc, token) {
   if (!token) return;
-  const prevX = doc.x, prevY = doc.y;   // preserva cursor do conteúdo
+  const prevX = doc.x, prevY = doc.y; // preserva cursor do conteúdo
   doc.save();
   const x = doc.page.margins.left;
-  const y = doc.page.height - doc.page.margins.bottom - 10; // dentro da área útil
-  const text = `Token: ${token}`;
-  doc.fontSize(8).fillColor('#222').text(text, x, y, { lineBreak: false });
-  const qrBuffer = await generateTokenQr(token);
   const qrSize = 40;
-  const textWidth = doc.widthOfString(text);
-  doc.image(qrBuffer, x + textWidth + 10, y - (qrSize - 8), {
+  const qrX = doc.page.width - doc.page.margins.right - qrSize;
+  const tokenY = doc.page.height - doc.page.margins.bottom - 20; // dentro da área útil
+  const aviso =
+    'Para checar a autenticidade do documento insira o token abaixo no Portal do Permissionário que pode ser acessado através do qr code ao lado.';
+  const avisoWidth = qrX - x - 10;
+  doc.fontSize(7).fillColor('#222');
+  const avisoHeight = doc.heightOfString(aviso, { width: avisoWidth });
+  const avisoY = tokenY - avisoHeight - 2;
+  doc.text(aviso, x, avisoY, { width: avisoWidth });
+
+  const text = `Token: ${token}`;
+  doc.fontSize(8).text(text, x, tokenY, { lineBreak: false });
+  const qrBuffer = await generateTokenQr(token);
+  doc.image(qrBuffer, qrX, tokenY - (qrSize - 8), {
     fit: [qrSize, qrSize],
   });
   doc.restore();
-  doc.x = prevX; doc.y = prevY;         // restaura cursor do conteúdo
+  doc.x = prevX;
+  doc.y = prevY; // restaura cursor do conteúdo
 }
 
 /* ===========================================================

--- a/src/api/adminRoutes.js
+++ b/src/api/adminRoutes.js
@@ -995,13 +995,21 @@ async function printToken(doc, token) {
 
   doc.save();
   const x = doc.page.margins.left;
-  const y = doc.page.height - doc.page.margins.bottom - 10; // dentro da área útil
-  const text = `Token: ${token}`;
-  doc.fontSize(8).fillColor('#222').text(text, x, y, { lineBreak: false });
-  const qrBuffer = await generateTokenQr(token);
   const qrSize = 40;
-  const textWidth = doc.widthOfString(text);
-  doc.image(qrBuffer, x + textWidth + 10, y - (qrSize - 8), {
+  const qrX = doc.page.width - doc.page.margins.right - qrSize;
+  const tokenY = doc.page.height - doc.page.margins.bottom - 20;
+  const aviso =
+    'Para checar a autenticidade do documento insira o token abaixo no Portal do Permissionário que pode ser acessado através do qr code ao lado.';
+  const avisoWidth = qrX - x - 10;
+  doc.fontSize(7).fillColor('#222');
+  const avisoHeight = doc.heightOfString(aviso, { width: avisoWidth });
+  const avisoY = tokenY - avisoHeight - 2;
+  doc.text(aviso, x, avisoY, { width: avisoWidth });
+
+  const text = `Token: ${token}`;
+  doc.fontSize(8).text(text, x, tokenY, { lineBreak: false });
+  const qrBuffer = await generateTokenQr(token);
+  doc.image(qrBuffer, qrX, tokenY - (qrSize - 8), {
     fit: [qrSize, qrSize],
   });
   doc.restore();

--- a/src/api/adminTermoEventosPDFRoutes.js
+++ b/src/api/adminTermoEventosPDFRoutes.js
@@ -256,15 +256,23 @@ function tabelaDiscriminacao(doc, payload) {
 async function printToken(doc, token) {
   if (!token) return;
   const prevX = doc.x, prevY = doc.y;
-  const x = doc.page.margins.left;
-  const y = doc.page.height - doc.page.margins.bottom - 10;
   doc.save();
-  const text = `Token: ${token}`;
-  doc.font('Times-Roman').fontSize(8).fillColor('#222').text(text, x, y, { lineBreak: false });
-  const qrBuffer = await generateTokenQr(token);
+  const x = doc.page.margins.left;
   const qrSize = 40;
-  const textWidth = doc.widthOfString(text);
-  doc.image(qrBuffer, x + textWidth + 10, y - (qrSize - 8), {
+  const qrX = doc.page.width - doc.page.margins.right - qrSize;
+  const tokenY = doc.page.height - doc.page.margins.bottom - 20;
+  const aviso =
+    'Para checar a autenticidade do documento insira o token abaixo no Portal do Permissionário que pode ser acessado através do qr code ao lado.';
+  const avisoWidth = qrX - x - 10;
+  doc.font('Times-Roman').fontSize(7).fillColor('#222');
+  const avisoHeight = doc.heightOfString(aviso, { width: avisoWidth });
+  const avisoY = tokenY - avisoHeight - 2;
+  doc.text(aviso, x, avisoY, { width: avisoWidth });
+
+  const text = `Token: ${token}`;
+  doc.font('Times-Roman').fontSize(8).text(text, x, tokenY, { lineBreak: false });
+  const qrBuffer = await generateTokenQr(token);
+  doc.image(qrBuffer, qrX, tokenY - (qrSize - 8), {
     fit: [qrSize, qrSize],
   });
   doc.restore();

--- a/src/api/adminTermoEventosRoutes.js
+++ b/src/api/adminTermoEventosRoutes.js
@@ -201,13 +201,21 @@ async function printToken(doc, token) {
   const prevX = doc.x, prevY = doc.y;
   doc.save();
   const x = doc.page.margins.left;
-  const y = doc.page.height - doc.page.margins.bottom - 10;
-  const text = `Token: ${token}`;
-  doc.fontSize(8).fillColor('#222').text(text, x, y, { lineBreak:false });
-  const qrBuffer = await generateTokenQr(token);
   const qrSize = 40;
-  const textWidth = doc.widthOfString(text);
-  doc.image(qrBuffer, x + textWidth + 10, y - (qrSize - 8), {
+  const qrX = doc.page.width - doc.page.margins.right - qrSize;
+  const tokenY = doc.page.height - doc.page.margins.bottom - 20;
+  const aviso =
+    'Para checar a autenticidade do documento insira o token abaixo no Portal do Permissionário que pode ser acessado através do qr code ao lado.';
+  const avisoWidth = qrX - x - 10;
+  doc.fontSize(7).fillColor('#222');
+  const avisoHeight = doc.heightOfString(aviso, { width: avisoWidth });
+  const avisoY = tokenY - avisoHeight - 2;
+  doc.text(aviso, x, avisoY, { width: avisoWidth });
+
+  const text = `Token: ${token}`;
+  doc.fontSize(8).text(text, x, tokenY, { lineBreak:false });
+  const qrBuffer = await generateTokenQr(token);
+  doc.image(qrBuffer, qrX, tokenY - (qrSize - 8), {
     fit: [qrSize, qrSize],
   });
   doc.restore();

--- a/src/api/permissionariosRoutes.js
+++ b/src/api/permissionariosRoutes.js
@@ -36,13 +36,21 @@ async function printToken(doc, token) {
   const prevX = doc.x, prevY = doc.y;
   doc.save();
   const x = doc.page.margins.left;
-  const y = doc.page.height - doc.page.margins.bottom - 10; // dentro da área útil
-  const text = `Token: ${token}`;
-  doc.fontSize(8).fillColor('#222').text(text, x, y, { lineBreak: false });
-  const qrBuffer = await generateTokenQr(token);
   const qrSize = 40;
-  const textWidth = doc.widthOfString(text);
-  doc.image(qrBuffer, x + textWidth + 10, y - (qrSize - 8), {
+  const qrX = doc.page.width - doc.page.margins.right - qrSize;
+  const tokenY = doc.page.height - doc.page.margins.bottom - 20; // dentro da área útil
+  const aviso =
+    'Para checar a autenticidade do documento insira o token abaixo no Portal do Permissionário que pode ser acessado através do qr code ao lado.';
+  const avisoWidth = qrX - x - 10;
+  doc.fontSize(7).fillColor('#222');
+  const avisoHeight = doc.heightOfString(aviso, { width: avisoWidth });
+  const avisoY = tokenY - avisoHeight - 2;
+  doc.text(aviso, x, avisoY, { width: avisoWidth });
+
+  const text = `Token: ${token}`;
+  doc.fontSize(8).text(text, x, tokenY, { lineBreak: false });
+  const qrBuffer = await generateTokenQr(token);
+  doc.image(qrBuffer, qrX, tokenY - (qrSize - 8), {
     fit: [qrSize, qrSize],
   });
   doc.restore();


### PR DESCRIPTION
## Summary
- add authenticity disclaimer and QR alignment to token PDF renderer
- print disclaimer above tokens in admin, termo de eventos, permissionários and ofícios routes

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68ba0ea246b48333bbda8a7c2c167b85