### PR TITLE
Handle PDF stream errors and avoid late response writes

### DIFF
--- a/src/api/adminOficiosRoutes.js
+++ b/src/api/adminOficiosRoutes.js
@@ -87,6 +87,10 @@ router.get(
 
       // 3) Cria PDF com margens ABNT (+0,5cm topo/rodapé)
       const doc = new PDFDocument({ size: 'A4', margins: abntMargins(0.5, 0.5, 2) });
+      doc.on('error', err => {
+        console.error('[adminOficios] pdf error:', err);
+        if (!res.headersSent) res.status(500).end();
+      });
       // 4) Aplica papel timbrado (todas as páginas)
       applyLetterhead(doc, { imagePath: path.join(__dirname, '..', 'assets', 'papel-timbrado-secti.png') });
 
@@ -263,7 +267,9 @@ router.get(
       );
     } catch (err) {
       console.error('[adminOficios] erro:', err.stack || err);
-      res.status(500).json({ error: err.message || 'Erro ao gerar ofício.' });
+      if (!res.headersSent) {
+        res.status(500).json({ error: err.message || 'Erro ao gerar ofício.' });
+      }
     }
   }
 );


### PR DESCRIPTION
## Summary
- handle PDF generation errors for admin oficio route with a dedicated event listener
- guard error handling to avoid writing to response after it has been sent

## Testing
- `npm test` *(fails: 62 passed, 7 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2c53cd608333b0bd84ed15ffbe59