### PR TITLE
Handle termo re-generation without token conflict

### DIFF
--- a/src/services/termoEventoPdfkitService.js
+++ b/src/services/termoEventoPdfkitService.js
@@ -696,9 +696,10 @@ const saldoISO = parcelas.length > 1
   await dbRun(
     `INSERT INTO documentos (tipo, token, permissionario_id, evento_id, pdf_url, pdf_public_url, status, created_at)
      VALUES ('termo_evento', ?, ?, ?, ?, ?, 'gerado', ?)
-     ON CONFLICT(token) DO UPDATE SET
+     ON CONFLICT(evento_id, tipo) DO UPDATE SET
        permissionario_id = excluded.permissionario_id,
        evento_id = excluded.evento_id,
+       token = excluded.token,
        pdf_url = excluded.pdf_url,
        pdf_public_url = excluded.pdf_public_url,
        status = 'gerado',


### PR DESCRIPTION
## Summary
- allow updating existing termo by evento/tipo upsert, refreshing token on conflict

## Testing
- `npm test` (fails: 38 failing tests)
- `SQLITE_STORAGE=./test.db node - <<'NODE'` (regenerated successfully)


------
https://chatgpt.com/codex/tasks/task_e_68c057e3dff48333886896d9b444b87e