### PR TITLE
Add success modal to password reset request page

### DIFF
--- a/public/solicitar-redefinicao.html
+++ b/public/solicitar-redefinicao.html
@@ -87,13 +87,34 @@
             </div>
         </footer>
     </div>
-    
+
+    <div class="modal fade" id="successModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header border-0">
+                    <h5 class="modal-title w-100 text-center">
+                        <i class="bi bi-check-circle-fill text-success" style="font-size: 3rem;"></i>
+                    </h5>
+                </div>
+                <div class="modal-body text-center">
+                    <h5 class="mb-3">Código enviado!</h5>
+                    <p class="mb-0">Verifique seu e-mail e também a caixa de spam.</p>
+                </div>
+                <div class="modal-footer border-0 justify-content-center">
+                    <button type="button" class="btn btn-success" data-bs-dismiss="modal">Fechar</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://unpkg.com/imask"></script>
     <script defer src="/js/mobile-adapter.js"></script>
     <script defer src="/js/ui-kit.js"></script>
     <script defer src="/js/mobile-tweaks.js"></script>
     <script>
         const cnpjInput = document.getElementById('cnpj');
+        const successModalElement = document.getElementById('successModal');
         IMask(cnpjInput, { mask: '00.000.000/0000-00' });
 
         document.getElementById('requestCodeForm').addEventListener('submit', async (event) => {
@@ -103,6 +124,10 @@
             const formContainer = document.getElementById('formContainer');
             const cnpj = cnpjInput.value;
             const submitButton = form.querySelector('button[type="submit"]');
+
+            messageDiv.style.display = 'none';
+            messageDiv.className = 'alert';
+            messageDiv.innerText = '';
 
             submitButton.disabled = true;
             submitButton.innerHTML = '<span class="spinner-border spinner-border-sm me-2" aria-hidden="true"></span> Enviando...';
@@ -119,10 +144,13 @@
                     throw new Error(result.error || 'Ocorreu um erro.');
                 }
 
-                messageDiv.innerText = 'Código enviado com sucesso! Verifique seu e-mail. Redirecionando...';
-                messageDiv.className = 'alert alert-success';
-                messageDiv.style.display = 'block';
+                messageDiv.style.display = 'none';
                 formContainer.style.display = 'none';
+
+                if (successModalElement) {
+                    const modal = new bootstrap.Modal(successModalElement);
+                    modal.show();
+                }
 
                 setTimeout(() => {
                     window.location.href = `/verificar-codigo.html?cnpj=${encodeURIComponent(cnpj)}&pid=${result.permissionarioId}`;


### PR DESCRIPTION
## Summary
- load the Bootstrap JavaScript bundle on the password reset request page
- add a success modal matching the admin modal style with the new success copy
- show the modal after a successful request while keeping the timed redirect to the code verification page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c88ca12cf88333be89ab3772c07bcd