### PR TITLE
Validate DAR IDs before reissue

### DIFF
--- a/public/eventos/dashboard-eventos.html
+++ b/public/eventos/dashboard-eventos.html
@@ -336,7 +336,11 @@
             catch{ alert('Não foi possível baixar a DAR. PDF inválido.'); }
             return;
           }
-          if (btn.dataset.darReemitir){
+          if (btn.dataset.darReemitir !== undefined){
+            if (!btn.dataset.darReemitir){
+              alert('Não é possível emitir esta DAR: identificador ausente.');
+              return;
+            }
             const evento = btn.dataset.evento;
             const linha  = btn.closest('tr');
             const idx    = linha?.children?.[0]?.textContent?.trim();

--- a/src/api/adminEventosRoutes.js
+++ b/src/api/adminEventosRoutes.js
@@ -565,6 +565,7 @@ router.get('/:eventoId/dars', async (req, res) => {
   try {
     const sql = `
       SELECT
+        d.id                                AS id,
         de.numero_parcela,
         COALESCE(de.valor_parcela, d.valor) AS valor,
         d.id                                AS dar_id,


### PR DESCRIPTION
## Summary
- warn users when attempting to reissue a DAR without an identifier in the event dashboard
- expose DAR record ID in the admin endpoint listing event DARs

## Testing
- `npm test` *(fails: test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1b1dd97083338874b6be865c4bf2