### PR TITLE
Capture digitable line and barcode when emitting event DARs

### DIFF
--- a/src/services/eventoDarService.js
+++ b/src/services/eventoDarService.js
@@ -227,12 +227,23 @@ async function criarEventoComDars(db, data, helpers) {
         };
 
         const retorno = await emitirGuiaSefaz(payloadSefaz);
+        const { linhaDigitavel, codigoBarras } = retorno;
         const tokenDoc = await gerarTokenDocumento('DAR_EVENTO', null, db);
         const pdf = await imprimirTokenEmPdf(retorno.pdfBase64, tokenDoc);
+        const extraCols = [];
+        const extraVals = [];
+        if (linhaDigitavel) {
+          extraCols.push('linha_digitavel = ?');
+          extraVals.push(linhaDigitavel);
+        }
+        if (codigoBarras) {
+          extraCols.push('codigo_barras = ?');
+          extraVals.push(codigoBarras);
+        }
         await dbRun(
           db,
-          `UPDATE dars SET numero_documento = ?, pdf_url = ?, status = 'Emitido' WHERE id = ?`,
-          [retorno.numeroGuia, pdf, darId]
+          `UPDATE dars SET numero_documento = ?, pdf_url = ?, status = 'Emitido'${extraCols.length ? ', ' + extraCols.join(', ') : ''} WHERE id = ?`,
+          [retorno.numeroGuia, pdf, ...extraVals, darId]
         );
       }
     }
@@ -446,12 +457,23 @@ async function atualizarEventoComDars(db, id, data, helpers) {
         };
 
         const retorno = await emitirGuiaSefaz(payloadSefaz);
+        const { linhaDigitavel, codigoBarras } = retorno;
         const tokenDoc = await gerarTokenDocumento('DAR_EVENTO', null, db);
         const pdf = await imprimirTokenEmPdf(retorno.pdfBase64, tokenDoc);
+        const extraCols = [];
+        const extraVals = [];
+        if (linhaDigitavel) {
+          extraCols.push('linha_digitavel = ?');
+          extraVals.push(linhaDigitavel);
+        }
+        if (codigoBarras) {
+          extraCols.push('codigo_barras = ?');
+          extraVals.push(codigoBarras);
+        }
         await dbRun(
           db,
-          `UPDATE dars SET numero_documento = ?, pdf_url = ?, status = 'Emitido' WHERE id = ?`,
-          [retorno.numeroGuia, pdf, darId]
+          `UPDATE dars SET numero_documento = ?, pdf_url = ?, status = 'Emitido'${extraCols.length ? ', ' + extraCols.join(', ') : ''} WHERE id = ?`,
+          [retorno.numeroGuia, pdf, ...extraVals, darId]
         );
       }
     }

--- a/tests/advertenciaDarService.test.js
+++ b/tests/advertenciaDarService.test.js
@@ -74,6 +74,8 @@ test('emitirDarAdvertencia cria dar e vincula à advertencia', async () => {
   assert.strictEqual(dar.data_vencimento, '2025-03-10');
   assert.strictEqual(dar.status, 'Emitido');
   assert.strictEqual(dar.numero_documento, '999');
+   assert.strictEqual(dar.linha_digitavel, 'LD');
+   assert.strictEqual(dar.codigo_barras, 'CB');
   await new Promise(res => db.close(res));
 });
 

--- a/tests/eventoDarService.test.js
+++ b/tests/eventoDarService.test.js
@@ -79,6 +79,8 @@ async function setupSchema(db) {
     tipo_permissionario TEXT,
     numero_documento TEXT,
     pdf_url TEXT,
+    linha_digitavel TEXT,
+    codigo_barras TEXT,
     data_emissao TEXT DEFAULT CURRENT_TIMESTAMP
   );`);
   await run(db, `CREATE TABLE DARs_Eventos (
@@ -91,7 +93,7 @@ async function setupSchema(db) {
 }
 
 const helpers = {
-  emitirGuiaSefaz: async () => ({ numeroGuia: '123', pdfBase64: 'pdf' }),
+  emitirGuiaSefaz: async () => ({ numeroGuia: '123', pdfBase64: 'pdf', linhaDigitavel: 'LD', codigoBarras: 'CB' }),
   gerarTokenDocumento: async () => 'token',
   imprimirTokenEmPdf: async (pdf, token) => `${pdf}-${token}`,
 };
@@ -133,6 +135,8 @@ test('criarEventoComDars insere evento e dars', async () => {
   assert.strictEqual(eventos.length, 1);
   const dars = await all(db, 'SELECT * FROM dars');
   assert.strictEqual(dars.length, 1);
+  assert.strictEqual(dars[0].linha_digitavel, 'LD');
+  assert.strictEqual(dars[0].codigo_barras, 'CB');
   await new Promise(res => db.close(res));
 });
 
@@ -190,6 +194,7 @@ test('atualizarEventoComDars substitui dars', async () => {
   await atualizarEventoComDars(db, id, updateData, helpers);
   const dars = await all(db, 'SELECT * FROM dars');
   assert.strictEqual(dars.length, 2);
+  assert.ok(dars.every(d => d.linha_digitavel === 'LD' && d.codigo_barras === 'CB'));
   await new Promise(res => db.close(res));
 });
 


### PR DESCRIPTION
## Summary
- Store `linha_digitavel` and `codigo_barras` returned by SEFAZ when creating or updating event DARs
- Verify persistence of these fields in event and advertência DAR service tests

## Testing
- `npm test` *(fails: table permissionarios has no column named valor_aluguel; SEFAZ_APP_TOKEN não configurado no .env.; expected 200 to equal 100; regex mismatch for cláusulas 1.2 and 5.21)*

------
https://chatgpt.com/codex/tasks/task_e_68baf64621c0833394c8570df82c0bce