### PR TITLE
Expand PDF bottom margin for authentication block

### DIFF
--- a/src/api/adminOficiosRoutes.js
+++ b/src/api/adminOficiosRoutes.js
@@ -86,7 +86,7 @@ router.get(
       const tokenDoc = await gerarTokenDocumento('OFICIO', permissionarioId, db);
 
       // 3) Cria PDF com margens ABNT (+0,5cm topo/rodapé)
-      const doc = new PDFDocument({ size: 'A4', margins: abntMargins(0.5, 0.5) });
+      const doc = new PDFDocument({ size: 'A4', margins: abntMargins(0.5, 0.5, 2) });
       res.setHeader('Content-Type', 'application/pdf');
       res.setHeader('Content-Disposition', `attachment; filename="oficio_${permissionarioId}.pdf"`);
       res.setHeader('X-Document-Token', tokenDoc);

--- a/src/api/adminRoutes.js
+++ b/src/api/adminRoutes.js
@@ -417,7 +417,7 @@ router.get(
       if (format === 'pdf') {
         const tokenDoc = await gerarTokenDocumento('RELATORIO_PERMISSIONARIOS', null, db);
 
-        const doc = new PDFDocument({ size: 'A4', margins: abntMargins(0.5, 0.5) });
+        const doc = new PDFDocument({ size: 'A4', margins: abntMargins(0.5, 0.5, 2) });
         res.header('Content-Type', 'application/pdf');
         res.attachment('permissionarios.pdf');
         res.setHeader('X-Document-Token', tokenDoc);
@@ -548,7 +548,7 @@ router.get(
         return res.status(404).json({ error: 'Nenhum devedor encontrado.' });
       }
 
-      const doc = new PDFDocument({ size: 'A4', margins: abntMargins(0.5, 0.5) });
+      const doc = new PDFDocument({ size: 'A4', margins: abntMargins(0.5, 0.5, 2) });
 
       const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'secti-'));
       const filePath = path.join(tmpDir, `relatorio_devedores_${Date.now()}.pdf`);
@@ -646,7 +646,7 @@ router.get(
         return res.status(204).send();
       }
 
-      const doc = new PDFDocument({ size: 'A4', margins: abntMargins(0.5, 0.5) });
+      const doc = new PDFDocument({ size: 'A4', margins: abntMargins(0.5, 0.5, 2) });
       const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'secti-'));
       const filePath = path.join(tmpDir, `relatorio_dars_${Date.now()}.pdf`);
       const stream = fs.createWriteStream(filePath);
@@ -724,7 +724,7 @@ router.get(
         return res.status(204).send();
       }
 
-      const doc = new PDFDocument({ size: 'A4', margins: abntMargins(0.5, 0.5) });
+      const doc = new PDFDocument({ size: 'A4', margins: abntMargins(0.5, 0.5, 2) });
       const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'secti-'));
       const filePath = path.join(tmpDir, `relatorio_eventos_dars_${Date.now()}.pdf`);
       const stream = fs.createWriteStream(filePath);

--- a/src/api/adminTermoEventosPDFRoutes.js
+++ b/src/api/adminTermoEventosPDFRoutes.js
@@ -338,7 +338,7 @@ router.get(
       fs.mkdirSync(outDir, { recursive: true });
 
       // Criado já com bufferPages para paginar ao final
-      const doc = new PDFDocument({ size: 'A4', margins: abntMargins(0.5, 0.5), bufferPages: true });
+      const doc = new PDFDocument({ size: 'A4', margins: abntMargins(0.5, 0.5, 2), bufferPages: true });
 
       // Caminho final só após saber o ID (vamos gerar um temporário primeiro)
       // Estratégia: salvar como arquivo, depois stream pro response.

--- a/src/api/adminTermoEventosRoutes.js
+++ b/src/api/adminTermoEventosRoutes.js
@@ -326,7 +326,7 @@ router.get(
 
       // ========== Gera PDF em memória ==========
       const letterheadPath = resolveLetterheadPath();
-      const margins = abntMargins(0.5, 0.5); // mesmo do ofício (+0,5cm topo/rodapé)
+      const margins = abntMargins(0.5, 0.5, 2); // inclui espaço para bloco de autenticação
       const doc = new PDFDocument({ size: 'A4', margins });
 
       const chunks = [];

--- a/src/api/permissionariosRoutes.js
+++ b/src/api/permissionariosRoutes.js
@@ -126,7 +126,7 @@ router.get('/:id/certidao', authMiddleware, async (req, res) => {
     const publicRelativePath = path.join('permissionarios', 'certidoes', filename); // para servir via /public
 
     // Documento PDF: padrão timbrado + ABNT + 0,5cm
-    const doc = new PDFDocument({ size: 'A4', margins: abntMargins(0.5, 0.5) });
+    const doc = new PDFDocument({ size: 'A4', margins: abntMargins(0.5, 0.5, 2) });
 
     // Coleta em buffer para salvar em disco e enviar ao cliente
     const chunks = [];

--- a/src/services/advertenciaPdfService.js
+++ b/src/services/advertenciaPdfService.js
@@ -80,7 +80,7 @@ async function gerarAdvertenciaPdfEIndexar({ advertenciaId = null, evento = {}, 
   const fileName = sanitizeForFilename(`Advertencia_${evento.id || 's-e'}_${cliente.nome_razao_social || 'cliente'}.pdf`);
   const filePath = path.join(publicDir, fileName);
 
-  const doc = new PDFDocument({ size: 'A4', margins: abntMargins() });
+  const doc = new PDFDocument({ size: 'A4', margins: abntMargins(0.5, 0.5, 2) });
   const ws = fs.createWriteStream(filePath);
   doc.pipe(ws);
 

--- a/src/services/termoEventoPdfkitService.js
+++ b/src/services/termoEventoPdfkitService.js
@@ -490,7 +490,7 @@ const saldoISO = parcelas.length > 1
   const filePath = path.join(publicDir, fileName);
 
   // 5) PDF: sem bufferPages (sem paginação pós-processamento)
-  const doc = new PDFDocument({ size: 'A4', margins: abntMargins(0.5, 0.5) });
+  const doc = new PDFDocument({ size: 'A4', margins: abntMargins(0.5, 0.5, 2) });
   const ws = fs.createWriteStream(filePath);
   doc.pipe(ws);
 

--- a/src/utils/pdfLetterhead.js
+++ b/src/utils/pdfLetterhead.js
@@ -7,10 +7,11 @@ const cm = (n) => Math.round(n * CM);
 
 // ABNT: topo/esq = 3 cm; dir/baixo = 2 cm.
 // Pedido: +0,5 cm em topo/baixo → topo=3.5; baixo=2.5
-function abntMargins(extraTopCm = 0.5, extraBottomCm = 0.5) {
+// authBlockHeightCm: altura adicional reservada para bloco de autenticação (token/QR)
+function abntMargins(extraTopCm = 0.5, extraBottomCm = 0.5, authBlockHeightCm = 0) {
   return {
     top: cm(3 + extraTopCm),     // 3,5 cm ~ 99 pt
-    bottom: cm(2 + extraBottomCm), // 2,5 cm ~ 71 pt
+    bottom: cm(2 + extraBottomCm + authBlockHeightCm), // inclui espaço para bloco de autenticação
     left: cm(3),                 // 3 cm ~ 85 pt
     right: cm(2),                // 2 cm ~ 57 pt
   };


### PR DESCRIPTION
## Summary
- allow `abntMargins` to reserve extra bottom space for token/QR block
- update PDF generators to use expanded bottom margin

## Testing
- `npm test` *(fails: tests 39, fail 34)*
- `node - <<'NODE' ...` to generate sample PDF with token
- `node - <<'NODE' ...` to parse sample PDF and confirm token text


------
https://chatgpt.com/codex/tasks/task_e_68ba1d38198c8333b953d0289f355b97