### PR TITLE
Restrict admin service status view to super admins

### DIFF
--- a/public/admin/service-status.html
+++ b/public/admin/service-status.html
@@ -460,22 +460,22 @@
             }
         };
 
-        document.addEventListener('visibilitychange', () => {
-            if (document.hidden) {
-                stopPolling();
+        const redirectToLogin = () => {
+            if (typeof window.logoutAdmin === 'function') {
+                window.logoutAdmin();
             } else {
-                fetchStatus();
-                startPolling();
+                localStorage.removeItem('adminToken');
+                localStorage.removeItem('adminAuthToken');
+                window.location.replace('/admin/login.html');
             }
-        });
+        };
 
-        window.addEventListener('beforeunload', () => {
-            stopPolling();
-        });
+        let token = (typeof window.getAdminToken === 'function' && window.getAdminToken())
+            || localStorage.getItem('adminToken')
+            || localStorage.getItem('adminAuthToken');
 
-        let token = localStorage.getItem('adminToken') || localStorage.getItem('adminAuthToken');
         if (!token) {
-            window.location.href = '/admin/login.html';
+            redirectToLogin();
             return;
         }
 
@@ -491,12 +491,27 @@
             role = payload?.role || '';
         } catch (error) {
             console.error('Erro ao decodificar token:', error);
+            redirectToLogin();
+            return;
         }
 
         if (role !== 'SUPER_ADMIN') {
-            statusContent.innerHTML = '<div class="alert alert-warning" role="alert">Esta área é restrita aos administradores com perfil SUPER_ADMIN.</div>';
+            redirectToLogin();
             return;
         }
+
+        document.addEventListener('visibilitychange', () => {
+            if (document.hidden) {
+                stopPolling();
+            } else {
+                fetchStatus();
+                startPolling();
+            }
+        });
+
+        window.addEventListener('beforeunload', () => {
+            stopPolling();
+        });
 
         await fetchStatus();
         startPolling();

--- a/src/api/adminRoutes.js
+++ b/src/api/adminRoutes.js
@@ -182,6 +182,52 @@ router.get(
 );
 
 /* ===========================================================
+   GET /api/admin/service-status
+   =========================================================== */
+router.get(
+  '/service-status',
+  [authMiddleware, authorizeRole(['SUPER_ADMIN'])],
+  async (_req, res) => {
+    const now = new Date();
+    const isoNow = now.toISOString();
+
+    const services = [];
+
+    try {
+      await dbGet('SELECT 1 AS ok');
+      services.push({
+        name: 'Banco de Dados (SQLite)',
+        status: 'up',
+        description: 'Conexão com o banco de dados estabelecida com sucesso.',
+        checkedAt: isoNow,
+      });
+    } catch (error) {
+      console.error('[service-status] Falha ao consultar o banco de dados:', error);
+      services.push({
+        name: 'Banco de Dados (SQLite)',
+        status: 'down',
+        description: 'Não foi possível executar uma consulta simples no banco de dados.',
+        checkedAt: isoNow,
+        details: error.message,
+      });
+    }
+
+    services.push({
+      name: 'Servidor de Aplicação',
+      status: 'up',
+      description: `Processo ${process.pid} em execução (${process.env.NODE_ENV || 'development'})`,
+      checkedAt: isoNow,
+      uptimeSeconds: Math.round(process.uptime()),
+    });
+
+    res.json({
+      generatedAt: isoNow,
+      services,
+    });
+  }
+);
+
+/* ===========================================================
    Rotas de Permissionários
    =========================================================== */
 


### PR DESCRIPTION
## Summary
- add a protected `/api/admin/service-status` endpoint that only SUPER_ADMIN users can call and return basic health information
- update the service status dashboard to decode the admin JWT like the main dashboard and redirect non SUPER_ADMIN roles back to login

## Testing
- npm test *(fails: suite expects seeded database, SMTP, and SEFAZ credentials that are unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8960cd7408333ab8e31416b64873d