### PR TITLE
Add admin DAR creation route with business day utilities

### DIFF
--- a/cron/gerarDarsMensais.js
+++ b/cron/gerarDarsMensais.js
@@ -17,39 +17,7 @@ const TEST_PERMISSIONARIO_ID = process.env.TEST_PERMISSIONARIO_ID
   : null;
 
 // ================== Datas (AL, BR) ==================
-function isFeriado(data) {
-  const dia = String(data.getDate()).padStart(2, '0');
-  const mes = String(data.getMonth() + 1).padStart(2, '0');
-  const dataStr = `${dia}/${mes}`;
-
-  const feriadosFixos = [
-    '01/01', // Confraternização Universal
-    '21/04', // Tiradentes
-    '01/05', // Dia do Trabalho
-    '24/06', // São João (AL)
-    '07/09', // Independência
-    '16/09', // Emancipação Política de Alagoas
-    '12/10', // N. Sra Aparecida
-    '02/11', // Finados
-    '15/11', // Proclamação da República
-    '25/12', // Natal
-  ];
-  return feriadosFixos.includes(dataStr);
-}
-
-function isDiaUtil(data) {
-  const w = data.getDay(); // 0 dom, 6 sáb
-  if (w === 0 || w === 6) return false;
-  if (isFeriado(data)) return false;
-  return true;
-}
-
-function getUltimoDiaUtil(ano, mes) {
-  // new Date(ano, mes, 0) => último dia do mês (mes é 1-12 aqui)
-  let d = new Date(ano, mes, 0);
-  while (!isDiaUtil(d)) d.setDate(d.getDate() - 1);
-  return d;
-}
+const { getLastBusinessDay } = require('../src/utils/businessDays');
 
 // ================== Helpers DB ==================
 function dbAll(db, sql, params = []) {
@@ -80,7 +48,7 @@ async function gerarDarsEEnviarNotificacoes() {
     const agora = new Date();
     const mesReferencia = agora.getMonth() + 1;
     const anoReferencia = agora.getFullYear();
-    const venc = getUltimoDiaUtil(anoReferencia, mesReferencia);
+    const venc = getLastBusinessDay(anoReferencia, mesReferencia);
     const vencISO = new Date(venc.getTime() - venc.getTimezoneOffset() * 60000)
       .toISOString()
       .slice(0, 10);

--- a/src/api/darsRoutes.js
+++ b/src/api/darsRoutes.js
@@ -83,6 +83,7 @@ async function ensureSchema() {
   await ensureColumn('dars', 'linha_digitavel', 'TEXT');
   await ensureColumn('dars', 'data_emissao', 'TEXT');
   await ensureColumn('dars', 'emitido_por_id', 'INTEGER');
+  await ensureColumn('dars', 'advertencia_fatos', 'TEXT');
   await ensureColumn('permissionarios', 'numero_documento', 'TEXT');
   await ensureColumn('permissionarios', 'telefone_cobranca', 'TEXT');
   await ensureColumn('permissionarios', 'tipo', 'TEXT');

--- a/src/services/notificacaoService.js
+++ b/src/services/notificacaoService.js
@@ -1,5 +1,5 @@
 // src/services/notificacaoService.js
-const { enviarEmailNotificacaoDar, enviarEmailNovaDar } = require('./emailService');
+const { enviarEmailNotificacaoDar, enviarEmailNovaDar, enviarEmailDarAdvertencia } = require('./emailService');
 const { escolherEmailDestino } = require('../utils/emailDestino');
 
 /**
@@ -25,6 +25,17 @@ async function notificarDarGerado(perm, dar, opts = { tipo: 'notificar' }) {
 
   if (opts.tipo === 'novo') {
     await enviarEmailNovaDar(emailParaEnvio, dadosDoDar);
+  } else if (opts.tipo === 'advertencia') {
+    const fatosList = Array.isArray(opts.fatos)
+      ? opts.fatos.filter((f) => String(f || '').trim()).map((f) => String(f).trim())
+      : [];
+    const advertenciaDados = {
+      nome_empresa: perm.nome_empresa,
+      data_vencimento: dar.data_vencimento,
+      valor: Number(dar.valor || 0),
+      fatos: fatosList.length ? fatosList : (String(dar.advertencia_fatos || '').split(/\r?\n/).map((f) => f.trim()).filter(Boolean))
+    };
+    await enviarEmailDarAdvertencia(emailParaEnvio, advertenciaDados);
   } else {
     // monta payload esperado por enviarEmailNotificacaoDar
     const dadosEmail = {

--- a/src/utils/businessDays.js
+++ b/src/utils/businessDays.js
@@ -1,0 +1,118 @@
+// src/utils/businessDays.js
+const FIXED_HOLIDAYS = new Set([
+  '01-01', // Confraternização Universal
+  '04-21', // Tiradentes
+  '05-01', // Dia do Trabalho
+  '06-24', // São João (AL)
+  '09-07', // Independência
+  '09-16', // Emancipação Política de Alagoas
+  '10-12', // Nossa Senhora Aparecida
+  '11-02', // Finados
+  '11-15', // Proclamação da República
+  '12-25'  // Natal
+]);
+
+function pad2(n) {
+  return String(n).padStart(2, '0');
+}
+
+function parseDateInput(value) {
+  if (!value && value !== 0) return null;
+  if (value instanceof Date) {
+    return isNaN(value.getTime()) ? null : new Date(value.getFullYear(), value.getMonth(), value.getDate());
+  }
+
+  const str = String(value).trim();
+  if (!str) return null;
+
+  let year;
+  let month;
+  let day;
+
+  if (/^\d{4}-\d{2}-\d{2}$/.test(str)) {
+    [year, month, day] = str.split('-').map(Number);
+  } else if (/^\d{2}\/\d{2}\/\d{4}$/.test(str)) {
+    const parts = str.split('/');
+    day = Number(parts[0]);
+    month = Number(parts[1]);
+    year = Number(parts[2]);
+  } else if (/^\d{2}-\d{2}-\d{4}$/.test(str)) {
+    const parts = str.split('-');
+    day = Number(parts[0]);
+    month = Number(parts[1]);
+    year = Number(parts[2]);
+  } else {
+    const date = new Date(str);
+    if (isNaN(date.getTime())) return null;
+    return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  }
+
+  if (!year || !month || !day) return null;
+  const coerced = new Date(year, month - 1, day);
+  if (isNaN(coerced.getTime())) return null;
+  return coerced;
+}
+
+function formatISODate(date) {
+  const dt = parseDateInput(date);
+  if (!dt) return null;
+  return `${dt.getFullYear()}-${pad2(dt.getMonth() + 1)}-${pad2(dt.getDate())}`;
+}
+
+function isHoliday(date, extraHolidays = []) {
+  const dt = parseDateInput(date);
+  if (!dt) return false;
+  const mmdd = `${pad2(dt.getMonth() + 1)}-${pad2(dt.getDate())}`;
+  if (FIXED_HOLIDAYS.has(mmdd)) return true;
+
+  return extraHolidays.some((raw) => {
+    if (!raw) return false;
+    const val = String(raw).trim();
+    if (!val) return false;
+    if (/^\d{4}-\d{2}-\d{2}$/.test(val)) {
+      return val === formatISODate(dt);
+    }
+    if (/^\d{2}[\/-]\d{2}$/.test(val)) {
+      const token = val.replace('/', '-');
+      return token === mmdd;
+    }
+    const parsed = parseDateInput(val);
+    if (!parsed) return false;
+    return formatISODate(parsed) === formatISODate(dt);
+  });
+}
+
+function isBusinessDay(date, extraHolidays = []) {
+  const dt = parseDateInput(date);
+  if (!dt) return false;
+  const day = dt.getDay();
+  if (day === 0 || day === 6) return false;
+  return !isHoliday(dt, extraHolidays);
+}
+
+function getLastBusinessDay(ano, mes, extraHolidays = []) {
+  const year = Number(ano);
+  const month = Number(mes);
+  if (!year || !month || month < 1 || month > 12) {
+    throw new Error('Mês ou ano inválido para cálculo de último dia útil.');
+  }
+  let cursor = new Date(year, month, 0);
+  while (!isBusinessDay(cursor, extraHolidays)) {
+    cursor.setDate(cursor.getDate() - 1);
+  }
+  return cursor;
+}
+
+function getLastBusinessDayISO(ano, mes, extraHolidays = []) {
+  const date = getLastBusinessDay(ano, mes, extraHolidays);
+  return formatISODate(date);
+}
+
+module.exports = {
+  parseDateInput,
+  formatISODate,
+  isHoliday,
+  isBusinessDay,
+  getLastBusinessDay,
+  getLastBusinessDayISO
+};

--- a/tests/adminDarsRoutesCreate.test.js
+++ b/tests/adminDarsRoutesCreate.test.js
@@ -1,0 +1,268 @@
+// tests/adminDarsRoutesCreate.test.js
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const fs = require('fs');
+const express = require('express');
+const supertest = require('supertest');
+
+async function setupContext(name, permissionarios = []) {
+  const dbFile = path.resolve(__dirname, `test-admin-dars-create-${name}.db`);
+  try { fs.unlinkSync(dbFile); } catch {}
+  const previousDbPath = process.env.SQLITE_STORAGE;
+  process.env.SQLITE_STORAGE = dbFile;
+
+  const dbModulePath = path.resolve(__dirname, '../src/database/db.js');
+  delete require.cache[dbModulePath];
+
+  const notifPath = path.resolve(__dirname, '../src/services/notificacaoService.js');
+  delete require.cache[notifPath];
+  const notifCalls = [];
+  require.cache[notifPath] = {
+    exports: {
+      notificarDarGerado: async (...args) => {
+        notifCalls.push(args);
+        return true;
+      }
+    }
+  };
+
+  const whatsappPath = path.resolve(__dirname, '../src/services/whatsappService.js');
+  delete require.cache[whatsappPath];
+  const whatsappCalls = [];
+  require.cache[whatsappPath] = {
+    exports: {
+      sendMessage: async (...args) => {
+        whatsappCalls.push(args);
+        return true;
+      }
+    }
+  };
+
+  const authPath = path.resolve(__dirname, '../src/middleware/authMiddleware.js');
+  delete require.cache[authPath];
+  require.cache[authPath] = { exports: (req, _res, next) => { req.user = { id: 1 }; next(); } };
+
+  const rolePath = path.resolve(__dirname, '../src/middleware/roleMiddleware.js');
+  delete require.cache[rolePath];
+  require.cache[rolePath] = { exports: () => (_req, _res, next) => next() };
+
+  const sefazPath = path.resolve(__dirname, '../src/services/sefazService.js');
+  delete require.cache[sefazPath];
+  require.cache[sefazPath] = {
+    exports: {
+      emitirGuiaSefaz: async () => {
+        throw new Error('SEFAZ não deve ser chamado nos testes de criação de DAR.');
+      },
+      consultarPagamentoPorCodigoBarras: async () => null,
+      listarPagamentosPorDataArrecadacao: async () => []
+    }
+  };
+
+  const db = require('../src/database/db');
+  const run = (sql, params = []) => new Promise((resolve, reject) => db.run(sql, params, (err) => err ? reject(err) : resolve()));
+  const get = (sql, params = []) => new Promise((resolve, reject) => db.get(sql, params, (err, row) => err ? reject(err) : resolve(row)));
+
+  await run(`CREATE TABLE permissionarios (
+    id INTEGER PRIMARY KEY,
+    nome_empresa TEXT,
+    valor_aluguel REAL,
+    tipo TEXT,
+    telefone TEXT,
+    telefone_cobranca TEXT,
+    email TEXT,
+    email_notificacao TEXT,
+    email_financeiro TEXT
+  )`);
+
+  await run(`CREATE TABLE dars (
+    id INTEGER PRIMARY KEY,
+    permissionario_id INTEGER,
+    tipo_permissionario TEXT,
+    valor REAL,
+    data_vencimento TEXT,
+    status TEXT,
+    mes_referencia INTEGER,
+    ano_referencia INTEGER,
+    advertencia_fatos TEXT
+  )`);
+
+  for (const perm of permissionarios) {
+    const columns = Object.keys(perm);
+    const placeholders = columns.map(() => '?').join(',');
+    await run(
+      `INSERT INTO permissionarios (${columns.join(',')}) VALUES (${placeholders})`,
+      columns.map((c) => perm[c])
+    );
+  }
+
+  const adminPath = path.resolve(__dirname, '../src/api/adminDarsRoutes.js');
+  delete require.cache[adminPath];
+  const adminDarsRoutes = require('../src/api/adminDarsRoutes');
+
+  const app = express();
+  app.use(express.json());
+  app.use('/api/admin/dars', adminDarsRoutes);
+  const request = supertest(app);
+
+  async function cleanup() {
+    await new Promise((resolve) => db.close(() => resolve()));
+    delete require.cache[adminPath];
+    delete require.cache[notifPath];
+    delete require.cache[whatsappPath];
+    delete require.cache[authPath];
+    delete require.cache[rolePath];
+    delete require.cache[dbModulePath];
+    delete require.cache[sefazPath];
+    if (previousDbPath === undefined) {
+      delete process.env.SQLITE_STORAGE;
+    } else {
+      process.env.SQLITE_STORAGE = previousDbPath;
+    }
+    try { fs.unlinkSync(dbFile); } catch {}
+  }
+
+  return { request, get, run, cleanup, notifCalls, whatsappCalls };
+}
+
+test('POST /api/admin/dars cria mensalidade com último dia útil', async () => {
+  const ctx = await setupContext('mensal', [
+    {
+      id: 1,
+      nome_empresa: 'Empresa Teste',
+      valor_aluguel: 150,
+      tipo: null,
+      telefone: '82911112222',
+      telefone_cobranca: '82999998888',
+      email: 'teste@empresa.com'
+    }
+  ]);
+
+  try {
+    const res = await ctx.request
+      .post('/api/admin/dars')
+      .send({ permissionarioId: 1, tipo: 'Mensalidade', competencia: '2024-02' })
+      .expect(201);
+
+    assert.ok(res.body?.dar);
+    assert.equal(res.body.dar.permissionario_id, 1);
+    assert.equal(res.body.dar.valor, 150);
+    assert.equal(res.body.dar.data_vencimento, '2024-02-29');
+    assert.equal(res.body.dar.status, 'Pendente');
+    assert.equal(res.body.dar.mes_referencia, 2);
+    assert.equal(res.body.dar.ano_referencia, 2024);
+
+    const row = await ctx.get('SELECT * FROM dars WHERE id = ?', [res.body.dar.id]);
+    assert.equal(row.tipo_permissionario, 'Permissionario');
+    assert.equal(row.valor, 150);
+    assert.equal(row.data_vencimento, '2024-02-29');
+    assert.equal(row.mes_referencia, 2);
+    assert.equal(row.ano_referencia, 2024);
+    assert.equal(row.advertencia_fatos, null);
+
+    assert.equal(ctx.notifCalls.length, 1);
+    assert.equal(ctx.notifCalls[0][2]?.tipo, 'novo');
+    assert.equal(ctx.whatsappCalls.length, 1);
+  } finally {
+    await ctx.cleanup();
+  }
+});
+
+test('POST /api/admin/dars rejeita mensalidade para permissionário isento ou sem aluguel', async () => {
+  const ctx = await setupContext('mensal-invalido', [
+    {
+      id: 1,
+      nome_empresa: 'Isento',
+      valor_aluguel: 0,
+      tipo: 'Isento',
+      telefone: '82911112222'
+    }
+  ]);
+
+  try {
+    const res = await ctx.request
+      .post('/api/admin/dars')
+      .send({ permissionarioId: 1, tipo: 'Mensalidade', competencia: '2024-03' })
+      .expect(400);
+
+    assert.match(res.body.error, /isento|aluguel/i);
+    assert.equal(ctx.notifCalls.length, 0);
+  } finally {
+    await ctx.cleanup();
+  }
+});
+
+test('POST /api/admin/dars cria DAR de advertência validando dia útil', async () => {
+  const ctx = await setupContext('advertencia', [
+    {
+      id: 5,
+      nome_empresa: 'Empresa Advertida',
+      valor_aluguel: 200,
+      tipo: null,
+      telefone: '82911113333',
+      email: 'contato@empresa.com'
+    }
+  ]);
+
+  try {
+    const res = await ctx.request
+      .post('/api/admin/dars')
+      .send({
+        permissionarioId: 5,
+        tipo: 'Advertencia',
+        competencia: '03/2024',
+        dataPagamento: '2024-03-18',
+        valor: '250.50',
+        fatos: ['Descumprimento de normas', 'Uso indevido do espaço']
+      })
+      .expect(201);
+
+    assert.ok(res.body?.dar);
+    assert.equal(res.body.dar.tipo_permissionario, 'Advertencia');
+    assert.equal(res.body.dar.valor, 250.5);
+    assert.equal(res.body.dar.data_vencimento, '2024-03-18');
+    assert.equal(res.body.dar.mes_referencia, 3);
+    assert.equal(res.body.dar.ano_referencia, 2024);
+    assert.ok(res.body.dar.advertencia_fatos.includes('Descumprimento'));
+
+    const row = await ctx.get('SELECT * FROM dars WHERE id = ?', [res.body.dar.id]);
+    assert.equal(row.tipo_permissionario, 'Advertencia');
+    assert.equal(row.advertencia_fatos.split('\n').length, 2);
+
+    assert.equal(ctx.notifCalls.length, 1);
+    assert.equal(ctx.notifCalls[0][2]?.tipo, 'advertencia');
+    assert.deepEqual(ctx.notifCalls[0][2]?.fatos, ['Descumprimento de normas', 'Uso indevido do espaço']);
+    assert.equal(ctx.whatsappCalls.length, 1);
+  } finally {
+    await ctx.cleanup();
+  }
+});
+
+test('POST /api/admin/dars rejeita advertência em final de semana', async () => {
+  const ctx = await setupContext('advertencia-weekend', [
+    {
+      id: 7,
+      nome_empresa: 'Empresa Weekend',
+      valor_aluguel: 100,
+      tipo: null,
+      telefone: '82911114444'
+    }
+  ]);
+
+  try {
+    await ctx.request
+      .post('/api/admin/dars')
+      .send({
+        permissionarioId: 7,
+        tipo: 'Advertencia',
+        dataPagamento: '2024-03-17',
+        valor: 120,
+        fatos: 'Incidente'
+      })
+      .expect(400);
+
+    assert.equal(ctx.notifCalls.length, 0);
+  } finally {
+    await ctx.cleanup();
+  }
+});


### PR DESCRIPTION
## Summary
- add reusable business-day helpers and adopt them in the monthly DAR cron
- implement the protected admin DAR creation endpoint with validations, notifications and WhatsApp alerts
- extend notification/email flows, ensure the new advertência column exists and cover the route with tests

## Testing
- node --test tests/adminDarsRoutesCreate.test.js
- npm test *(fails: requires SEFAZ_APP_TOKEN and other env-dependent services)*

------
https://chatgpt.com/codex/tasks/task_e_68cae88ef0608333af496a5887f76773