### PR TITLE
fix token positioning on PDF

### DIFF
--- a/src/api/adminRoutes.js
+++ b/src/api/adminRoutes.js
@@ -1008,13 +1008,20 @@ function printToken(doc, token, qrBuffer) {
   const avisoWidth = qrX - x - 10;
   doc.fontSize(7).fillColor('#222');
   const avisoHeight = doc.heightOfString(aviso, { width: avisoWidth });
-  const avisoY = baseY + 2;
-  const tokenY = avisoY + avisoHeight + 2;
-  doc.text(aviso, x, avisoY, { width: avisoWidth });
 
+  // calcula alturas para manter todo o bloco dentro da área útil
   const text = `Token: ${token}`;
-  doc.fontSize(8).text(text, x, tokenY, { lineBreak: false });
-  doc.image(qrBuffer, qrX, tokenY - (qrSize - 8), {
+  doc.fontSize(8);
+  const tokenHeight = doc.heightOfString(text);
+  const totalHeight = avisoHeight + 2 + tokenHeight;
+
+  const avisoY = baseY - totalHeight;
+  const tokenY = baseY - tokenHeight;
+  const qrY = tokenY - (qrSize - tokenHeight);
+
+  doc.text(aviso, x, avisoY, { width: avisoWidth });
+  doc.text(text, x, tokenY, { lineBreak: false });
+  doc.image(qrBuffer, qrX, qrY, {
     fit: [qrSize, qrSize],
   });
   doc.restore();


### PR DESCRIPTION
## Summary
- adjust token printing in PDF to compute positions from bottom margin

## Testing
- `npm test tests/adminRelatorioDevedores.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68ba2682638c83339d2d559dd469d119