### PR TITLE
Ensure PDF generation writes file before indexing

### DIFF
--- a/src/services/termoEventoExportService.js
+++ b/src/services/termoEventoExportService.js
@@ -268,14 +268,19 @@ async function salvarDocumentoRegistro(buffer, tipo, permissionarioId, eventoId,
     [eventoId || null, tipo]
   );
 
-  // Gera (ou reaproveita) token
-  const token = existing?.token || (Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2));
   const createdAt = new Date().toISOString();
 
   // Monta nome & salva PDF
   const fileName = nomeArquivo(evRow, existing?.id || 'novo');
   const filePath = path.join(dir, fileName);
   fs.writeFileSync(filePath, buffer);
+
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Falha ao gravar PDF em ${filePath}`);
+  }
+
+  // Gera (ou reaproveita) token somente após garantir o arquivo
+  const token = existing?.token || (Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2));
 
   const publicUrl = `/documentos/${fileName}`;
 

--- a/src/services/termoEventoPdfkitService.js
+++ b/src/services/termoEventoPdfkitService.js
@@ -683,6 +683,12 @@ const saldoISO = parcelas.length > 1
   await finishPromise;
   console.log('[TERMO][SERVICE] PDF gravado em', filePath);
 
+  // Garantia de que o arquivo foi realmente gravado
+  if (!fs.existsSync(filePath)) {
+    console.error('[TERMO][SERVICE] Falha ao gravar PDF em', filePath);
+    throw new Error('Falha ao gerar PDF do termo do evento');
+  }
+
   // 6) Indexa (UPSERT por evento+tipo)
   const createdAt = new Date().toISOString();
   const publicUrl = `/documentos/${fileName}`;


### PR DESCRIPTION
## Summary
- verify generated PDF exists before inserting documento record
- defer token creation for advertências until PDF is saved
- confirm export service only indexes docs when PDF file is present

## Testing
- `npm test` *(fails: 33 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1a46799c8333b08b5d2e6258bd31