### PR TITLE
test: ensure event client info appears in DAR report

### DIFF
--- a/tests/adminRelatorioDars.test.js
+++ b/tests/adminRelatorioDars.test.js
@@ -68,6 +68,8 @@ test('relatorio de dars inclui guias emitidas mesmo sem emitido_por_id ou permis
   assert.match(parsed.text, /Perm/);
   assert.match(parsed.text, /DOC123/);
   assert.match(parsed.text, /DOC_EVENTO/);
+  assert.match(parsed.text, /Cliente X/);
+  assert.match(parsed.text, /999/);
   assert.ok(!/DOCNOVO/.test(parsed.text));
 });
 


### PR DESCRIPTION
## Summary
- verify event client row is linked to DAR and rendered in DAR report
- assert PDF shows the client's name and document

## Testing
- `node --test tests/adminRelatorioDars.test.js`
- `npm test` *(fails: dashboard-stats respects tipo filter, preview indica DAR vencido, reemitir DAR vencido atualiza valor e vencimento, tests/permissionariosCertidao.test.js, inclui cláusulas 1.2 e 5.21 quando há empréstimo de equipamentos)*

------
https://chatgpt.com/codex/tasks/task_e_68bada98382c8333bc691570ea3bde3f