### PR TITLE
Add coworking info to espacos configuration

### DIFF
--- a/src/config/espacos.js
+++ b/src/config/espacos.js
@@ -3,4 +3,8 @@ export const ESPACOS_INFO = {
     nome: 'Espaço Principal',
     capacidade: 100,
   },
+  coworking: {
+    nome: 'Coworking do Espaço de Fomento',
+    capacidade: 30,
+  },
 };

--- a/test/termoEventoPdfkitService.test.js
+++ b/test/termoEventoPdfkitService.test.js
@@ -25,6 +25,9 @@ assert.strictEqual(dados.vigencia.fim, vigenciaEsperada.toISOString());
 assert.deepStrictEqual(dados.dars, evento.dars);
 
 assert.deepStrictEqual(getEspacoInfo('default'), ESPACOS_INFO.default);
+assert.deepStrictEqual(getEspacoInfo('coworking'), ESPACOS_INFO.coworking);
+assert.strictEqual(ESPACOS_INFO.coworking.nome, 'Coworking do Espaço de Fomento');
+assert.strictEqual(ESPACOS_INFO.coworking.capacidade, 30);
 
 (async () => {
   const token = 'TOKEN123';


### PR DESCRIPTION
## Summary
- add coworking information for ESPACOS_INFO
- verify coworking info in termo pdf service tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c067dc560c8333896b97ac2c501ac6