### PR TITLE
Include permissionarioId in password reset flow

### DIFF
--- a/public/solicitar-redefinicao.html
+++ b/public/solicitar-redefinicao.html
@@ -118,14 +118,14 @@
                 if (!response.ok) {
                     throw new Error(result.error || 'Ocorreu um erro.');
                 }
-                
+
                 messageDiv.innerText = 'Código enviado com sucesso! Verifique seu e-mail. Redirecionando...';
                 messageDiv.className = 'alert alert-success';
                 messageDiv.style.display = 'block';
                 formContainer.style.display = 'none';
 
                 setTimeout(() => {
-                    window.location.href = `/verificar-codigo.html?cnpj=${encodeURIComponent(cnpj)}`;
+                    window.location.href = `/verificar-codigo.html?cnpj=${encodeURIComponent(cnpj)}&pid=${result.permissionarioId}`;
                 }, 3000);
 
             } catch (error) {

--- a/public/verificar-codigo.html
+++ b/public/verificar-codigo.html
@@ -92,14 +92,15 @@
             const form = event.target;
             const messageDiv = document.getElementById('message');
             
-            // Pega o CNPJ da URL, que foi passado da página anterior
+            // Pega o CNPJ e o ID do permissionário da URL
             const urlParams = new URLSearchParams(window.location.search);
             const cnpj = urlParams.get('cnpj');
+            const permissionarioId = urlParams.get('pid');
             const codigo = document.getElementById('codigo').value;
             const submitButton = form.querySelector('button[type="submit"]');
 
-            if (!cnpj) {
-                messageDiv.innerText = 'Erro: CNPJ não encontrado. Por favor, reinicie o processo.';
+            if (!cnpj || !permissionarioId) {
+                messageDiv.innerText = 'Erro: dados inválidos. Por favor, reinicie o processo.';
                 messageDiv.className = 'alert alert-danger';
                 messageDiv.style.display = 'block';
                 return;
@@ -112,7 +113,7 @@
                 const response = await fetch('/api/auth/verificar-codigo', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ cnpj: cnpj, codigo: codigo })
+                    body: JSON.stringify({ cnpj, codigo, permissionarioId })
                 });
 
                 const result = await response.json();


### PR DESCRIPTION
## Summary
- Append permissionarioId to verification redirect after requesting access
- Pass permissionarioId from URL to verification request and validate presence

## Testing
- `npm test` *(fails: SEFAZ_APP_TOKEN não configurado; 4 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bae260a8f8833380d352c5bff0cd8f