### PR TITLE
refactor: remove duplicate ld declaration in comprovante route

### DIFF
--- a/src/api/adminDarsRoutes.js
+++ b/src/api/adminDarsRoutes.js
@@ -557,7 +557,6 @@ router.get(
       if (dar.nome_empresa) doc.text(`Permissionário: ${dar.nome_empresa}`);
       if (dar.cnpj) doc.text(`CNPJ: ${dar.cnpj}`);
       if (numeroGuia) doc.text(`Número da Guia: ${numeroGuia}`);
-      const ld = dar.linha_digitavel || dar.codigo_barras;
       if (ld) doc.text(`Linha Digitável/Código de Barras: ${ld}`);
       const dataPg = pagamento.dataPagamento ? new Date(pagamento.dataPagamento).toLocaleDateString('pt-BR') : '';
       doc.text(`Data do Pagamento: ${dataPg}`);


### PR DESCRIPTION
## Summary
- reuse initial `ld` variable in DAR comprovante handler

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68bb0eb7b3c8833399f435e7942a0553