### PR TITLE
fix advertencias cliente fk migration

### DIFF
--- a/src/migrations/20250913130000-alter-advertencias-cliente-fk.js
+++ b/src/migrations/20250913130000-alter-advertencias-cliente-fk.js
@@ -2,6 +2,13 @@
 
 module.exports = {
   async up(queryInterface, Sequelize) {
+    const fks = await queryInterface.getForeignKeyReferencesForTable('Advertencias');
+    for (const fk of fks) {
+      if (fk.columnName === 'cliente_id') {
+        await queryInterface.removeConstraint('Advertencias', fk.constraintName);
+      }
+    }
+
     await queryInterface.changeColumn('Advertencias', 'cliente_id', {
       type: Sequelize.INTEGER,
       allowNull: false,
@@ -15,11 +22,18 @@ module.exports = {
   },
 
   async down(queryInterface, Sequelize) {
+    const fks = await queryInterface.getForeignKeyReferencesForTable('Advertencias');
+    for (const fk of fks) {
+      if (fk.columnName === 'cliente_id') {
+        await queryInterface.removeConstraint('Advertencias', fk.constraintName);
+      }
+    }
+
     await queryInterface.changeColumn('Advertencias', 'cliente_id', {
       type: Sequelize.INTEGER,
       allowNull: false,
       references: {
-        model: 'Clientes',
+        model: 'Clientes_Eventos',
         key: 'id',
       },
       onUpdate: 'CASCADE',


### PR DESCRIPTION
## Summary
- drop existing cliente_id foreign key before altering Advertencias
- ensure both directions reference Clientes_Eventos

## Testing
- `npm test` (fails: Cannot find module 'express')
- `npx sequelize-cli db:migrate --migrations-path src/migrations --url sqlite:tmp_mig.db` (fails: command terminated after extended runtime)


------
https://chatgpt.com/codex/tasks/task_e_68bef1c56fac8333854165599d5c7dd6