### PR TITLE
Fix advertencias cliente FK reference

### DIFF
--- a/src/migrations/20250907153000-create-advertencias.js
+++ b/src/migrations/20250907153000-create-advertencias.js
@@ -22,7 +22,7 @@ module.exports = {
         type: Sequelize.INTEGER,
         allowNull: false,
         references: {
-          model: 'Clientes',
+          model: 'Clientes_Eventos',
           key: 'id',
         },
         onUpdate: 'CASCADE',

--- a/src/migrations/20250913130000-alter-advertencias-cliente-fk.js
+++ b/src/migrations/20250913130000-alter-advertencias-cliente-fk.js
@@ -1,0 +1,29 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.changeColumn('Advertencias', 'cliente_id', {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'Clientes_Eventos',
+        key: 'id',
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE',
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.changeColumn('Advertencias', 'cliente_id', {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'Clientes',
+        key: 'id',
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE',
+    });
+  }
+};


### PR DESCRIPTION
## Summary
- point `cliente_id` in advertencias to `Clientes_Eventos`
- add migration to update existing advertencias FK

## Testing
- `npx sequelize-cli db:migrate` *(fails: Cannot find module './core/yargs')*
- `npm test` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_68beee00b0848333b87cf67d24966d0f