### PR TITLE
feat: add termo enviado notification

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "test": "node test/termoEventoPdfkitService.test.js"
+    "test": "node test/termoEventoPdfkitService.test.js && node test/enviarTermo.test.js"
   },
   "dependencies": {
     "bwip-js": "^4.7.0",

--- a/src/services/NotificationService.js
+++ b/src/services/NotificationService.js
@@ -1,0 +1,7 @@
+export default class NotificationService {
+  static async sendTermoEnviado(nomeCliente, numeroTermo, nomeEvento, email) {
+    const mensagem = `Olá ${nomeCliente},\n\nO Termo de Permissão de Uso ${numeroTermo} para o evento ${nomeEvento} foi enviado para o e-mail ${email}.\nAssine o quanto antes para garantir a realização do seu evento no Centro de Inovação do Jaraguá.\n\nEquipe do CIPT.`;
+    // Aqui poderia haver uma integração real com serviço de e-mail ou outra notificação
+    return mensagem;
+  }
+}

--- a/src/services/termoEventoPdfkitService.js
+++ b/src/services/termoEventoPdfkitService.js
@@ -1,5 +1,6 @@
 import PDFDocument from 'pdfkit';
 import { ESPACOS_INFO } from '../config/espacos.js';
+import NotificationService from './NotificationService.js';
 
 export const CLAUSULAS_TERMO = {
   '5.19': 'Cláusula 5.19 - O permissionário deverá utilizar os espaços somente para os fins autorizados, responsabilizando-se pela integridade dos bens públicos.',
@@ -98,6 +99,12 @@ export async function generateTermoPdf(data, token = '') {
 
     doc.end();
   });
+}
+
+export async function enviarTermoParaAssinatura(dados, token, nomeCliente, numeroTermo, nomeEvento, email) {
+  const pdf = await generateTermoPdf(dados, token);
+  await NotificationService.sendTermoEnviado(nomeCliente, numeroTermo, nomeEvento, email);
+  return pdf;
 }
 
 export function getEspacoInfo(nome) {

--- a/test/enviarTermo.test.js
+++ b/test/enviarTermo.test.js
@@ -1,0 +1,46 @@
+import assert from 'assert';
+import { composeDataFromEvent, enviarTermoParaAssinatura } from '../src/services/termoEventoPdfkitService.js';
+import NotificationService from '../src/services/NotificationService.js';
+
+const eventoBase = {
+  valor: 2495,
+  dataRealizacaoInicio: '2025-08-12T03:00:00Z',
+  dataRealizacaoFim: '2025-08-12T15:00:00Z',
+  dataMontagem: '2025-08-10T03:00:00Z',
+  dataDesmontagem: '2025-08-13T03:00:00Z',
+  saldoPagamento: 3000,
+  clausulas: ['5.19', '5.20'],
+  dars: [
+    { dataVencimento: '2025-08-01T03:00:00Z' },
+    { dataVencimento: '2025-08-20T03:00:00Z' }
+  ],
+  espacos: ['default']
+};
+
+(async () => {
+  const dados = composeDataFromEvent(eventoBase);
+  const token = 'TOKEN123';
+  const nomeCliente = 'João da Silva';
+  const numeroTermo = 'TERMO-123';
+  const nomeEvento = 'Festa de Teste';
+  const email = 'joao@example.com';
+
+  const original = NotificationService.sendTermoEnviado;
+  const mensagens = [];
+  NotificationService.sendTermoEnviado = async (...args) => {
+    const msg = await original(...args);
+    mensagens.push(msg);
+    return msg;
+  };
+
+  const pdf = await enviarTermoParaAssinatura(dados, token, nomeCliente, numeroTermo, nomeEvento, email);
+
+  NotificationService.sendTermoEnviado = original;
+
+  assert.ok(Buffer.isBuffer(pdf) && pdf.length > 0, 'Deve gerar um PDF');
+  assert.strictEqual(mensagens.length, 1, 'Deve enviar uma notificação');
+  const esperado = `Olá ${nomeCliente},\n\nO Termo de Permissão de Uso ${numeroTermo} para o evento ${nomeEvento} foi enviado para o e-mail ${email}.\nAssine o quanto antes para garantir a realização do seu evento no Centro de Inovação do Jaraguá.\n\nEquipe do CIPT.`;
+  assert.strictEqual(mensagens[0], esperado, 'Mensagem de notificação incorreta');
+
+  console.log('Teste de notificação passou.');
+})();


### PR DESCRIPTION
## Summary
- add notification service to send termo enviado message
- notify when sending termo for signature
- cover notification with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1e2e923488333af3847bba1384009