### PR TITLE
Use PDFKit service for termo event generation

### DIFF
--- a/src/api/termoEventosRoutes.js
+++ b/src/api/termoEventosRoutes.js
@@ -1,11 +1,11 @@
 const express = require('express');
 const router = express.Router();
-const { gerarTermoEventoEIndexar } = require('../services/termoEventoExportService');
+const { gerarTermoEventoPdfkitEIndexar } = require('../services/termoEventoPdfkitService');
 
 router.post('/:eventoId/gerar-termo', async (req, res) => {
   try {
     const { eventoId } = req.params;
-    const out = await gerarTermoEventoEIndexar(eventoId);
+    const out = await gerarTermoEventoPdfkitEIndexar(eventoId);
     return res.json({
       ok: true,
       documentoId: out.documentoId,


### PR DESCRIPTION
## Summary
- Switch termoEventos route to use termoEventoPdfkitService
- Use gerarTermoEventoPdfkitEIndexar when generating termo

## Testing
- `npm test` (fails: 38 failing, 5 passing)


------
https://chatgpt.com/codex/tasks/task_e_68c04237e67083338f5f2f8eaa896c5f