### PR TITLE
Ensure proximoNumeroTermo fetch sends credentials

### DIFF
--- a/public/js/proximoNumeroTermo.js
+++ b/public/js/proximoNumeroTermo.js
@@ -1,7 +1,7 @@
 async function fillNextNumeroTermo(mask, year) {
   try {
     const query = year ? `?ano=${year}` : '';
-    const res = await fetch(`/api/admin/termos/proximo-numero${query}`);
+    const res = await fetch(`/api/admin/termos/proximo-numero${query}`, { credentials: 'include' });
     if (!res.ok) throw new Error('Falha ao obter número');
     const data = await res.json();
     const valor = data.numeroTermo || '';

--- a/tests/proximoNumeroTermo.test.js
+++ b/tests/proximoNumeroTermo.test.js
@@ -59,12 +59,15 @@ test('rota retorna próximo numeroTermo', async () => {
 // ==== Teste do front-end util ====
 test('fillNextNumeroTermo preenche campo automaticamente', async () => {
   let called = false;
-  global.fetch = async () => {
+  let options;
+  global.fetch = async (_url, opts) => {
     called = true;
+    options = opts;
     return { ok: true, json: async () => ({ numeroTermo: '010/2025' }) };
   };
   const mask = { value: '' };
   await fillNextNumeroTermo(mask);
   assert.ok(called);
+  assert.deepStrictEqual(options, { credentials: 'include' });
   assert.strictEqual(mask.value, '010/2025');
 });


### PR DESCRIPTION
## Summary
- Include credentials in `fillNextNumeroTermo` fetch request
- Verify the frontend utility calls `fetch` with credentials in tests

## Testing
- `node --test tests/proximoNumeroTermo.test.js`
- `npm test` *(fails: 14 tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68bedb04e3448333917f93a39848c554