### PR TITLE
chore: disable caching for eventos DARs build

### DIFF
--- a/public/admin/eventos-dars.html
+++ b/public/admin/eventos-dars.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+  <meta http-equiv="Pragma" content="no-cache">
+  <meta http-equiv="Expires" content="0">
   <title>Gestão de DARs de Eventos - CIPT</title>
   
   <link rel="icon" type="image/png" href="/images/logo-cipt.png">


### PR DESCRIPTION
## Summary
- add cache-control meta tags so browsers fetch the latest eventos DARs build

## Testing
- `curl -I -H 'Cache-Control: no-cache' http://localhost:4321/admin/eventos-dars.html` *(fails: Method Not Allowed)*
- `curl -s http://localhost:4321/admin/eventos-dars.html | grep -n "abrirModalDARs" -n`
- `curl -s http://localhost:4321/admin/eventos-dars.html | grep -n "Parcialmente Pago" -n`
- `npm test` *(fails: SEFAZ_APP_TOKEN não configurado no .env.; SQLITE_ERROR: no such table: Clientes_Eventos; db.serialize is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b080113c8333a0d9539bfd810e56