### PR TITLE
fix: ensure event vigencia final is stored

### DIFF
--- a/src/api/adminEventosRoutes.js
+++ b/src/api/adminEventosRoutes.js
@@ -408,7 +408,7 @@ router.get('/', async (req, res) => {
     await dbRun(
       `UPDATE Eventos
           SET status = 'Realizado'
-        WHERE DATE(data_vigencia_final) < DATE('now')
+        WHERE DATE(substr(data_vigencia_final,1,10)) < DATE('now')
           AND status IN ('Pendente','Emitido','Reemitido','Pago','Parcialmente Pago')`,
       [],
       'realizar-eventos-passados'

--- a/src/api/eventosRoutes.js
+++ b/src/api/eventosRoutes.js
@@ -96,9 +96,15 @@ router.post('/', async (req, res) => {
     }
 
     // Ordena as datas para garantir que a primeira é a correta
-    const datasOrdenadas = datasEvento.sort((a, b) => new Date(a) - new Date(b));
-    const dataVigenciaFinal = new Date(datasOrdenadas.at(-1));
-    dataVigenciaFinal.setDate(dataVigenciaFinal.getDate() + 1);
+    const datasOrdenadas = [...datasEvento].sort((a, b) => new Date(a) - new Date(b));
+    let dataVigenciaFinal = req.body.dataVigenciaFinal || req.body.data_vigencia_final || null;
+    if (!dataVigenciaFinal && datasOrdenadas.length) {
+        const tmp = new Date(datasOrdenadas.at(-1));
+        tmp.setDate(tmp.getDate() + 1);
+        dataVigenciaFinal = tmp.toISOString().slice(0,10);
+    } else if (dataVigenciaFinal) {
+        dataVigenciaFinal = new Date(dataVigenciaFinal).toISOString().slice(0,10);
+    }
     const primeiraDataEvento = new Date(datasOrdenadas[0]);
     
     const ultimaDataVencimento = new Date(parcelas.sort((a, b) => new Date(b.vencimento) - new Date(a.vencimento))[0].vencimento);
@@ -136,7 +142,7 @@ router.post('/', async (req, res) => {
                 JSON.stringify(espacosUtilizados || []),
                 areaM2 || null,
                 datasEvento.join(','),
-                dataVigenciaFinal.toISOString().slice(0,10),
+                dataVigenciaFinal,
                 totalDiarias,
                 valorBruto,
                 tipoDescontoAuto,

--- a/src/migrations/20250920120000-backfill-data-vigencia-final.js
+++ b/src/migrations/20250920120000-backfill-data-vigencia-final.js
@@ -1,0 +1,36 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface) {
+    const [rows] = await queryInterface.sequelize.query(
+      `SELECT id, datas_evento FROM Eventos WHERE data_vigencia_final IS NULL OR data_vigencia_final = ''`
+    );
+    for (const row of rows) {
+      let datas = [];
+      try {
+        const parsed = JSON.parse(row.datas_evento);
+        if (Array.isArray(parsed)) datas = parsed;
+      } catch (e) {
+        if (row.datas_evento) {
+          datas = String(row.datas_evento).split(/[,;\s]+/).filter(Boolean);
+        }
+      }
+      if (!Array.isArray(datas) || datas.length === 0) continue;
+      const ordenadas = datas.map((d) => new Date(d)).sort((a, b) => a - b);
+      const max = ordenadas[ordenadas.length - 1];
+      if (!max || isNaN(max)) continue;
+      max.setDate(max.getDate() + 1);
+      const iso = max.toISOString().slice(0, 10);
+      await queryInterface.sequelize.query(
+        `UPDATE Eventos SET data_vigencia_final = ? WHERE id = ?`,
+        { replacements: [iso, row.id] }
+      );
+    }
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.query(
+      `UPDATE Eventos SET data_vigencia_final = NULL`
+    );
+  }
+};

--- a/src/services/eventoDarService.js
+++ b/src/services/eventoDarService.js
@@ -125,10 +125,16 @@ async function criarEventoComDars(db, data, helpers) {
     }
   }
 
-  const datasOrdenadas = Array.isArray(datasEvento) ? [...datasEvento].sort((a,b)=> new Date(a)-new Date(b)) : [];
-  const dataVigenciaFinal = datasOrdenadas.length ? new Date(datasOrdenadas.at(-1)) : null;
-  if (dataVigenciaFinal) {
-    dataVigenciaFinal.setDate(dataVigenciaFinal.getDate() + 1);
+  const datasOrdenadas = Array.isArray(datasEvento)
+    ? [...datasEvento].sort((a, b) => new Date(a) - new Date(b))
+    : [];
+  let dataVigenciaFinal = data.dataVigenciaFinal || data.data_vigencia_final || null;
+  if (!dataVigenciaFinal && datasOrdenadas.length) {
+    const tmp = new Date(datasOrdenadas.at(-1));
+    tmp.setDate(tmp.getDate() + 1);
+    dataVigenciaFinal = tmp.toISOString().slice(0, 10);
+  } else if (dataVigenciaFinal) {
+    dataVigenciaFinal = new Date(dataVigenciaFinal).toISOString().slice(0, 10);
   }
 
   const MAX_ATTEMPTS = 5;
@@ -170,7 +176,7 @@ async function criarEventoComDars(db, data, helpers) {
         areaM2 != null ? Number(areaM2) : null,
         datasEventoStr,
         datasEventoStr,
-        dataVigenciaFinal ? dataVigenciaFinal.toISOString().slice(0,10) : null,
+        dataVigenciaFinal || null,
         Number(totalDiarias || 0),
         Number(valorBruto || 0),
         String(tipoDescontoAuto || 'Geral'),
@@ -354,10 +360,16 @@ async function atualizarEventoComDars(db, id, data, helpers) {
       throw new Error(`A soma das parcelas (R$ ${somaParcelas.toFixed(2)}) não corresponde ao Valor Final (R$ ${Number(valorFinal||0).toFixed(2)}).`);
     }
   }
-  const datasOrdenadas = Array.isArray(datasEvento) ? [...datasEvento].sort((a,b)=> new Date(a)-new Date(b)) : [];
-  const dataVigenciaFinal = datasOrdenadas.length ? new Date(datasOrdenadas.at(-1)) : null;
-  if (dataVigenciaFinal) {
-    dataVigenciaFinal.setDate(dataVigenciaFinal.getDate() + 1);
+  const datasOrdenadas = Array.isArray(datasEvento)
+    ? [...datasEvento].sort((a, b) => new Date(a) - new Date(b))
+    : [];
+  let dataVigenciaFinal = data.dataVigenciaFinal || data.data_vigencia_final || null;
+  if (!dataVigenciaFinal && datasOrdenadas.length) {
+    const tmp = new Date(datasOrdenadas.at(-1));
+    tmp.setDate(tmp.getDate() + 1);
+    dataVigenciaFinal = tmp.toISOString().slice(0, 10);
+  } else if (dataVigenciaFinal) {
+    dataVigenciaFinal = new Date(dataVigenciaFinal).toISOString().slice(0, 10);
   }
 
   await dbRun(db, 'BEGIN TRANSACTION');
@@ -396,7 +408,7 @@ async function atualizarEventoComDars(db, id, data, helpers) {
         JSON.stringify(espacosUtilizados || []),
         areaM2 != null ? Number(areaM2) : null,
         JSON.stringify(datasEvento || []),
-        dataVigenciaFinal ? dataVigenciaFinal.toISOString().slice(0,10) : null,
+        dataVigenciaFinal || null,
         Number(totalDiarias || 0),
         Number(valorBruto || 0),
         String(tipoDescontoAuto || 'Geral'),


### PR DESCRIPTION
## Summary
- normalize event vigencia final comparison in admin list endpoint
- persist data_vigencia_final based on provided value or last event date when creating/updating events
- add migration to backfill missing data_vigencia_final

## Testing
- `NODE_OPTIONS=--require ./.pnp.cjs node --test` *(fails: test failures)*
- `npx sequelize-cli db:migrate` *(fails: Unable to resolve sequelize package)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b30546f48333b428b764da75b248