### PR TITLE
Align comprovante date range

### DIFF
--- a/src/api/adminDarsRoutes.js
+++ b/src/api/adminDarsRoutes.js
@@ -497,8 +497,10 @@ router.get(
       if (!pagamento) {
         let dataInicioISO = toISO(dar.data_pagamento || dar.data_vencimento) || isoHojeLocal();
         let dataFimISO = isoHojeLocal();
-        const diff = Math.abs(new Date(dataFimISO) - new Date(dataInicioISO));
-        if (diff > 24 * 60 * 60 * 1000) {
+        // Compare the start and end dates using the ISO string values.
+        // If they are different, align the end date with the start date so the
+        // lookup queries a single day.
+        if (dataFimISO !== dataInicioISO) {
           dataFimISO = dataInicioISO;
         }
 


### PR DESCRIPTION
## Summary
- Align start/end date strings for SEFAZ lookup to ensure single-day queries

## Testing
- `npm test` (fails: ERR_TEST_FAILURE)

------
https://chatgpt.com/codex/tasks/task_e_68bb0f53d0d88333a841b68eb9b9ba23