### PR TITLE
Alias parcelas and due dates for admin DARs

### DIFF
--- a/src/api/adminEventosRoutes.js
+++ b/src/api/adminEventosRoutes.js
@@ -582,12 +582,13 @@ router.get('/:eventoId/dars', async (req, res) => {
     const sql = `
       SELECT
         d.id                                AS id,
-        de.numero_parcela,
+        de.numero_parcela                   AS parcela_num,
         COALESCE(de.valor_parcela, d.valor) AS valor,
         d.id                                AS dar_id,
-        d.data_vencimento                   AS venc,
+        de.data_vencimento                  AS vencimento,
         d.status                            AS status,
-        d.pdf_url                           AS pdf_url
+        d.pdf_url                           AS pdf_url,
+        d.numero_documento                  AS dar_numero
       FROM DARs_Eventos de
       JOIN dars d ON d.id = de.id_dar
       WHERE de.id_evento = ?


### PR DESCRIPTION
## Summary
- Alias `de.numero_parcela` as `parcela_num`
- Use `de.data_vencimento` as `vencimento` and expose DAR numbers

## Testing
- `npm test` *(fails: tests 43, suites 0, pass 5, fail 38)*

------
https://chatgpt.com/codex/tasks/task_e_68c191a6a63883339cb3fad42311dadd