### PR TITLE
Corrige exibição da sidebar no mobile e pull-to-refresh

### DIFF
--- a/public/js/admin-sidebar.js
+++ b/public/js/admin-sidebar.js
@@ -22,11 +22,13 @@ document.addEventListener('DOMContentLoaded', () => {
             .then(() => {
                 applyRoleToSidebar(role);
                 initSidebarBehaviour();
+                document.dispatchEvent(new CustomEvent('sidebar:ready', { detail: { role } }));
             })
             .catch(err => console.error('Erro ao injetar sidebar:', err));
     } else {
         applyRoleToSidebar(role);
         initSidebarBehaviour(); // Sidebar já está no HTML
+        document.dispatchEvent(new CustomEvent('sidebar:ready', { detail: { role } }));
     }
 });
 


### PR DESCRIPTION
## Summary
- dispara um evento `sidebar:ready` após a injeção do HTML compartilhado e recria o hambúrguer no mobile
- torna a detecção do topo mais criteriosa antes de acionar o pull-to-refresh para evitar recarregamentos acidentais
- evita bloqueio da rolagem ao checar o estado durante o gesto e aguarda a conclusão antes de recarregar

## Testing
- npm test *(falhou: ambiente sem dependências como express/axios/sqlite3 instaladas para executar a suíte completa)*

------
https://chatgpt.com/codex/tasks/task_e_68c8ae42d5708333b2d169ee907f2c7d