### PR TITLE
Handle missing PDF in document verification

### DIFF
--- a/public/verificar-token.html
+++ b/public/verificar-token.html
@@ -103,9 +103,14 @@
                 }
                 const data = await response.json();
 
-                let html = data.authentic
-                    ? '<div class="alert alert-success">Documento autêntico</div>'
-                    : '<div class="alert alert-danger">Documento inválido</div>';
+                let html;
+                if (data.authentic) {
+                    html = '<div class="alert alert-success">Documento autêntico</div>';
+                } else if (data.message) {
+                    html = `<div class="alert alert-warning">${data.message}</div>`;
+                } else {
+                    html = '<div class="alert alert-danger">Documento inválido</div>';
+                }
 
                 if (data.created_at) {
                     html += `<p>Data de emissão: ${new Date(data.created_at).toLocaleDateString('pt-BR')}</p>`;

--- a/src/api/documentosRoutes.js
+++ b/src/api/documentosRoutes.js
@@ -90,8 +90,10 @@ router.get('/verify/:token', async (req, res) => {
     const relativePath = pdf_public_url ? pdf_public_url.replace(/^\//, '') : '';
     const abs = path.join(PUBLIC_DIR, relativePath);
     const authentic = pdf_public_url ? fs.existsSync(abs) : false;
+    let message;
     if (!authentic) {
       logger.warn(`[documentos] Arquivo ausente para token ${req.params.token}: ${pdf_public_url}`);
+      message = 'Documento encontrado, porém o arquivo PDF não está disponível';
     }
     return res.json({
       valid: true,
@@ -101,6 +103,7 @@ router.get('/verify/:token', async (req, res) => {
       status,
       pdf_public_url,
       authentic,
+      ...(message ? { message } : {}),
     });
   } catch (e) {
     console.error('[documentos]/verify erro:', e.message);

--- a/tests/adminAdvertenciasRoutes.test.js
+++ b/tests/adminAdvertenciasRoutes.test.js
@@ -167,6 +167,7 @@ test('GET /api/documentos/verify/:token retorna metadados', async () => {
   assert.equal(res.body.status, 'gerado');
   assert.ok(res.body.created_at);
   assert.equal(res.body.authentic, false);
+  assert.equal(res.body.message, 'Documento encontrado, porém o arquivo PDF não está disponível');
   assert.ok(!('token' in res.body));
 });
 


### PR DESCRIPTION
## Summary
- Return a `message` when `/api/documentos/verify/:token` finds no PDF file
- Show the backend `message` on `verificar-token.html` with a warning
- Test token verification endpoint for the new warning message

## Testing
- `npm test` *(fails: dashboard-stats respects tipo filter, relatorio de dars inclui guias emitidas mesmo sem emitido_por_id ou permissionario, retorna 204 quando nao existem dars emitidas, preview indica DAR vencido, reemitir DAR vencido atualiza valor e vencimento, inclui cláusulas 1.2 e 5.21 quando há empréstimo de equipamentos)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1b6850d48333b4c4cb0548adc0fd