### PR TITLE
Ensure token stays inside page bottom margin

### DIFF
--- a/src/api/permissionariosRoutes.js
+++ b/src/api/permissionariosRoutes.js
@@ -42,17 +42,24 @@ function printToken(doc, token, qrBuffer) {
   const aviso =
     'Para checar a autenticidade do documento insira o token abaixo no Portal do Permissionário que pode ser acessado através do qr code ao lado.';
   const avisoWidth = qrX - x - 10;
-  doc.fontSize(7).fillColor('#222');
-  const avisoHeight = doc.heightOfString(aviso, { width: avisoWidth });
-  const avisoY = baseY + 2;
-  const tokenY = avisoY + avisoHeight + 2;
-  doc.text(aviso, x, avisoY, { width: avisoWidth });
 
+  // Calcula as alturas usando as fontes corretas
+  doc.fontSize(7);
+  const avisoHeight = doc.heightOfString(aviso, { width: avisoWidth });
   const text = `Token: ${token}`;
+  doc.fontSize(8);
+  const tokenHeight = doc.heightOfString(text, { width: avisoWidth });
+
+  const spacing = 2;
+  const totalHeight = avisoHeight + spacing + tokenHeight;
+  const avisoY = baseY - totalHeight;
+  const tokenY = avisoY + avisoHeight + spacing;
+
+  // Renderiza dentro da margem inferior
+  doc.fontSize(7).fillColor('#222').text(aviso, x, avisoY, { width: avisoWidth });
   doc.fontSize(8).text(text, x, tokenY, { lineBreak: false });
-  doc.image(qrBuffer, qrX, tokenY - (qrSize - 8), {
-    fit: [qrSize, qrSize],
-  });
+  const qrY = baseY - qrSize;
+  doc.image(qrBuffer, qrX, qrY, { fit: [qrSize, qrSize] });
   doc.restore();
   doc.x = prevX; doc.y = prevY;
 }


### PR DESCRIPTION
## Summary
- Recalculate token block position to render within bottom margin

## Testing
- `npm test`
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68badab9d0308333b577d3dd02d6f500