### PR TITLE
Atualiza status Realizado e badges neutras

### DIFF
--- a/public/admin/eventos-dars.html
+++ b/public/admin/eventos-dars.html
@@ -976,6 +976,7 @@ async function carregarClientes(){
       const status = ev.status || 'Pendente';
       const badge = status === 'Pago' ? 'bg-success'
                   : ['Emitido','Reemitido'].includes(status) ? 'bg-primary'
+                  : status === 'Realizado' ? 'bg-secondary'
                   : 'bg-warning text-dark';
       const rowClass = ev.remarcado ? 'table-warning' : '';
       
@@ -1113,7 +1114,8 @@ function atualizarStatusNaTabelaEventos(eventoId, status){
         badge.className = 'badge ' + (
           status==='Pago'
             ? 'bg-success'
-            : (['Emitido','Reemitido'].includes(status) ? 'bg-primary' : 'bg-warning text-dark')
+            : (['Emitido','Reemitido'].includes(status) ? 'bg-primary'
+               : (status === 'Realizado' ? 'bg-secondary' : 'bg-warning text-dark'))
         );
       }
     }
@@ -1397,6 +1399,7 @@ function normalizarEvento(payload){
                          </div>`);
                 const badge = status==='Pago' ? 'bg-success'
                              : ['Emitido','Reemitido'].includes(status) ? 'bg-primary'
+                             : status==='Realizado' ? 'bg-secondary'
                              : status==='Vencido' ? 'bg-danger'
                              : 'bg-warning text-dark';
                 return `<tr>

--- a/public/eventos/dashboard-eventos.html
+++ b/public/eventos/dashboard-eventos.html
@@ -323,7 +323,10 @@
                   : (isEmit
                       ? `<button class="btn btn-sm btn-success" data-dar-download="${d.dar_pdf}" data-evento="${eventoId}" data-parc="${d.parcela_num||''}"><i class="bi bi-download"></i> Baixar</button>`
                       : `<button class="btn btn-sm btn-outline-primary" data-dar-reemitir="${darId}" data-evento="${eventoId}"><i class="bi bi-printer"></i> Emitir 2ª Via</button>`);
-                const badge = status==='Pago' ? 'bg-success' : (['Emitido','Reemitido'].includes(status) ? 'bg-primary' : (status==='Vencido' ? 'bg-danger':'bg-warning text-dark'));
+                const badge = status==='Pago' ? 'bg-success'
+                             : (['Emitido','Reemitido'].includes(status) ? 'bg-primary'
+                                : (status==='Vencido' ? 'bg-danger'
+                                   : (status==='Realizado' ? 'bg-secondary' : 'bg-warning text-dark')));
                 return `<tr>
                   <td>${d.parcela_num || d.referencia || '-'}</td>
                   <td class="text-end">${formatBRL(valor)}</td>
@@ -426,8 +429,10 @@
             const lista = darsByEvento?.[evId] || [];
             const temPago    = lista.some(x=> normalizaStatus(x.status||x.dar_status)==='Pago');
             const temEmitido = lista.some(x=> ['Emitido','Reemitido'].includes(normalizaStatus(x.status||x.dar_status)));
-            const status     = temPago ? 'Pago' : (temEmitido ? 'Emitido' : 'Pendente');
-            const badge      = status==='Pago' ? 'success' : (['Emitido','Reemitido'].includes(status) ? 'primary' : 'warning text-dark');
+            const status     = ev.status || (temPago ? 'Pago' : (temEmitido ? 'Emitido' : 'Pendente'));
+            const badge      = status==='Pago' ? 'success'
+                              : (['Emitido','Reemitido'].includes(status) ? 'primary'
+                                 : (status === 'Realizado' ? 'secondary' : 'warning text-dark'));
             const valor = Number(typeof ev.valor_final==='number' ? ev.valor_final
                           : parseFloat(String(ev.valor_final||'0').replace(/\./g,'').replace(',','.')) || 0);
             const datasFmt = formatDatasEvento(ev.datas_evento || ev.data);

--- a/src/api/adminEventosRoutes.js
+++ b/src/api/adminEventosRoutes.js
@@ -416,6 +416,15 @@ router.get('/', async (req, res) => {
     const limitNum = parseInt(limit, 10) || 10;
     const offset = (pageNum - 1) * limitNum;
 
+    await dbRun(
+      `UPDATE Eventos
+          SET status = 'Realizado'
+        WHERE DATE(data_vigencia_final) < DATE('now')
+          AND status IN ('Pendente','Emitido','Reemitido','Pago','Parcialmente Pago')`,
+      [],
+      'realizar-eventos-passados'
+    );
+
     let whereClause = '';
     const params = [];
     if (search) {


### PR DESCRIPTION
## Summary
- Atualiza automaticamente status dos eventos vencidos para `Realizado`
- Exibe eventos realizados com cor neutra nas listagens

## Testing
- `npm test` *(fails: tests reported 38 failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a6c82e88833391e229a3be7ae8fb