### PR TITLE
Add DAR generation workflow for permissionários

### DIFF
--- a/public/admin/permissionarios.html
+++ b/public/admin/permissionarios.html
@@ -49,11 +49,16 @@
             </header>
 
             <main class="content">
-                <div class="d-flex justify-content-between align-items-center mb-4">
+                <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-4">
                     <h1 class="h2">Gerenciamento de Permissionários</h1>
-                    <a href="/admin/permissionario-form.html" class="btn btn-primary">
-                        <i class="bi bi-plus-circle-fill me-2"></i>Cadastrar Novo
-                    </a>
+                    <div class="d-flex flex-wrap gap-2">
+                        <a href="/admin/permissionario-form.html" class="btn btn-primary">
+                            <i class="bi bi-plus-circle-fill me-2" aria-hidden="true"></i>Cadastrar Novo
+                        </a>
+                        <button type="button" class="btn btn-success" id="gerarDarButton">
+                            <i class="bi bi-receipt-cutoff me-2" aria-hidden="true"></i>Gerar DAR
+                        </button>
+                    </div>
                 </div>
 
                 <div class="card">
@@ -101,7 +106,86 @@
             </main>
         </div>
     </div>
-    
+
+    <div class="modal fade" id="gerarDarModal" tabindex="-1" aria-labelledby="gerarDarModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h2 class="modal-title h5 mb-0" id="gerarDarModalLabel">Gerar DAR para Permissionário</h2>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+                </div>
+                <form id="gerarDarForm" novalidate>
+                    <div class="modal-body">
+                        <div class="mb-3">
+                            <label for="darPermissionarioSelect" class="form-label">Permissionário</label>
+                            <select id="darPermissionarioSelect" class="form-select" aria-describedby="darPermissionarioHelp" required>
+                                <option value="" disabled selected>Selecione um permissionário</option>
+                            </select>
+                            <div id="darPermissionarioHelp" class="form-text">A lista é carregada automaticamente com os permissionários ativos.</div>
+                            <div class="invalid-feedback">Escolha o permissionário para continuar.</div>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="darTipoSelect" class="form-label">Tipo de DAR</label>
+                            <select id="darTipoSelect" class="form-select" required>
+                                <option value="Mensalidade" selected>Mensalidade</option>
+                                <option value="Advertência">Advertência</option>
+                            </select>
+                            <div class="invalid-feedback">Informe o tipo de DAR que deseja gerar.</div>
+                        </div>
+
+                        <section id="mensalidadeFields" aria-live="polite">
+                            <div class="mb-3">
+                                <label for="mensalidadeCompetencia" class="form-label">Competência (mês/ano)</label>
+                                <input type="month" id="mensalidadeCompetencia" class="form-control" required>
+                                <div class="form-text">Escolha o mês e ano referentes à cobrança da mensalidade.</div>
+                                <div class="invalid-feedback">Informe a competência (mês/ano) da mensalidade.</div>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label" for="mensalidadeValorBase">Valor base do aluguel</label>
+                                <div id="mensalidadeValorBase" class="form-control-plaintext px-3 py-2 bg-light border rounded" role="status" aria-live="polite">
+                                    Selecione um permissionário para visualizar o valor base cadastrado.
+                                </div>
+                                <div class="form-text">O valor exibido é o cadastrado para o permissionário escolhido.</div>
+                            </div>
+                        </section>
+
+                        <section id="advertenciaFields" class="d-none" aria-live="polite">
+                            <div class="row g-3">
+                                <div class="col-12 col-md-6">
+                                    <label for="advertenciaValor" class="form-label">Valor da Advertência</label>
+                                    <div class="input-group">
+                                        <span class="input-group-text" id="advertenciaValorPrefixo">R$</span>
+                                        <input type="number" min="0" step="0.01" class="form-control" id="advertenciaValor" aria-describedby="advertenciaValorPrefixo" required>
+                                        <div class="invalid-feedback">Informe o valor que será cobrado na advertência.</div>
+                                    </div>
+                                </div>
+                                <div class="col-12 col-md-6">
+                                    <label for="advertenciaDataPagamento" class="form-label">Data limite para pagamento</label>
+                                    <input type="date" id="advertenciaDataPagamento" class="form-control" required aria-describedby="advertenciaDataHelp">
+                                    <div id="advertenciaDataHelp" class="form-text">Datas em finais de semana ou feriados não são permitidas.</div>
+                                    <div class="invalid-feedback" id="advertenciaDataFeedback">Informe uma data útil para o pagamento.</div>
+                                </div>
+                            </div>
+                            <div class="mt-3">
+                                <label for="advertenciaDescricao" class="form-label">Descrição dos fatos</label>
+                                <textarea id="advertenciaDescricao" class="form-control" rows="3" required aria-describedby="advertenciaDescricaoHelp"></textarea>
+                                <div id="advertenciaDescricaoHelp" class="form-text">Descreva o motivo ou contexto da advertência.</div>
+                                <div class="invalid-feedback">Descreva os fatos relacionados à advertência.</div>
+                            </div>
+                        </section>
+                    </div>
+                    <div class="modal-footer flex-wrap gap-2">
+                        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
+                        <button type="submit" class="btn btn-primary">
+                            <i class="bi bi-cloud-arrow-up me-2" aria-hidden="true"></i>Enviar Solicitação
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.8.2/jspdf.plugin.autotable.min.js"></script>
@@ -139,9 +223,31 @@
         const limitSelect = document.getElementById('limitSelect');
         const tableBody = document.getElementById('permissionarios-table-body');
         const paginationNav = document.getElementById('paginationNav');
-        
+        const gerarDarButton = document.getElementById('gerarDarButton');
+        const gerarDarModalEl = document.getElementById('gerarDarModal');
+        const gerarDarForm = document.getElementById('gerarDarForm');
+        const darPermissionarioSelect = document.getElementById('darPermissionarioSelect');
+        const darTipoSelect = document.getElementById('darTipoSelect');
+        const mensalidadeFields = document.getElementById('mensalidadeFields');
+        const mensalidadeCompetencia = document.getElementById('mensalidadeCompetencia');
+        const mensalidadeValorBaseEl = document.getElementById('mensalidadeValorBase');
+        const advertenciaFields = document.getElementById('advertenciaFields');
+        const advertenciaValor = document.getElementById('advertenciaValor');
+        const advertenciaDataPagamento = document.getElementById('advertenciaDataPagamento');
+        const advertenciaDescricao = document.getElementById('advertenciaDescricao');
+        const advertenciaDataFeedback = document.getElementById('advertenciaDataFeedback');
+
+        const gerarDarModal = gerarDarModalEl ? new bootstrap.Modal(gerarDarModalEl) : null;
+        const FERIADOS_FIXOS = ['01-01', '04-21', '05-01', '09-07', '10-12', '11-02', '11-15', '12-25'];
+        const FERIADOS_PONTUAIS = new Set(); // ajuste conforme calendário municipal/estadual
+
+        let permissionariosModalCache = [];
+        const permissionarioDetalhesCache = new Map();
+        let selectedPermissionario = null;
+        const mensalidadeValorBaseDefault = 'Selecione um permissionário para visualizar o valor base cadastrado.';
+
         let currentPage = 1, currentSearch = '', currentLimit = 10, searchTimeout;
-        
+
         async function fetchPermissionarios() {
             tableBody.innerHTML = '<tr><td colspan="6" class="text-center">Carregando...</td></tr>';
             try {
@@ -154,6 +260,254 @@
                 renderPagination(data.totalPages, data.currentPage);
             } catch (error) {
                 tableBody.innerHTML = `<tr><td colspan="6" class="text-center text-danger">${error.message}</td></tr>`;
+            }
+        }
+
+        function updateMensalidadeValorBase(permissionarioInfo) {
+            if (!mensalidadeValorBaseEl) return;
+            if (!permissionarioInfo) {
+                mensalidadeValorBaseEl.textContent = mensalidadeValorBaseDefault;
+                return;
+            }
+            const valor = Number(permissionarioInfo.valor_aluguel);
+            if (!Number.isFinite(valor) || valor <= 0) {
+                mensalidadeValorBaseEl.textContent = 'Valor não cadastrado para este permissionário.';
+                return;
+            }
+            mensalidadeValorBaseEl.textContent = valor.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+        }
+
+        function isFimDeSemana(dataISO) {
+            if (!dataISO) return false;
+            const referencia = new Date(`${dataISO}T12:00:00`);
+            const diaSemana = Number.isNaN(referencia.getTime()) ? -1 : referencia.getUTCDay();
+            return diaSemana === 0 || diaSemana === 6;
+        }
+
+        function isFeriado(dataISO) {
+            if (!dataISO) return false;
+            const [ano, mes, dia] = dataISO.split('-');
+            if (!ano || !mes || !dia) return false;
+            const chave = `${mes}-${dia}`;
+            return FERIADOS_FIXOS.includes(chave) || FERIADOS_PONTUAIS.has(dataISO);
+        }
+
+        function validarDataAdvertencia() {
+            if (!advertenciaDataPagamento) return;
+            const valor = advertenciaDataPagamento.value;
+            if (!valor || advertenciaFields.classList.contains('d-none')) {
+                advertenciaDataPagamento.setCustomValidity('');
+                if (advertenciaDataFeedback) advertenciaDataFeedback.textContent = 'Informe uma data útil para o pagamento.';
+                return;
+            }
+
+            if (isFimDeSemana(valor) || isFeriado(valor)) {
+                advertenciaDataPagamento.setCustomValidity('Datas em finais de semana ou feriados não são permitidas.');
+                if (advertenciaDataFeedback) advertenciaDataFeedback.textContent = 'Escolha uma data que não recaia em fins de semana ou feriados oficiais.';
+            } else {
+                advertenciaDataPagamento.setCustomValidity('');
+                if (advertenciaDataFeedback) advertenciaDataFeedback.textContent = 'Datas em finais de semana ou feriados não são permitidas.';
+            }
+        }
+
+        function atualizarCamposPorTipo() {
+            if (!darTipoSelect) return;
+            const tipo = darTipoSelect.value;
+            const isMensalidade = tipo === 'Mensalidade';
+            if (mensalidadeFields) mensalidadeFields.classList.toggle('d-none', !isMensalidade);
+            if (advertenciaFields) advertenciaFields.classList.toggle('d-none', isMensalidade);
+
+            if (mensalidadeCompetencia) mensalidadeCompetencia.required = isMensalidade;
+            if (advertenciaValor) advertenciaValor.required = !isMensalidade;
+            if (advertenciaDataPagamento) advertenciaDataPagamento.required = !isMensalidade;
+            if (advertenciaDescricao) advertenciaDescricao.required = !isMensalidade;
+
+            if (isMensalidade) {
+                validarDataAdvertencia();
+            } else {
+                validarDataAdvertencia();
+            }
+        }
+
+        async function carregarPermissionariosModal(forceReload = false) {
+            if (!darPermissionarioSelect) return;
+            if (permissionariosModalCache.length && !forceReload) {
+                renderizarOpcoesPermissionarios();
+                return;
+            }
+
+            try {
+                darPermissionarioSelect.disabled = true;
+                darPermissionarioSelect.setAttribute('aria-busy', 'true');
+                darPermissionarioSelect.innerHTML = '';
+                const placeholder = document.createElement('option');
+                placeholder.value = '';
+                placeholder.textContent = 'Carregando permissionários…';
+                placeholder.disabled = true;
+                placeholder.selected = true;
+                darPermissionarioSelect.appendChild(placeholder);
+
+                const response = await fetch(`/api/admin/permissionarios?page=1&limit=500`, {
+                    headers: { 'Authorization': `Bearer ${token}` }
+                });
+                if (!response.ok) throw new Error('Não foi possível carregar os permissionários.');
+                const data = await response.json();
+                permissionariosModalCache = data.permissionarios || [];
+                renderizarOpcoesPermissionarios();
+            } catch (error) {
+                console.error('Erro ao carregar permissionários para o modal:', error);
+                AppUI.toast(error.message || 'Falha ao carregar a lista de permissionários.', 'error');
+                darPermissionarioSelect.innerHTML = '';
+                const fallback = document.createElement('option');
+                fallback.value = '';
+                fallback.textContent = 'Erro ao carregar dados';
+                fallback.disabled = true;
+                fallback.selected = true;
+                darPermissionarioSelect.appendChild(fallback);
+            } finally {
+                darPermissionarioSelect.disabled = false;
+                darPermissionarioSelect.setAttribute('aria-busy', 'false');
+            }
+        }
+
+        function renderizarOpcoesPermissionarios() {
+            if (!darPermissionarioSelect) return;
+            const valorAtual = darPermissionarioSelect.value;
+            darPermissionarioSelect.innerHTML = '';
+
+            const defaultOption = document.createElement('option');
+            defaultOption.value = '';
+            defaultOption.disabled = true;
+            defaultOption.selected = true;
+            defaultOption.textContent = 'Selecione um permissionário';
+            darPermissionarioSelect.appendChild(defaultOption);
+
+            permissionariosModalCache
+                .slice()
+                .sort((a, b) => a.nome_empresa.localeCompare(b.nome_empresa))
+                .forEach((p) => {
+                    const option = document.createElement('option');
+                    option.value = p.id;
+                    option.textContent = `${p.nome_empresa} • ${formatarCNPJ(p.cnpj)}`;
+                    darPermissionarioSelect.appendChild(option);
+                });
+
+            if (valorAtual && Array.from(darPermissionarioSelect.options).some(opt => opt.value === valorAtual)) {
+                darPermissionarioSelect.value = valorAtual;
+            }
+        }
+
+        async function handlePermissionarioSelecionado() {
+            if (!darPermissionarioSelect) return;
+            const idSelecionado = darPermissionarioSelect.value;
+            if (!idSelecionado) {
+                selectedPermissionario = null;
+                updateMensalidadeValorBase(null);
+                return;
+            }
+
+            if (permissionarioDetalhesCache.has(idSelecionado)) {
+                selectedPermissionario = permissionarioDetalhesCache.get(idSelecionado);
+                updateMensalidadeValorBase(selectedPermissionario);
+                return;
+            }
+
+            try {
+                updateMensalidadeValorBase({ valor_aluguel: null });
+                if (mensalidadeValorBaseEl) {
+                    mensalidadeValorBaseEl.textContent = 'Carregando informações do permissionário…';
+                }
+                const response = await fetch(`/api/admin/permissionarios/${idSelecionado}`, {
+                    headers: { 'Authorization': `Bearer ${token}` }
+                });
+                if (!response.ok) throw new Error('Não foi possível obter os dados do permissionário.');
+                const data = await response.json();
+                permissionarioDetalhesCache.set(idSelecionado, data);
+                selectedPermissionario = data;
+                updateMensalidadeValorBase(selectedPermissionario);
+            } catch (error) {
+                console.error('Erro ao carregar permissionário:', error);
+                AppUI.toast(error.message || 'Falha ao carregar os dados do permissionário.', 'error');
+                selectedPermissionario = null;
+                updateMensalidadeValorBase(null);
+            }
+        }
+
+        async function enviarGeracaoDar(event) {
+            if (!gerarDarForm) return;
+            event.preventDefault();
+
+            gerarDarForm.classList.add('was-validated');
+            validarDataAdvertencia();
+
+            if (!gerarDarForm.checkValidity()) {
+                AppUI.toast('Revise os campos destacados antes de prosseguir.', 'warn');
+                return;
+            }
+
+            if (!darPermissionarioSelect || !darPermissionarioSelect.value) {
+                AppUI.toast('Selecione um permissionário para gerar o DAR.', 'warn');
+                return;
+            }
+
+            const tipo = darTipoSelect?.value || 'Mensalidade';
+            const payload = {
+                tipo,
+                permissionarioId: Number(darPermissionarioSelect.value)
+            };
+
+            if (tipo === 'Mensalidade') {
+                const competencia = mensalidadeCompetencia?.value || '';
+                const [ano, mes] = competencia.split('-');
+                payload.anoReferencia = ano ? Number(ano) : null;
+                payload.mesReferencia = mes ? Number(mes) : null;
+                payload.valor = selectedPermissionario && Number(selectedPermissionario.valor_aluguel)
+                    ? Number(selectedPermissionario.valor_aluguel)
+                    : null;
+            } else {
+                payload.valor = advertenciaValor?.value ? Number(advertenciaValor.value) : null;
+                payload.dataPagamento = advertenciaDataPagamento?.value || null;
+                payload.descricao = advertenciaDescricao?.value?.trim() || '';
+            }
+
+            try {
+                AppUI.loading.show();
+                const response = await fetch(`/api/admin/permissionarios/${payload.permissionarioId}/dars`, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Authorization': `Bearer ${token}`
+                    },
+                    body: JSON.stringify(payload)
+                });
+
+                let resultado = {};
+                try {
+                    resultado = await response.json();
+                } catch (jsonError) {
+                    resultado = {};
+                }
+
+                if (!response.ok) {
+                    throw new Error(resultado.error || 'Não foi possível gerar o DAR.');
+                }
+
+                AppUI.toast(resultado.message || 'DAR gerada com sucesso!', 'success');
+                gerarDarForm.reset();
+                gerarDarForm.classList.remove('was-validated');
+                if (darTipoSelect) darTipoSelect.value = 'Mensalidade';
+                atualizarCamposPorTipo();
+                updateMensalidadeValorBase(null);
+                selectedPermissionario = null;
+                permissionarioDetalhesCache.clear();
+                permissionariosModalCache = [];
+                gerarDarModal?.hide();
+                await fetchPermissionarios();
+            } catch (error) {
+                console.error('Falha ao gerar DAR:', error);
+                AppUI.toast(error.message || 'Falha ao gerar o DAR.', 'error');
+            } finally {
+                AppUI.loading.hide();
             }
         }
 
@@ -255,7 +609,7 @@
                 e.preventDefault();
                 const format = e.target.dataset.format;
                 const searchTerm = searchInput.value;
-                
+
                 if (format === 'pdf') {
                     // A exportação para PDF é feita no lado do cliente e continua igual
                     exportToPDF(searchTerm);
@@ -269,7 +623,51 @@
         async function exportToPDF(searchTerm) {
              // ... seu código para gerar PDF continua aqui, sem alterações ...
         }
-        
+
+        if (gerarDarButton && gerarDarModal) {
+            gerarDarButton.addEventListener('click', async () => {
+                await carregarPermissionariosModal();
+                if (gerarDarForm) {
+                    gerarDarForm.reset();
+                    gerarDarForm.classList.remove('was-validated');
+                }
+                if (darTipoSelect) darTipoSelect.value = 'Mensalidade';
+                selectedPermissionario = null;
+                updateMensalidadeValorBase(null);
+                atualizarCamposPorTipo();
+                gerarDarModal.show();
+            });
+        }
+
+        if (gerarDarModalEl) {
+            gerarDarModalEl.addEventListener('shown.bs.modal', () => {
+                darPermissionarioSelect?.focus();
+            });
+            gerarDarModalEl.addEventListener('hidden.bs.modal', () => {
+                if (gerarDarForm) {
+                    gerarDarForm.reset();
+                    gerarDarForm.classList.remove('was-validated');
+                }
+                selectedPermissionario = null;
+                updateMensalidadeValorBase(null);
+                if (darTipoSelect) {
+                    darTipoSelect.value = 'Mensalidade';
+                    atualizarCamposPorTipo();
+                }
+                if (darPermissionarioSelect && darPermissionarioSelect.options.length) {
+                    darPermissionarioSelect.selectedIndex = 0;
+                }
+            });
+        }
+
+        darTipoSelect?.addEventListener('change', atualizarCamposPorTipo);
+        darPermissionarioSelect?.addEventListener('change', handlePermissionarioSelecionado);
+        advertenciaDataPagamento?.addEventListener('change', validarDataAdvertencia);
+        advertenciaDataPagamento?.addEventListener('blur', validarDataAdvertencia);
+        gerarDarForm?.addEventListener('submit', enviarGeracaoDar);
+
+        atualizarCamposPorTipo();
+        validarDataAdvertencia();
         fetchPermissionarios();
     });
 </script>


### PR DESCRIPTION
## Summary
- add a "Gerar DAR" action to the permissionários admin page alongside the existing registration CTA
- introduce a responsive Bootstrap modal to capture mensalidade or advertência data with contextual fields
- wire up client-side handlers for loading permissionários, validating inputs, and submitting the DAR request with AppUI feedback

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cae6bdd0308333be91771773569bc2