### PR TITLE
feat(admin): add service status health check endpoint

### DIFF
--- a/src/api/adminStatusRoutes.js
+++ b/src/api/adminStatusRoutes.js
@@ -1,0 +1,94 @@
+// src/api/adminStatusRoutes.js
+const express = require('express');
+const axios = require('axios');
+const { exec } = require('child_process');
+const { promisify } = require('util');
+
+const adminAuthMiddleware = require('../middleware/adminAuthMiddleware');
+const authorizeRole = require('../middleware/roleMiddleware');
+const { verifySmtpConnection } = require('../services/emailService');
+const { checkSefazHealth } = require('../services/sefazService');
+const { checkHealth: checkWhatsAppHealth } = require('../services/whatsappService');
+
+const router = express.Router();
+const execAsync = promisify(exec);
+
+async function checkVpnHealth() {
+  const url = (process.env.VPN_HEALTHCHECK_URL || '').trim();
+  const timeout = Number(process.env.VPN_HEALTHCHECK_TIMEOUT_MS || 5000);
+
+  if (url) {
+    try {
+      const method = (process.env.VPN_HEALTHCHECK_METHOD || 'GET').toUpperCase();
+      const requestConfig = {
+        method,
+        url,
+        timeout,
+        validateStatus: () => true,
+      };
+      if (method === 'POST') {
+        requestConfig.data = { ping: true };
+      }
+      const response = await axios(requestConfig);
+      if (response.status >= 200 && response.status < 400) {
+        return true;
+      }
+      throw new Error(`Health-check HTTP ${response.status}`);
+    } catch (err) {
+      const message = err?.message || err;
+      throw new Error(typeof message === 'string' ? message : 'Falha no health-check HTTP da VPN.');
+    }
+  }
+
+  const host = (process.env.VPN_HEALTHCHECK_HOST || '').trim();
+  if (!host) {
+    throw new Error('VPN_HEALTHCHECK_URL ou VPN_HEALTHCHECK_HOST não configurados.');
+  }
+
+  const seconds = Math.max(1, Math.ceil(timeout / 1000));
+  const command = process.platform === 'win32'
+    ? `ping -n 1 -w ${seconds * 1000} ${host}`
+    : `ping -c 1 -W ${seconds} ${host}`;
+
+  try {
+    await execAsync(command, { timeout: timeout + 1000 });
+    return true;
+  } catch (err) {
+    const message = err?.message || err;
+    throw new Error(typeof message === 'string' ? message : 'Falha no ping da VPN.');
+  }
+}
+
+router.get(
+  '/service-status',
+  [adminAuthMiddleware, authorizeRole(['SUPER_ADMIN'])],
+  async (_req, res) => {
+    const status = {
+      email: 'erro',
+      sefaz: 'erro',
+      whatsapp: 'erro',
+      vpn: 'erro',
+    };
+
+    const checks = [
+      { key: 'email', fn: verifySmtpConnection },
+      { key: 'sefaz', fn: checkSefazHealth },
+      { key: 'whatsapp', fn: checkWhatsAppHealth },
+      { key: 'vpn', fn: checkVpnHealth },
+    ];
+
+    for (const check of checks) {
+      try {
+        await check.fn();
+        status[check.key] = 'ok';
+      } catch (err) {
+        status[check.key] = 'erro';
+        console.error(`[SERVICE-STATUS] ${check.key} indisponível:`, err?.message || err);
+      }
+    }
+
+    res.json(status);
+  }
+);
+
+module.exports = router;

--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,7 @@ const adminRoutes           = require('./api/adminRoutes');
 const adminManagementRoutes = require('./api/adminManagementRoutes');
 const adminDarsRoutes       = require('./api/adminDarsRoutes');
 const adminOficiosRoutes    = require('./api/adminOficiosRoutes');
+const adminStatusRoutes     = require('./api/adminStatusRoutes');
 const adminTermoEventosRoutes = require('./api/adminTermoEventosRoutes');
 const permissionariosRoutes = require('./api/permissionariosRoutes');
 const botRoutes             = require('./api/botRoutes');
@@ -103,6 +104,7 @@ mount('/api/admin/auth',        'adminAuthRoutes',       adminAuthRoutes,       
 mount('/api/admin/dars',        'adminDarsRoutes',       adminDarsRoutes,       app);
 mount('/api/admins',            'adminManagementRoutes', adminManagementRoutes, app);
 mount('/api/admin',             'adminRoutes',           adminRoutes,           app);
+mount('/api/admin',             'adminStatusRoutes',     adminStatusRoutes,     app);
 mount('/api/admin',             'adminOficiosRoutes',    adminOficiosRoutes,    app);
 mount('/api/admin',             'adminAdvertenciasRoutes', adminAdvertenciasRoutes, app);
 mount('/api/admin',             'adminTermoEventosRoutes', adminTermoEventosRoutes, app);


### PR DESCRIPTION
## Summary
- add a protected `/api/admin/service-status` route that checks SMTP, SEFAZ, WhatsApp and VPN availability for super admins
- expose reusable SMTP verification helper and SEFAZ/WhatsApp health checks for the new endpoint
- register the new admin router in the application bootstrap

## Testing
- npm test *(fails: suite depends on external services, SEFAZ token and SQLite tables in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c89391a5bc83339dd1324799b4678b