### PR TITLE
Ensure valor_aluguel column exists for permissionarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ O projeto também tenta rodar esse comando automaticamente na inicialização, m
 Após atualizar o código para versões mais recentes, execute novamente as migrações para criar novas estruturas de banco de dados,
 como a tabela de auditoria de reservas (`reservas_audit`).
 
+Arquivos de banco de dados criados antes da inclusão da coluna `valor_aluguel` em `permissionarios` precisam ser migrados ou
+recriados para que essa coluna seja adicionada corretamente.
+
 ## Salas de Reunião
 
 Para habilitar o módulo de salas:

--- a/src/database/init.js
+++ b/src/database/init.js
@@ -38,7 +38,7 @@ module.exports = new Promise((resolve, reject) => {
       console.log('Tabela "permissionarios" verificada/criada com sucesso.');
     });
 
-    // Garantir coluna 'tipo' na tabela Permissionários
+    // Garantir colunas opcionais na tabela Permissionários
     db.all(`PRAGMA table_info('permissionarios')`, (err, columns) => {
       if (err) {
         return console.error('Erro ao inspecionar a tabela "permissionarios":', err.message);
@@ -46,6 +46,11 @@ module.exports = new Promise((resolve, reject) => {
       const colNames = columns.map((c) => c.name);
       if (!colNames.includes('tipo')) {
         db.run(`ALTER TABLE permissionarios ADD COLUMN tipo TEXT;`);
+      }
+      if (!colNames.includes('valor_aluguel')) {
+        db.run(
+          `ALTER TABLE permissionarios ADD COLUMN valor_aluguel REAL DEFAULT 0;`
+        );
       }
     });
 

--- a/src/migrations/20250911130000-ensure-valor-aluguel-permissionarios.js
+++ b/src/migrations/20250911130000-ensure-valor-aluguel-permissionarios.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const table = await queryInterface.describeTable('permissionarios');
+    if (!table['valor_aluguel']) {
+      await queryInterface.addColumn('permissionarios', 'valor_aluguel', {
+        type: Sequelize.FLOAT,
+        allowNull: false,
+        defaultValue: 0,
+      });
+    }
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('permissionarios', 'valor_aluguel');
+  },
+};


### PR DESCRIPTION
## Summary
- add initialization fallback to create permissionarios.valor_aluguel when missing
- create Sequelize migration enforcing valor_aluguel (non-null, default 0)
- note that legacy database files must be migrated or recreated to include valor_aluguel

## Testing
- `npm test` *(fails: dashboard-stats respects tipo filter; preview indica DAR vencido; reemitir DAR vencido atualiza valor e vencimento; inclui cláusulas 1.2 e 5.21 quando há empréstimo de equipamentos)*

------
https://chatgpt.com/codex/tasks/task_e_68bae8a238b0833381eb1a6f6cbdb124