### PR TITLE
Adjust token layout within PDF to avoid overflow

### DIFF
--- a/src/api/adminTermoEventosRoutes.js
+++ b/src/api/adminTermoEventosRoutes.js
@@ -210,15 +210,15 @@ function printToken(doc, token, qrBuffer) {
   const avisoWidth = qrX - x - 10;
   doc.fontSize(7).fillColor('#222');
   const avisoHeight = doc.heightOfString(aviso, { width: avisoWidth });
-  const avisoY = baseY + 2;
+  const avisoY = baseY - avisoHeight - 10;   // 10pt de margem
   const tokenY = avisoY + avisoHeight + 2;
   doc.text(aviso, x, avisoY, { width: avisoWidth });
 
   const text = `Token: ${token}`;
   doc.fontSize(8).text(text, x, tokenY, { lineBreak:false });
-  doc.image(qrBuffer, qrX, tokenY - (qrSize - 8), {
-    fit: [qrSize, qrSize],
-  });
+
+  const qrY = tokenY - qrSize + 8;
+  doc.image(qrBuffer, qrX, qrY, { fit: [qrSize, qrSize] });
   doc.restore();
   doc.x = prevX; doc.y = prevY;
 }


### PR DESCRIPTION
## Summary
- keep token block inside page margins in `printToken`
- align QR code image using calculated `tokenY`

## Testing
- `node - <<'NODE' ... NODE`
- `npm test` *(fails: 64 passed, 15 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c03a478cd883339cf0af7044020a83