### PR TITLE
Ajusta configuração de TLS para alertas de e-mail

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # --- Configurações de Email --- 
-EMAIL_HOST="smtp.gmail.com" 
-EMAIL_PORT=465 
+EMAIL_HOST="smtp.gmail.com"
+# Use 465 para TLS implícito (secure=true) ou 587 para STARTTLS (secure=false/requireTLS=true)
+EMAIL_PORT=465
 EMAIL_USER="supcti.secti@gmail.com" 
 EMAIL_PASS="qnmc rgwt uaod qvzw" 
 

--- a/src/services/alertService.js
+++ b/src/services/alertService.js
@@ -3,10 +3,14 @@ require('dotenv').config();
 
 let transporter;
 if (process.env.EMAIL_HOST) {
+  const port = Number(process.env.EMAIL_PORT);
+  const secure = port === 465;
+
   transporter = nodemailer.createTransport({
     host: process.env.EMAIL_HOST,
-    port: process.env.EMAIL_PORT,
-    secure: true,
+    port: Number.isNaN(port) ? undefined : port,
+    secure,
+    requireTLS: secure === false,
     auth: { user: process.env.EMAIL_USER, pass: process.env.EMAIL_PASS },
   });
 }


### PR DESCRIPTION
## Summary
- deriva automaticamente o uso de TLS implícito com base na porta configurada no serviço de alertas
- habilita STARTTLS quando a conexão não usa TLS implícito
- documenta no .env.example como escolher a porta correta para o servidor SMTP

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c88668133083339186b100f384fb5d