### PR TITLE
Expose letterhead renderer for manual invocation

### DIFF
--- a/src/api/adminOficiosRoutes.js
+++ b/src/api/adminOficiosRoutes.js
@@ -104,7 +104,7 @@ router.get(
         if (!res.headersSent) res.status(500).end();
       });
       // 4) Aplica papel timbrado (todas as páginas)
-      applyLetterhead(doc, { imagePath: path.join(__dirname, '..', 'assets', 'papel-timbrado-secti.png') });
+      const renderLetterhead = applyLetterhead(doc, { imagePath: path.join(__dirname, '..', 'assets', 'papel-timbrado-secti.png') });
 
       res.setHeader('Content-Type', 'application/pdf');
       res.setHeader('Content-Disposition', `attachment; filename="oficio_${permissionarioId}.pdf"`);
@@ -274,6 +274,7 @@ router.get(
       }
 
       // 8) Finaliza
+      renderLetterhead();
       doc.end();
 
       // (opcional) gravar referência no banco

--- a/src/api/adminRoutes.js
+++ b/src/api/adminRoutes.js
@@ -428,7 +428,7 @@ router.get(
         doc.pipe(res);
 
         // Papel timbrado em todas as páginas
-        applyLetterhead(doc, { imagePath: path.join(__dirname, '..', 'assets', 'papel-timbrado-secti.png') });
+        const renderLetterhead = applyLetterhead(doc, { imagePath: path.join(__dirname, '..', 'assets', 'papel-timbrado-secti.png') });
 
         // Cursor inicial dentro da área útil
         doc.x = doc.page.margins.left;
@@ -442,6 +442,7 @@ router.get(
         doc.moveDown(2);
         generateTable(doc, permissionarios);
 
+        renderLetterhead();
         doc.end();
         return;
       }
@@ -563,7 +564,7 @@ router.get(
       doc.pipe(stream);
 
       // Papel timbrado em todas as páginas
-      applyLetterhead(doc, { imagePath: path.join(__dirname, '..', 'assets', 'papel-timbrado-secti.png') });
+      const renderLetterhead = applyLetterhead(doc, { imagePath: path.join(__dirname, '..', 'assets', 'papel-timbrado-secti.png') });
 
       // Cursor inicial dentro da área útil
       doc.x = doc.page.margins.left;
@@ -576,6 +577,7 @@ router.get(
       doc.fillColor('#333').fontSize(16).text('Relatório de Devedores', { align: 'center' });
       doc.moveDown(2);
       generateDebtorsTable(doc, devedores);
+      renderLetterhead();
       doc.end();
 
       await new Promise((resolve, reject) => {
@@ -663,7 +665,7 @@ router.get(
       const stream = fs.createWriteStream(filePath);
       doc.pipe(stream);
 
-      applyLetterhead(doc, { imagePath: path.join(__dirname, '..', 'assets', 'papel-timbrado-secti.png') });
+      const renderLetterhead = applyLetterhead(doc, { imagePath: path.join(__dirname, '..', 'assets', 'papel-timbrado-secti.png') });
 
       doc.x = doc.page.margins.left;
       doc.y = doc.page.margins.top;
@@ -673,6 +675,7 @@ router.get(
       doc.fillColor('#333').fontSize(16).text('Relatório de DARs', { align: 'center' });
       doc.moveDown(2);
       generateDarsTable(doc, dars);
+      renderLetterhead();
       doc.end();
 
       await new Promise((resolve, reject) => {
@@ -758,7 +761,7 @@ router.get(
       const stream = fs.createWriteStream(filePath);
       doc.pipe(stream);
 
-      applyLetterhead(doc, { imagePath: path.join(__dirname, '..', 'assets', 'papel-timbrado-secti.png') });
+      const renderLetterhead = applyLetterhead(doc, { imagePath: path.join(__dirname, '..', 'assets', 'papel-timbrado-secti.png') });
       doc.x = doc.page.margins.left;
       doc.y = doc.page.margins.top;
       printToken(doc, tokenDoc, qrBuffer);
@@ -795,6 +798,7 @@ router.get(
         }
       });
 
+      renderLetterhead();
       doc.end();
 
       await new Promise((resolve, reject) => {
@@ -864,7 +868,7 @@ router.get(
       const stream = fs.createWriteStream(filePath);
       doc.pipe(stream);
 
-      applyLetterhead(doc, { imagePath: path.join(__dirname, '..', 'assets', 'papel-timbrado-secti.png') });
+      const renderLetterhead = applyLetterhead(doc, { imagePath: path.join(__dirname, '..', 'assets', 'papel-timbrado-secti.png') });
 
       doc.x = doc.page.margins.left;
       doc.y = doc.page.margins.top;
@@ -873,6 +877,7 @@ router.get(
       doc.fillColor('#333').fontSize(16).text('Relatório DARs de Eventos', { align: 'center' });
       doc.moveDown(2);
       generateEventoDarsTable(doc, dars);
+      renderLetterhead();
       doc.end();
 
       await new Promise((resolve, reject) => {

--- a/src/api/adminTermoEventosPDFRoutes.js
+++ b/src/api/adminTermoEventosPDFRoutes.js
@@ -351,7 +351,7 @@ router.get(
       doc.pipe(fileStream);
 
       // Timbrado (usa SEU helper do ofício) - caminho que você informou:
-      applyLetterhead(doc, { imagePath: path.join(process.cwd(), 'public', 'images', 'papel-timbrado-secti.png') });
+      const renderLetterhead = applyLetterhead(doc, { imagePath: path.join(process.cwd(), 'public', 'images', 'papel-timbrado-secti.png') });
 
       // Primeira página: cursor na área útil + token
       doc.x = doc.page.margins.left;
@@ -527,6 +527,7 @@ router.get(
       printPageNumbers(doc);
 
       // Finaliza doc: fecha stream e só então indexa + devolve
+      renderLetterhead();
       doc.end();
 
       fileStream.on('finish', async () => {

--- a/src/api/adminTermoEventosRoutes.js
+++ b/src/api/adminTermoEventosRoutes.js
@@ -358,7 +358,7 @@ router.get(
       doc.on('data', (c) => chunks.push(c));
 
       // Timbrado (todas as páginas)
-      applyLetterhead(doc, { imagePath: letterheadPath });
+      const renderLetterhead = applyLetterhead(doc, { imagePath: letterheadPath });
 
       // Cursor inicial e token a cada página
       doc.x = doc.page.margins.left;
@@ -504,6 +504,7 @@ router.get(
       });
 
       // Finaliza
+      renderLetterhead();
       doc.end();
 
     } catch (err) {

--- a/src/api/permissionariosRoutes.js
+++ b/src/api/permissionariosRoutes.js
@@ -178,7 +178,7 @@ router.get('/:id/certidao', authMiddleware, async (req, res) => {
 
     // === Renderização ===
     // Papel timbrado em todas as páginas
-    applyLetterhead(doc, { imagePath: path.join(__dirname, '..', 'assets', 'papel-timbrado-secti.png') });
+    const renderLetterhead = applyLetterhead(doc, { imagePath: path.join(__dirname, '..', 'assets', 'papel-timbrado-secti.png') });
 
     // Cursor inicial na área útil + token por página
     doc.x = doc.page.margins.left;
@@ -271,6 +271,7 @@ router.get('/:id/certidao', authMiddleware, async (req, res) => {
     }
 
   // Finaliza
+  renderLetterhead();
   doc.end();
 } catch (err) {
     console.error('[permissionarios/certidao] erro:', err.stack || err);

--- a/src/services/advertenciaPdfService.js
+++ b/src/services/advertenciaPdfService.js
@@ -84,7 +84,7 @@ async function gerarAdvertenciaPdfEIndexar({ advertenciaId = null, evento = {}, 
   const ws = fs.createWriteStream(filePath);
   doc.pipe(ws);
 
-  applyLetterhead(doc, {});
+  const renderLetterhead = applyLetterhead(doc, {});
   doc.font('Times-Bold').fontSize(14).text('TERMO DE ADVERTÊNCIA', { align: 'center' });
   doc.moveDown();
 
@@ -117,6 +117,7 @@ async function gerarAdvertenciaPdfEIndexar({ advertenciaId = null, evento = {}, 
     ws.on('finish', resolve);
     ws.on('error', reject);
   });
+  renderLetterhead();
   doc.end();
   await finishPromise;
 

--- a/src/services/darComprovanteService.js
+++ b/src/services/darComprovanteService.js
@@ -118,7 +118,7 @@ async function gerarComprovante(darId, db, { reuseExisting = true } = {}) {
   const tokenDoc = await gerarTokenDocumento('DAR_COMPROVANTE', dar.permissionario_id, db);
 
   const doc = new PDFDocument({ size: 'A4', margins: abntMargins(0.5, 0.5, 2) });
-  applyLetterhead(doc);
+  const renderLetterhead = applyLetterhead(doc);
 
   const chunks = [];
   let tokenYFromBottom = 0;
@@ -190,6 +190,7 @@ async function gerarComprovante(darId, db, { reuseExisting = true } = {}) {
 
   tokenYFromBottom = doc.page.height - ((boxTop + 100) + 100 + cm(2));
 
+  renderLetterhead();
   doc.end();
 
   return endPromise;

--- a/src/services/termoEventoPdfkitService.js
+++ b/src/services/termoEventoPdfkitService.js
@@ -499,7 +499,7 @@ const saldoISO = parcelas.length > 1
   if (!fs.existsSync(letterheadPath)) {
     letterheadPath = path.join(__dirname, '..', 'assets', 'papel-timbrado-secti.png');
   }
-  applyLetterhead(doc, { imagePath: letterheadPath });
+  const renderLetterhead = applyLetterhead(doc, { imagePath: letterheadPath });
 
   // Cursor inicial
   doc.font('Times-Roman').fontSize(12);
@@ -679,6 +679,7 @@ const saldoISO = parcelas.length > 1
     ws.on('finish', resolve);
     ws.on('error', reject);
   });
+  renderLetterhead();
   doc.end();
   await finishPromise;
   console.log('[TERMO][SERVICE] PDF gravado em', filePath);

--- a/src/utils/pdfLetterhead.js
+++ b/src/utils/pdfLetterhead.js
@@ -68,13 +68,8 @@ function applyLetterhead(doc, opts = {}) {
   render();
   // novas páginas
   doc.on('pageAdded', render);
-
-  // garante que o timbrado seja desenhado antes de finalizar o documento
-  const originalEnd = doc.end.bind(doc);
-  doc.end = (...args) => {
-    render();
-    return originalEnd(...args);
-  };
+  // retorna função para permitir renderização manual antes de finalizar o documento
+  return render;
 }
 
 module.exports = { applyLetterhead, abntMargins, cm };

--- a/tests/adminDarsComprovante.test.js
+++ b/tests/adminDarsComprovante.test.js
@@ -64,7 +64,7 @@ test('comprovante persiste data de pagamento encontrada', async () => {
   } };
 
   const letterPath = path.resolve(__dirname, '../src/utils/pdfLetterhead.js');
-  require.cache[letterPath] = { exports: { applyLetterhead: () => {}, abntMargins: () => ({}), cm: () => 0 } };
+  require.cache[letterPath] = { exports: { applyLetterhead: () => () => {}, abntMargins: () => ({}), cm: () => 0 } };
 
   const pdfkitPath = require.resolve('pdfkit');
   require.cache[pdfkitPath] = { exports: class {
@@ -179,7 +179,7 @@ test('comprovante busca pagamentos anteriores ao vencimento', async () => {
   } };
 
   const letterPath = path.resolve(__dirname, '../src/utils/pdfLetterhead.js');
-  require.cache[letterPath] = { exports: { applyLetterhead: () => {}, abntMargins: () => ({}), cm: () => 0 } };
+  require.cache[letterPath] = { exports: { applyLetterhead: () => () => {}, abntMargins: () => ({}), cm: () => 0 } };
 
   const pdfkitPath = require.resolve('pdfkit');
   require.cache[pdfkitPath] = { exports: class {
@@ -290,7 +290,7 @@ test('comprovante reutiliza PDF existente quando token e arquivo presentes', asy
   const tokenPath = path.resolve(__dirname, '../src/utils/token.js');
   require.cache[tokenPath] = { exports: { gerarTokenDocumento: async () => 'tok', imprimirTokenEmPdf: async (b64) => b64 } };
   const letterPath = path.resolve(__dirname, '../src/utils/pdfLetterhead.js');
-  require.cache[letterPath] = { exports: { applyLetterhead: () => {}, abntMargins: () => ({}), cm: () => 0 } };
+  require.cache[letterPath] = { exports: { applyLetterhead: () => () => {}, abntMargins: () => ({}), cm: () => 0 } };
   const pdfkitPath = require.resolve('pdfkit');
   require.cache[pdfkitPath] = { exports: class { constructor() { this.page = { width: 0, height: 0 }; } on(){} end(){} } };
   const qrPath = require.resolve('qrcode');

--- a/tests/termoEventoDatasMultiplas.test.js
+++ b/tests/termoEventoDatasMultiplas.test.js
@@ -26,7 +26,7 @@ function setupPdf(events) {
 
   const letterheadPath = path.resolve(__dirname, '../src/utils/pdfLetterhead.js');
   require.cache[letterheadPath] = {
-    exports: { applyLetterhead: () => {}, abntMargins: () => ({ top:50, bottom:50, left:50, right:50 }) }
+    exports: { applyLetterhead: () => () => {}, abntMargins: () => ({ top:50, bottom:50, left:50, right:50 }) }
   };
 
   delete require.cache[require.resolve('../src/services/termoEventoPdfkitService.js')];

--- a/tests/termoEventoPdfkitServiceSpaces.test.js
+++ b/tests/termoEventoPdfkitServiceSpaces.test.js
@@ -25,7 +25,7 @@ function setup(events) {
   require.cache[sqlitePath] = { exports: sqlite3Stub };
 
   const letterheadPath = path.resolve(__dirname, '../src/utils/pdfLetterhead.js');
-  require.cache[letterheadPath] = { exports: { applyLetterhead: () => {}, abntMargins: () => ({ top:50, bottom:50, left:50, right:50 }) } };
+  require.cache[letterheadPath] = { exports: { applyLetterhead: () => () => {}, abntMargins: () => ({ top:50, bottom:50, left:50, right:50 }) } };
 
   delete require.cache[require.resolve('../src/services/termoEventoPdfkitService.js')];
   return require('../src/services/termoEventoPdfkitService.js');


### PR DESCRIPTION
## Summary
- return the internal render function from `applyLetterhead` instead of overriding `doc.end`
- update all PDF generation modules to call the returned render function before `doc.end`
- adjust tests to mock new `applyLetterhead` behavior

## Testing
- `npm test` *(fails: test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c03641e9d483339e7c40f7f14d4875