### PR TITLE
Improve DAR comprovante lookup and clamp query date

### DIFF
--- a/src/services/sefazService.js
+++ b/src/services/sefazService.js
@@ -534,6 +534,21 @@ async function listarPagamentosPorDataArrecadacao(dataInicioISO, dataFimISO, cod
   return lista.map(mapPagamento);
 }
 
+async function consultarPagamentoPorCodigoBarras(numeroGuia, linhaDigitavel) {
+  const payload = {};
+  if (numeroGuia) payload.numeroGuia = onlyDigits(numeroGuia);
+  if (linhaDigitavel) payload.linhaDigitavel = onlyDigits(linhaDigitavel);
+  if (!payload.numeroGuia && !payload.linhaDigitavel) return null;
+
+  const { data } = await reqWithRetry(
+    () => sefaz.post('/api/public/v2/guia/pagamento/por-barras', payload),
+    'pagamento/por-barras'
+  );
+
+  const item = Array.isArray(data) ? data[0] : data;
+  return item ? mapPagamento(item) : null;
+}
+
 async function listarPagamentosPorDataInclusao(dataInicioDateTime, dataFimDateTime, codigoReceita) {
   const payload = {
     dataHoraInicioInclusao: dataInicioDateTime,
@@ -564,6 +579,7 @@ module.exports = {
   onlyDigits,
   normalizeCodigoReceita,
   // conciliação
+  consultarPagamentoPorCodigoBarras,
   listarPagamentosPorDataArrecadacao,
   listarPagamentosPorDataInclusao,
 };

--- a/tests/adminDarsComprovante.test.js
+++ b/tests/adminDarsComprovante.test.js
@@ -1,0 +1,62 @@
+// tests/adminDarsComprovante.test.js
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const fs = require('fs');
+const express = require('express');
+const supertest = require('supertest');
+
+test('comprovante uses barcode lookup and clamps date range', async () => {
+  const dbPath = path.resolve(__dirname, 'test-admin-comprovante.db');
+  try { fs.unlinkSync(dbPath); } catch {}
+  process.env.SQLITE_STORAGE = dbPath;
+
+  const db = require('../src/database/db');
+  const run = (sql, params=[]) => new Promise((res, rej) => db.run(sql, params, err => err ? rej(err) : res()));
+
+  await run(`CREATE TABLE permissionarios (id INTEGER PRIMARY KEY, nome_empresa TEXT, cnpj TEXT)`);
+  await run(`CREATE TABLE dars (
+    id INTEGER PRIMARY KEY,
+    permissionario_id INTEGER,
+    data_vencimento TEXT,
+    data_pagamento TEXT,
+    mes_referencia INTEGER,
+    ano_referencia INTEGER,
+    valor REAL,
+    status TEXT,
+    numero_documento TEXT,
+    pdf_url TEXT,
+    codigo_barras TEXT,
+    linha_digitavel TEXT
+  )`);
+  await run(`INSERT INTO permissionarios (id, nome_empresa, cnpj) VALUES (1, 'Perm', '12345678000199')`);
+  await run(`INSERT INTO dars (id, permissionario_id, data_vencimento, data_pagamento, mes_referencia, ano_referencia, valor, status, numero_documento, codigo_barras, linha_digitavel) VALUES (10, 1, '2024-01-10', '2024-01-15', 1, 2024, 100, 'Pago', 'NUM123', 'CB', 'LD')`);
+
+  const authPath = path.resolve(__dirname, '../src/middleware/authMiddleware.js');
+  require.cache[authPath] = { exports: (_req, _res, next) => { _req.user = { id: 1 }; next(); } };
+  const rolePath = path.resolve(__dirname, '../src/middleware/roleMiddleware.js');
+  require.cache[rolePath] = { exports: () => (_req, _res, next) => next() };
+
+  const sefazPath = path.resolve(__dirname, '../src/services/sefazService.js');
+  const directCalls = [];
+  const rangeCalls = [];
+  require.cache[sefazPath] = { exports: {
+    emitirGuiaSefaz: async () => ({}),
+    consultarPagamentoPorCodigoBarras: async (...args) => { directCalls.push(args); return null; },
+    listarPagamentosPorDataArrecadacao: async (...args) => { rangeCalls.push(args); return []; }
+  } };
+
+  const adminDarsRoutes = require('../src/api/adminDarsRoutes');
+  const app = express();
+  app.use(express.json());
+  app.use('/api/admin/dars', adminDarsRoutes);
+
+  await supertest(app).get('/api/admin/dars/10/comprovante').expect(404);
+
+  assert.equal(directCalls.length, 1);
+  assert.deepEqual(directCalls[0], ['NUM123', 'LD']);
+  assert.equal(rangeCalls.length, 1);
+  const [inicio, fim] = rangeCalls[0];
+  assert.equal(inicio, '2024-01-15');
+  assert.equal(fim, '2024-01-15');
+});

--- a/tests/adminDarsReemitir.test.js
+++ b/tests/adminDarsReemitir.test.js
@@ -24,7 +24,11 @@ test('reemitir DAR vencido atualiza valor e vencimento', async () => {
   process.env.RECEITA_CODIGO_PERMISSIONARIO = '12345';
 
   const sefazPath = path.resolve(__dirname, '../src/services/sefazService.js');
-  require.cache[sefazPath] = { exports: { emitirGuiaSefaz: async () => ({ numeroGuia: '999', pdfBase64: 'PDF' }) } };
+  require.cache[sefazPath] = { exports: {
+    emitirGuiaSefaz: async () => ({ numeroGuia: '999', pdfBase64: 'PDF' }),
+    consultarPagamentoPorCodigoBarras: async () => null,
+    listarPagamentosPorDataArrecadacao: async () => [],
+  } };
 
   const cobrancaPath = path.resolve(__dirname, '../src/services/cobrancaService.js');
   require.cache[cobrancaPath] = { exports: { calcularEncargosAtraso: async () => ({ valorAtualizado: 150, novaDataVencimento: '2030-01-31' }) } };


### PR DESCRIPTION
## Summary
- add barcode lookup helper to SEFAZ service
- clamp payment search to single day when generating DAR comprovante
- test comprovante route uses new lookup strategy

## Testing
- `npm test` *(fails: tests 42, pass 5, fail 37)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0c3e1f388333b114d86103254d7e