### PR TITLE
docs: add WhatsApp bot environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+RESERVAS_API_URL=https://api.exemplo.com
+WHATSAPP_BOT_URL=https://bot.exemplo.com/messages
+WHATSAPP_BOT_TOKEN=seu_token_aqui
+
+# Opcional
+RUN_SERVER=true
+PORT=3001

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Sistema de Pagamento CIPT
+
+## Variáveis de Ambiente
+
+Defina as variáveis abaixo para executar o projeto:
+
+- `RESERVAS_API_URL`: URL base da API de reservas utilizada pelos serviços de reservas.
+- `WHATSAPP_BOT_URL`: Endpoint do bot de WhatsApp responsável por enviar notificações.
+- `WHATSAPP_BOT_TOKEN`: Token de autenticação para acessar o bot de WhatsApp.
+- `RUN_SERVER`: Quando definido, inicia o servidor de reservas de exemplo incluído no projeto.
+- `PORT`: Porta utilizada pelo servidor de reservas quando `RUN_SERVER` está ativo.
+
+Consulte o arquivo `.env.example` para um exemplo de configuração.


### PR DESCRIPTION
## Summary
- document WhatsApp bot URL and token environment variables
- provide `.env.example` showing required configuration

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68c1e5c133b883338a02db96d0258642