### PR TITLE
Ajusta posicionamento do token em PDFs

### DIFF
--- a/src/api/adminOficiosRoutes.js
+++ b/src/api/adminOficiosRoutes.js
@@ -31,13 +31,14 @@ async function printToken(doc, token) {
   const x = doc.page.margins.left;
   const qrSize = 40;
   const qrX = doc.page.width - doc.page.margins.right - qrSize;
-  const tokenY = doc.page.height - doc.page.margins.bottom - 20; // dentro da área útil
+  const baseY = doc.page.height - doc.page.margins.bottom; // dentro da área útil
   const aviso =
     'Para checar a autenticidade do documento insira o token abaixo no Portal do Permissionário que pode ser acessado através do qr code ao lado.';
   const avisoWidth = qrX - x - 10;
   doc.fontSize(7).fillColor('#222');
   const avisoHeight = doc.heightOfString(aviso, { width: avisoWidth });
-  const avisoY = tokenY - avisoHeight - 2;
+  const avisoY = baseY + 2;
+  const tokenY = avisoY + avisoHeight + 2;
   doc.text(aviso, x, avisoY, { width: avisoWidth });
 
   const text = `Token: ${token}`;

--- a/src/api/adminRoutes.js
+++ b/src/api/adminRoutes.js
@@ -997,13 +997,14 @@ async function printToken(doc, token) {
   const x = doc.page.margins.left;
   const qrSize = 40;
   const qrX = doc.page.width - doc.page.margins.right - qrSize;
-  const tokenY = doc.page.height - doc.page.margins.bottom - 20;
+  const baseY = doc.page.height - doc.page.margins.bottom;
   const aviso =
     'Para checar a autenticidade do documento insira o token abaixo no Portal do Permissionário que pode ser acessado através do qr code ao lado.';
   const avisoWidth = qrX - x - 10;
   doc.fontSize(7).fillColor('#222');
   const avisoHeight = doc.heightOfString(aviso, { width: avisoWidth });
-  const avisoY = tokenY - avisoHeight - 2;
+  const avisoY = baseY + 2;
+  const tokenY = avisoY + avisoHeight + 2;
   doc.text(aviso, x, avisoY, { width: avisoWidth });
 
   const text = `Token: ${token}`;

--- a/src/api/adminTermoEventosPDFRoutes.js
+++ b/src/api/adminTermoEventosPDFRoutes.js
@@ -260,13 +260,14 @@ async function printToken(doc, token) {
   const x = doc.page.margins.left;
   const qrSize = 40;
   const qrX = doc.page.width - doc.page.margins.right - qrSize;
-  const tokenY = doc.page.height - doc.page.margins.bottom - 20;
+  const baseY = doc.page.height - doc.page.margins.bottom;
   const aviso =
     'Para checar a autenticidade do documento insira o token abaixo no Portal do Permissionário que pode ser acessado através do qr code ao lado.';
   const avisoWidth = qrX - x - 10;
   doc.font('Times-Roman').fontSize(7).fillColor('#222');
   const avisoHeight = doc.heightOfString(aviso, { width: avisoWidth });
-  const avisoY = tokenY - avisoHeight - 2;
+  const avisoY = baseY + 2;
+  const tokenY = avisoY + avisoHeight + 2;
   doc.text(aviso, x, avisoY, { width: avisoWidth });
 
   const text = `Token: ${token}`;

--- a/src/api/adminTermoEventosRoutes.js
+++ b/src/api/adminTermoEventosRoutes.js
@@ -203,13 +203,14 @@ async function printToken(doc, token) {
   const x = doc.page.margins.left;
   const qrSize = 40;
   const qrX = doc.page.width - doc.page.margins.right - qrSize;
-  const tokenY = doc.page.height - doc.page.margins.bottom - 20;
+  const baseY = doc.page.height - doc.page.margins.bottom;
   const aviso =
     'Para checar a autenticidade do documento insira o token abaixo no Portal do Permissionário que pode ser acessado através do qr code ao lado.';
   const avisoWidth = qrX - x - 10;
   doc.fontSize(7).fillColor('#222');
   const avisoHeight = doc.heightOfString(aviso, { width: avisoWidth });
-  const avisoY = tokenY - avisoHeight - 2;
+  const avisoY = baseY + 2;
+  const tokenY = avisoY + avisoHeight + 2;
   doc.text(aviso, x, avisoY, { width: avisoWidth });
 
   const text = `Token: ${token}`;

--- a/src/api/permissionariosRoutes.js
+++ b/src/api/permissionariosRoutes.js
@@ -38,13 +38,14 @@ async function printToken(doc, token) {
   const x = doc.page.margins.left;
   const qrSize = 40;
   const qrX = doc.page.width - doc.page.margins.right - qrSize;
-  const tokenY = doc.page.height - doc.page.margins.bottom - 20; // dentro da área útil
+  const baseY = doc.page.height - doc.page.margins.bottom; // dentro da área útil
   const aviso =
     'Para checar a autenticidade do documento insira o token abaixo no Portal do Permissionário que pode ser acessado através do qr code ao lado.';
   const avisoWidth = qrX - x - 10;
   doc.fontSize(7).fillColor('#222');
   const avisoHeight = doc.heightOfString(aviso, { width: avisoWidth });
-  const avisoY = tokenY - avisoHeight - 2;
+  const avisoY = baseY + 2;
+  const tokenY = avisoY + avisoHeight + 2;
   doc.text(aviso, x, avisoY, { width: avisoWidth });
 
   const text = `Token: ${token}`;

--- a/src/utils/token.js
+++ b/src/utils/token.js
@@ -88,7 +88,7 @@ async function imprimirTokenEmPdf(pdfBase64, token) {
   pages.forEach(page => {
     const pageWidth = page.getWidth();
     const qrX = pageWidth - qrSize - marginX;
-    const tokenY = 20;
+    const tokenY = 10;
     const avisoWidth = qrX - marginX - 10;
 
     const lines = wrapText(aviso, font, avisoFontSize, avisoWidth);
@@ -112,7 +112,7 @@ async function imprimirTokenEmPdf(pdfBase64, token) {
 
     page.drawImage(qrImage, {
       x: qrX,
-      y: 10,
+      y: 0,
       width: qrSize,
       height: qrSize,
     });


### PR DESCRIPTION
## Summary
- Reposiciona bloco de autenticação para a margem inferior em diversos geradores de PDF
- Ajusta utilitário de tokens para deslocar QR e aviso

## Testing
- `node -e "const { PDFDocument }=require('pdf-lib'); const fs=require('fs'); const {imprimirTokenEmPdf}=require('./src/utils/token'); (async()=>{ const pdfDoc=await PDFDocument.create(); const page=pdfDoc.addPage(); page.drawText('Texto no final da página',{x:50,y:50}); const pdfBytes=await pdfDoc.save(); const base64=Buffer.from(pdfBytes).toString('base64'); const modified=await imprimirTokenEmPdf(base64,'tokentest'); fs.writeFileSync('sample_token.pdf', Buffer.from(modified,'base64')); console.log('sample_token.pdf generated'); })();"`
- `npm test` (fails: 6)

------
https://chatgpt.com/codex/tasks/task_e_68ba1b71782c833384a39e2f1837b956