### PR TITLE
feat: notify via whatsapp after term request

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,12 @@ EMAIL_PASS="qnmc rgwt uaod qvzw"
 # --- Chave Secreta para Tokens --- 
 JWT_SECRET="uma-chave-super-secreta-e-longa-para-meu-projeto-12345" 
 BOT_KEY="Secti@2025#" 
-BOT_SHARED_KEY="Secti@2025#" # 
-BOT_AUTH_DEBUG=1 
+BOT_SHARED_KEY="Secti@2025#" #
+BOT_AUTH_DEBUG=1
+
+# --- WhatsApp Bot ---
+WHATSAPP_BOT_URL="https://seu-bot-de-whatsapp.example.com/send"
+WHATSAPP_BOT_TOKEN="coloque_o_token_aqui"
 
 ADMIN_PUBLIC_BASE=https://admin.portalcipt.com.br 
 # Admin (para equipe/admin)

--- a/src/services/whatsappService.js
+++ b/src/services/whatsappService.js
@@ -1,0 +1,30 @@
+// src/services/whatsappService.js
+const axios = require('axios');
+
+const BASE_URL = (process.env.WHATSAPP_BOT_URL || '').replace(/\/+$/, '');
+const TOKEN = process.env.WHATSAPP_BOT_TOKEN || '';
+
+async function sendMessage(msisdn, text) {
+  if (!BASE_URL) {
+    console.warn('[WHATSAPP] WHATSAPP_BOT_URL não configurada.');
+    return false;
+  }
+  try {
+    const url = BASE_URL; // assume base already includes path
+    const headers = { 'Content-Type': 'application/json' };
+    if (TOKEN) headers.Authorization = `Bearer ${TOKEN}`;
+    const body = { msisdn, text };
+    const resp = await axios.post(url, body, { headers, timeout: 10000, validateStatus: () => true });
+    if (resp.status >= 200 && resp.status < 300) {
+      console.log('[WHATSAPP] mensagem enviada', msisdn);
+      return true;
+    }
+    console.error('[WHATSAPP] falha HTTP', resp.status, resp.data);
+    return false;
+  } catch (err) {
+    console.error('[WHATSAPP] erro ao enviar', err.message || err);
+    return false;
+  }
+}
+
+module.exports = { sendMessage };


### PR DESCRIPTION
## Summary
- add WhatsApp service to send messages with env-configured URL and token
- notify signer via WhatsApp after requesting Assinafy signatures
- document WhatsApp bot environment variables

## Testing
- `npm test` *(fails: tests 43, pass 5, fail 38)*

------
https://chatgpt.com/codex/tasks/task_e_68c07b6b07a483338554fed70e67bd5a