### PR TITLE
Add token_definir_senha_expires migration

### DIFF
--- a/src/migrations/20250912100000-add-token-definir-senha-expires.js
+++ b/src/migrations/20250912100000-add-token-definir-senha-expires.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const table = await queryInterface.describeTable('Clientes_Eventos');
+    if (!table['token_definir_senha_expires']) {
+      await queryInterface.sequelize.query(
+        'ALTER TABLE Clientes_Eventos ADD COLUMN token_definir_senha_expires INTEGER'
+      );
+    }
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('Clientes_Eventos', 'token_definir_senha_expires');
+  }
+};


### PR DESCRIPTION
## Summary
- add migration to track `token_definir_senha_expires` on `Clientes_Eventos`

## Testing
- `npm test` *(fails: tests 72, pass 68, fail 4)*

------
https://chatgpt.com/codex/tasks/task_e_68baeb2322c88333ab44b44e345d7f07