### PR TITLE
Atualiza envio de CPF com dados completos e adiciona rota PATCH

### DIFF
--- a/public/admin/eventos-dars.html
+++ b/public/admin/eventos-dars.html
@@ -1548,14 +1548,32 @@ function normalizarEvento(payload){
       submitBtn.disabled = true;
       submitBtn.innerHTML = `<span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span> Salvando...`;
       try {
+        const cli = clientes.find(c => String(c.id) === String(clienteId));
+        if (!cli) throw new Error('Cliente não encontrado');
+        const payload = {
+          nome_razao_social: cli.nome_razao_social,
+          tipo_pessoa: cli.tipo_pessoa,
+          documento: cli.documento,
+          email: cli.email,
+          telefone: cli.telefone,
+          nome_responsavel: cli.nome_responsavel,
+          tipo_cliente: cli.tipo_cliente,
+          documento_responsavel: cpf,
+          cep: cli.cep,
+          logradouro: cli.logradouro,
+          numero: cli.numero,
+          complemento: cli.complemento,
+          bairro: cli.bairro,
+          cidade: cli.cidade,
+          uf: cli.uf
+        };
         const resp = await fetch(`/api/admin/eventos-clientes/${clienteId}`, {
           method:'PUT',
           headers:{ 'Content-Type':'application/json', ...AUTH_HEADERS },
-          body: JSON.stringify({ documento_responsavel: cpf })
+          body: JSON.stringify(payload)
         });
         if (!resp.ok) throw new Error('Falha ao salvar CPF');
-        const cli = clientes.find(c => String(c.id) === String(clienteId));
-        if (cli) cli.documento_responsavel = cpf;
+        cli.documento_responsavel = cpf;
         cpfModal.style.display = 'none';
         await baixarTermoOriginal(eventoId, btn);
       } catch(err){

--- a/src/api/eventosClientesRoutes.js
+++ b/src/api/eventosClientesRoutes.js
@@ -755,6 +755,26 @@ adminRouter.put('/:id', async (req, res) => {
   }
 });
 
+
+adminRouter.patch('/:id/cpf', async (req, res) => {
+  const { id } = req.params;
+  let { documento_responsavel } = req.body || {};
+  documento_responsavel = onlyDigits(documento_responsavel || '');
+  if (!isCpf(documento_responsavel)) {
+    return res.status(400).json({ error: 'CPF inválido.' });
+  }
+  try {
+    const result = await dbRun(`UPDATE Clientes_Eventos SET documento_responsavel = ? WHERE id = ?`, [documento_responsavel, id]);
+    if (!result.changes) {
+      return res.status(404).json({ error: 'Cliente de evento não encontrado.' });
+    }
+    res.json({ message: 'CPF do responsável atualizado com sucesso.' });
+  } catch (err) {
+    console.error('[EVENTOS-CLIENTES][PATCH CPF] ERRO:', err.message);
+    res.status(500).json({ error: 'Erro ao atualizar CPF do responsável.' });
+  }
+});
+
 // REENVIAR LINK DE DEFINIÇÃO DE SENHA
 adminRouter.post('/:id/reenviar-senha', async (req, res) => {
   const { id } = req.params;


### PR DESCRIPTION
## Resumo
- Envia todos os campos do cliente ao salvar CPF do responsável em `eventos-dars.html`
- Adiciona rota `PATCH /api/admin/eventos-clientes/:id/cpf` para atualização isolada do CPF

## Testes
- `npm test` (falhou: tests 43, pass 5, fail 38)


------
https://chatgpt.com/codex/tasks/task_e_68c0788a0f3083338626de04ab9c81fc