### PR TITLE
fix: preserve original due date when no delay

### DIFF
--- a/public/admin/eventos-dars.html
+++ b/public/admin/eventos-dars.html
@@ -1341,7 +1341,10 @@ function normalizarEvento(payload){
         const r = await fetch(u, { headers: AUTH_HEADERS });
         if (!r.ok) continue;
         const j = await r.json();
-        const arr = j?.dars || j?.DARs || j || [];
+        const arr =
+          j?.dars || j?.DARs ||
+          j?.data?.dars || j?.data?.DARs ||
+          j?.data || j || [];
         if (Array.isArray(arr)) return arr;
       }catch{}
     }
@@ -1378,18 +1381,20 @@ function normalizarEvento(payload){
                 const pdfStr = (d.dar_pdf || '').toString().replace(/\s/g,'');
                 const hasB64 = isPdfBase64(pdfStr);
                 const darId = d.id || d.dar_id || d.parcela_id || d.referencia || d.parcela_num || '';
-                const btn = hasB64
-                  ? `<button class="btn btn-sm btn-success" data-dar-b64="${pdfStr}" data-evento="${eventoId}" data-parc="${d.parcela_num||''}">
-                      <i class="bi bi-download"></i> Baixar
-                     </button>`
-                  : `<div class="btn-group">
-                       <button class="btn btn-sm btn-outline-primary btn-reemitir-dar" data-dar-id="${darId}" data-evento-id="${eventoId}">
-                         <i class="bi bi-printer"></i> Reemitir
-                       </button>
-                       <button class="btn btn-sm btn-outline-secondary btn-baixar-endpoint" data-dar-id="${darId}" data-evento-id="${eventoId}">
-                         <i class="bi bi-file-earmark-arrow-down"></i> Baixar
-                       </button>
-                     </div>`;
+                const btn = status === 'Pago'
+                  ? `<span class="text-success"><i class="bi bi-check-circle-fill"></i> Pago</span>`
+                  : (hasB64
+                      ? `<button class="btn btn-sm btn-success" data-dar-b64="${pdfStr}" data-evento="${eventoId}" data-parc="${d.parcela_num||''}">
+                          <i class="bi bi-download"></i> Baixar
+                         </button>`
+                      : `<div class="btn-group">
+                           <button class="btn btn-sm btn-outline-primary btn-reemitir-dar" data-dar-id="${darId}" data-evento-id="${eventoId}">
+                             <i class="bi bi-printer"></i> Reemitir
+                           </button>
+                           <button class="btn btn-sm btn-outline-secondary btn-baixar-endpoint" data-dar-id="${darId}" data-evento-id="${eventoId}">
+                             <i class="bi bi-file-earmark-arrow-down"></i> Baixar
+                           </button>
+                         </div>`);
                 const badge = status==='Pago' ? 'bg-success'
                              : ['Emitido','Reemitido'].includes(status) ? 'bg-primary'
                              : status==='Vencido' ? 'bg-danger'

--- a/public/eventos/dashboard-eventos.html
+++ b/public/eventos/dashboard-eventos.html
@@ -254,7 +254,11 @@
           const r = await fetch(u, { headers });
           if (!r.ok) continue;
           const j = await r.json().catch(()=> ({}));
-          const lista = j?.dars || j?.data || (Array.isArray(j) ? j : []);
+          const lista =
+            j?.dars ||
+            j?.data?.dars ||
+            j?.data ||
+            (Array.isArray(j) ? j : []);
           if (Array.isArray(lista) && lista.length) return lista;
         }catch{}
       }
@@ -314,9 +318,11 @@
                 const status  = normalizaStatus(d.status ?? d.dar_status ?? 'Pendente');
                 const isEmit  = !!(d.dar_pdf && String(d.dar_pdf).replace(/\s/g,'').length>30);
                 const darId   = d.id || d.dar_id || d.parcela_id || d.referencia || d.parcela_num || '';
-                const btn = isEmit
-                  ? `<button class="btn btn-sm btn-success" data-dar-download="${d.dar_pdf}" data-evento="${eventoId}" data-parc="${d.parcela_num||''}"><i class="bi bi-download"></i> Baixar</button>`
-                  : `<button class="btn btn-sm btn-outline-primary" data-dar-reemitir="${darId}" data-evento="${eventoId}"><i class="bi bi-printer"></i> Emitir 2ª Via</button>`;
+                const btn = status === 'Pago'
+                  ? `<span class="text-success"><i class="bi bi-check-circle-fill"></i> Pago</span>`
+                  : (isEmit
+                      ? `<button class="btn btn-sm btn-success" data-dar-download="${d.dar_pdf}" data-evento="${eventoId}" data-parc="${d.parcela_num||''}"><i class="bi bi-download"></i> Baixar</button>`
+                      : `<button class="btn btn-sm btn-outline-primary" data-dar-reemitir="${darId}" data-evento="${eventoId}"><i class="bi bi-printer"></i> Emitir 2ª Via</button>`);
                 const badge = status==='Pago' ? 'bg-success' : (['Emitido','Reemitido'].includes(status) ? 'bg-primary' : (status==='Vencido' ? 'bg-danger':'bg-warning text-dark'));
                 return `<tr>
                   <td>${d.parcela_num || d.referencia || '-'}</td>

--- a/src/api/eventosClientesRoutes.js
+++ b/src/api/eventosClientesRoutes.js
@@ -222,7 +222,13 @@ clientRouter.post('/dars/:id/reemitir', async (req, res) => {
     const enc = await calcularEncargosAtraso(dar).catch(() => null);
     if (enc) {
       if (enc.valorAtualizado != null) dar.valor = enc.valorAtualizado;
-      if (enc.novaDataVencimento) dar.data_vencimento = enc.novaDataVencimento;
+      if (enc.novaDataVencimento) {
+        const nova = new Date(enc.novaDataVencimento);
+        const original = new Date(row.data_vencimento);
+        if (nova > original) {
+          dar.data_vencimento = enc.novaDataVencimento;
+        }
+      }
     }
 
     const docCliente = onlyDigits(row.documento);

--- a/src/services/cobrancaService.js
+++ b/src/services/cobrancaService.js
@@ -46,9 +46,12 @@ async function calcularEncargosAtraso(dar) {
     // Se a nova data de vencimento for anterior ou igual à original, não há encargos
     if (diasAtraso <= 0) {
         return {
-            valorOriginal: dar.valor, multa: 0, juros: 0, diasAtraso: 0,
+            valorOriginal: dar.valor,
+            multa: 0,
+            juros: 0,
+            diasAtraso: 0,
             valorAtualizado: dar.valor,
-            novaDataVencimento: novaDataVencimento.toISOString().split('T')[0]
+            novaDataVencimento: dar.data_vencimento
         };
     }
 


### PR DESCRIPTION
## Summary
- keep original vencimento when DAR is reissued without atrasos
- only update DAR vencimento if new date is later than current
- handle nested DAR listings and hide actions for paid DARs in dashboards

## Testing
- `npm test` *(fails: test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a04df2ec833396d47ee07584ad1c