### PR TITLE
Add uniform success modals to password and email flows

### DIFF
--- a/public/admin/definir-senha.html
+++ b/public/admin/definir-senha.html
@@ -69,6 +69,26 @@
         <footer class="footer">
             </footer>
     </div>
+<div class="modal fade" id="successModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header border-0">
+                <h5 class="modal-title w-100 text-center">
+                    <i class="bi bi-check-circle-fill text-success" style="font-size: 3rem;"></i>
+                </h5>
+            </div>
+            <div class="modal-body text-center">
+                <h5 class="mb-3">Senha definida!</h5>
+                <p class="mb-0">Você será redirecionado para o login.</p>
+            </div>
+            <div class="modal-footer border-0 justify-content-center">
+                <button type="button" class="btn btn-success" data-bs-dismiss="modal">Fechar</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script defer src="/js/mobile-adapter.js"></script>
   <script defer src="/js/ui-kit.js"></script>
   <script defer src="/js/mobile-tweaks.js"></script>
@@ -97,6 +117,7 @@
             const confirmPassword = document.getElementById('confirm_password').value;
             const messageDiv = document.getElementById('message');
             const form = document.getElementById('passwordForm');
+            const successModalEl = document.getElementById('successModal');
 
             if (password !== confirmPassword) {
                 messageDiv.className = 'alert alert-danger';
@@ -114,16 +135,16 @@
                 const result = await response.json();
 
                 if (response.ok) {
-                    messageDiv.className = 'alert alert-success';
-                    messageDiv.innerHTML = `${result.message} <br><a href="/admin/login.html">Ir para o Login</a>`;
                     form.style.display = 'none';
+                    const modal = new bootstrap.Modal(successModalEl);
+                    modal.show();
+                    setTimeout(() => window.location.href = '/admin/login.html', 3000);
                 } else {
                     throw new Error(result.error);
                 }
             } catch (error) {
                 messageDiv.className = 'alert alert-danger';
                 messageDiv.innerText = error.message;
-            } finally {
                 messageDiv.style.display = 'block';
             }
         });

--- a/public/admin/solicitar-redefinicao.html
+++ b/public/admin/solicitar-redefinicao.html
@@ -44,7 +44,7 @@
                     <h2 class="h3 mb-1 fw-bold">Redefinir Senha</h2>
                     <p class="text-muted">Digite seu e-mail para receber o link de redefinição.</p>
                 </div>
-                
+
                 <form id="resetForm">
                     <div class="form-floating mb-3">
                         <input type="email" class="form-control" id="email" name="email" placeholder="E-mail" required>
@@ -61,9 +61,30 @@
         <footer class="footer">
             </footer>
     </div>
+
+    <div class="modal fade" id="successModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header border-0">
+                    <h5 class="modal-title w-100 text-center">
+                        <i class="bi bi-check-circle-fill text-success" style="font-size: 3rem;"></i>
+                    </h5>
+                </div>
+                <div class="modal-body text-center">
+                    <h5 class="mb-3">Link enviado!</h5>
+                    <p class="mb-0">Verifique seu e-mail e também a caixa de spam.</p>
+                </div>
+                <div class="modal-footer border-0 justify-content-center">
+                    <button type="button" class="btn btn-success" data-bs-dismiss="modal">Fechar</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script defer src="/js/mobile-adapter.js"></script>
-  <script defer src="/js/ui-kit.js"></script>
-  <script defer src="/js/mobile-tweaks.js"></script>
+    <script defer src="/js/ui-kit.js"></script>
+    <script defer src="/js/mobile-tweaks.js"></script>
     <script>
         document.getElementById('resetForm').addEventListener('submit', async (event) => {
             event.preventDefault();
@@ -85,17 +106,18 @@
                 });
                 const result = await response.json();
 
-                messageDiv.className = response.ok ? 'alert alert-success' : 'alert alert-danger';
-                messageDiv.innerText = result.message || result.error;
-                
                 if (response.ok) {
                     form.style.display = 'none';
+                    const modal = new bootstrap.Modal(document.getElementById('successModal'));
+                    modal.show();
+                } else {
+                    throw new Error(result.error || 'Ocorreu um erro.');
                 }
             } catch (error) {
                 messageDiv.className = 'alert alert-danger';
-                messageDiv.innerText = 'Ocorreu um erro de comunicação. Tente novamente.';
-            } finally {
+                messageDiv.innerText = error.message || 'Ocorreu um erro de comunicação. Tente novamente.';
                 messageDiv.style.display = 'block';
+            } finally {
                 button.disabled = false;
                 button.innerHTML = originalButtonText;
             }

--- a/public/definir-senha-evento.html
+++ b/public/definir-senha-evento.html
@@ -78,6 +78,26 @@
             </div>
         </footer>
     </div>
+    <div class="modal fade" id="successModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header border-0">
+                    <h5 class="modal-title w-100 text-center">
+                        <i class="bi bi-check-circle-fill text-success" style="font-size: 3rem;"></i>
+                    </h5>
+                </div>
+                <div class="modal-body text-center">
+                    <h5 class="mb-3">Senha definida!</h5>
+                    <p class="mb-0">Você será redirecionado para o login.</p>
+                </div>
+                <div class="modal-footer border-0 justify-content-center">
+                    <button type="button" class="btn btn-success" data-bs-dismiss="modal">Fechar</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script defer src="/js/mobile-adapter.js"></script>
     <script defer src="/js/ui-kit.js"></script>
     <script defer src="/js/mobile-tweaks.js"></script>
@@ -88,6 +108,7 @@
 
         const form = document.getElementById('passwordForm');
         const messageDiv = document.getElementById('message');
+        const successModalEl = document.getElementById('successModal');
         const welcomeMsg = document.getElementById('welcomeMessage');
         const token = new URLSearchParams(window.location.search).get('token');
 
@@ -151,11 +172,9 @@
                 const data = await resp.json();
                 if (!resp.ok) throw new Error(data.error || 'Falha ao definir a senha.');
 
-                messageDiv.className = 'alert alert-success';
-                messageDiv.textContent = 'Senha definida com sucesso! Redirecionando para o login em 3 segundos...';
-                messageDiv.style.display = 'block';
                 form.style.display = 'none';
-                
+                const modal = new bootstrap.Modal(successModalEl);
+                modal.show();
                 setTimeout(() => window.location.href = '/eventos/login-eventos.html', 3000);
 
             } catch (err) {

--- a/public/definir-senha.html
+++ b/public/definir-senha.html
@@ -89,6 +89,26 @@
             </div>
         </div>
     </footer>
+    <div class="modal fade" id="successModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header border-0">
+                    <h5 class="modal-title w-100 text-center">
+                        <i class="bi bi-check-circle-fill text-success" style="font-size: 3rem;"></i>
+                    </h5>
+                </div>
+                <div class="modal-body text-center">
+                    <h5 class="mb-3">Senha definida!</h5>
+                    <p class="mb-0">Você será redirecionado para o login.</p>
+                </div>
+                <div class="modal-footer border-0 justify-content-center">
+                    <button type="button" class="btn btn-success" data-bs-dismiss="modal">Fechar</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script defer src="/js/mobile-adapter.js"></script>
     <script defer src="/js/ui-kit.js"></script>
     <script defer src="/js/mobile-tweaks.js"></script>
@@ -104,6 +124,7 @@
         const passwordResetToken = localStorage.getItem('passwordResetToken');
         const form = document.getElementById('passwordForm');
         const messageDiv = document.getElementById('message');
+        const successModalEl = document.getElementById('successModal');
 
         if (!passwordResetToken) {
             messageDiv.innerText = 'ERRO: Permissão para redefinir a senha não encontrada. Por favor, reinicie o processo.';
@@ -153,24 +174,19 @@
 
                 const result = await response.json();
                 if (response.ok) {
-                    messageDiv.innerText = result.message;
-                    messageDiv.className = 'alert alert-success';
                     form.style.display = 'none';
                     localStorage.removeItem('passwordResetToken');
-                    
-                    const loginLink = document.createElement('a');
-                    loginLink.href = '/login.html';
-                    loginLink.className = 'btn btn-primary w-100 mt-3';
-                    loginLink.innerText = 'Ir para o Login';
-                    messageDiv.parentNode.appendChild(loginLink);
+                    const modal = new bootstrap.Modal(successModalEl);
+                    modal.show();
+                    setTimeout(() => { window.location.href = '/login.html'; }, 3000);
                 } else {
                     throw new Error(result.error);
                 }
             } catch (error) {
                 messageDiv.innerText = error.message;
                 messageDiv.className = 'alert alert-danger';
-            } finally {
                 messageDiv.style.display = 'block';
+            } finally {
                 submitButton.disabled = false;
                 submitButton.innerHTML = 'Salvar Nova Senha';
             }

--- a/public/eventos/solicitar-redefinicao-evento.html
+++ b/public/eventos/solicitar-redefinicao-evento.html
@@ -76,9 +76,29 @@
         </footer>
     </div>
 
+    <div class="modal fade" id="successModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header border-0">
+                    <h5 class="modal-title w-100 text-center">
+                        <i class="bi bi-check-circle-fill text-success" style="font-size: 3rem;"></i>
+                    </h5>
+                </div>
+                <div class="modal-body text-center">
+                    <h5 class="mb-3">Link enviado!</h5>
+                    <p class="mb-0">Verifique seu e-mail e também a caixa de spam.</p>
+                </div>
+                <div class="modal-footer border-0 justify-content-center">
+                    <button type="button" class="btn btn-success" data-bs-dismiss="modal">Fechar</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script defer src="/js/mobile-adapter.js"></script>
-  <script defer src="/js/ui-kit.js"></script>
-  <script defer src="/js/mobile-tweaks.js"></script>   
+    <script defer src="/js/ui-kit.js"></script>
+    <script defer src="/js/mobile-tweaks.js"></script>
     <script>
         document.getElementById('redefinir-form').addEventListener('submit', async (e) => {
             e.preventDefault();
@@ -87,19 +107,17 @@
             const button = e.target.querySelector('button');
             button.disabled = true;
 
-            messageDiv.style.display = 'block';
             messageDiv.className = 'alert alert-info';
             messageDiv.innerText = 'Processando sua solicitação...';
+            messageDiv.style.display = 'block';
 
-            // **NOTA: É preciso criar esta rota na API: /api/eventos/clientes/solicitar-redefinicao**
-            // Ela receberá o 'login', encontrará o cliente, gerará um novo token e enviará o e-mail.
-            // Por enquanto, vamos simular o comportamento de sucesso.
-            
+            // Simulação de sucesso; substituir por chamada à API real
             setTimeout(() => {
-                messageDiv.className = 'alert alert-success';
-                messageDiv.innerText = 'Se o identificador informado estiver em nossa base de dados, um link de redefinição foi enviado para o e-mail associado. Por favor, verifique sua caixa de entrada e spam.';
+                messageDiv.style.display = 'none';
                 document.getElementById('redefinir-form').reset();
                 button.disabled = false;
+                const modal = new bootstrap.Modal(document.getElementById('successModal'));
+                modal.show();
             }, 2000);
         });
     </script>

--- a/public/solicitar-redefinicao.html
+++ b/public/solicitar-redefinicao.html
@@ -87,13 +87,34 @@
             </div>
         </footer>
     </div>
-    
+
+    <div class="modal fade" id="successModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header border-0">
+                    <h5 class="modal-title w-100 text-center">
+                        <i class="bi bi-check-circle-fill text-success" style="font-size: 3rem;"></i>
+                    </h5>
+                </div>
+                <div class="modal-body text-center">
+                    <h5 class="mb-3">Código enviado!</h5>
+                    <p class="mb-0">Verifique seu e-mail e também a caixa de spam.</p>
+                </div>
+                <div class="modal-footer border-0 justify-content-center">
+                    <button type="button" class="btn btn-success" data-bs-dismiss="modal">Fechar</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://unpkg.com/imask"></script>
     <script defer src="/js/mobile-adapter.js"></script>
     <script defer src="/js/ui-kit.js"></script>
     <script defer src="/js/mobile-tweaks.js"></script>
     <script>
         const cnpjInput = document.getElementById('cnpj');
+        const successModalElement = document.getElementById('successModal');
         IMask(cnpjInput, { mask: '00.000.000/0000-00' });
 
         document.getElementById('requestCodeForm').addEventListener('submit', async (event) => {
@@ -103,6 +124,10 @@
             const formContainer = document.getElementById('formContainer');
             const cnpj = cnpjInput.value;
             const submitButton = form.querySelector('button[type="submit"]');
+
+            messageDiv.style.display = 'none';
+            messageDiv.className = 'alert';
+            messageDiv.innerText = '';
 
             submitButton.disabled = true;
             submitButton.innerHTML = '<span class="spinner-border spinner-border-sm me-2" aria-hidden="true"></span> Enviando...';
@@ -119,10 +144,13 @@
                     throw new Error(result.error || 'Ocorreu um erro.');
                 }
 
-                messageDiv.innerText = 'Código enviado com sucesso! Verifique seu e-mail. Redirecionando...';
-                messageDiv.className = 'alert alert-success';
-                messageDiv.style.display = 'block';
+                messageDiv.style.display = 'none';
                 formContainer.style.display = 'none';
+
+                if (successModalElement) {
+                    const modal = new bootstrap.Modal(successModalElement);
+                    modal.show();
+                }
 
                 setTimeout(() => {
                     window.location.href = `/verificar-codigo.html?cnpj=${encodeURIComponent(cnpj)}&pid=${result.permissionarioId}`;


### PR DESCRIPTION
## Summary
- show a shared success modal on admin and event password reset requests with spam-check notice
- display the same modal after completing password definitions for users, events, and admins with timed login redirects

## Testing
- `npm test` *(fails: Cannot find module 'jsdom', 'sqlite3', 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68c88ca12cf88333be89ab3772c07bcd