### PR TITLE
Ensure unique numero_termo in Eventos

### DIFF
--- a/src/api/eventosRoutes.js
+++ b/src/api/eventosRoutes.js
@@ -107,14 +107,6 @@ router.post('/', async (req, res) => {
         return res.status(400).json({ error: 'A data de vencimento da última parcela deve ser anterior à data de início do evento.' });
     }
     
-    // Garante índice único e resolve número do termo
-    await new Promise((resolve, reject) => {
-        db.run(
-            'CREATE UNIQUE INDEX IF NOT EXISTS ux_eventos_numero_termo ON Eventos(numero_termo)',
-            (err) => (err ? reject(err) : resolve())
-        );
-    });
-
     let numeroTermoFinal = numeroTermo;
     if (!numeroTermoFinal) {
         numeroTermoFinal = await getNextNumeroTermo(db, new Date().getFullYear());

--- a/src/migrations/20250912120000-add-unique-index-eventos-numero-termo.js
+++ b/src/migrations/20250912120000-add-unique-index-eventos-numero-termo.js
@@ -1,0 +1,27 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // Remove duplicated numero_termo keeping the lowest rowid
+    await queryInterface.sequelize.query(`
+      DELETE FROM Eventos
+      WHERE numero_termo IS NOT NULL
+        AND rowid NOT IN (
+          SELECT MIN(rowid)
+          FROM Eventos
+          WHERE numero_termo IS NOT NULL
+          GROUP BY numero_termo
+        );
+    `);
+
+    // Create unique index to enforce uniqueness
+    await queryInterface.addIndex('Eventos', ['numero_termo'], {
+      name: 'ux_eventos_numero_termo',
+      unique: true,
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeIndex('Eventos', 'ux_eventos_numero_termo');
+  },
+};

--- a/src/services/eventoDarService.js
+++ b/src/services/eventoDarService.js
@@ -25,10 +25,6 @@ const dbAll = (db, sql, p = []) =>
   });
 
 async function getNextNumeroTermo(db, year = new Date().getFullYear()) {
-  await dbRun(
-    db,
-    'CREATE UNIQUE INDEX IF NOT EXISTS ux_eventos_numero_termo ON Eventos(numero_termo)'
-  );
   const row = await dbGet(
     db,
     `SELECT numero_termo FROM Eventos WHERE numero_termo LIKE ? ORDER BY CAST(SUBSTR(numero_termo,1,INSTR(numero_termo,'/')-1) AS INTEGER) DESC LIMIT 1`,


### PR DESCRIPTION
## Summary
- remove on-demand index creation from services and routes
- add migration to deduplicate existing termos and enforce unique index

## Testing
- `sqlite3 test.db "SELECT numero_termo, COUNT(*) FROM Eventos GROUP BY numero_termo HAVING COUNT(*) > 1;"`
- `sqlite3 test.db "DELETE FROM Eventos WHERE rowid NOT IN (SELECT MIN(rowid) FROM Eventos GROUP BY numero_termo);"`
- `sqlite3 test.db "SELECT numero_termo, COUNT(*) FROM Eventos GROUP BY numero_termo HAVING COUNT(*) > 1;"`
- `npm test` *(fails: 65 passed, 14 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bee88d1ca48333b6962cf31a37fab6