### PR TITLE
Sincroniza signatários com e-mail atualizado antes de reenviar termo

### DIFF
--- a/tests/adminEventosRoutes.test.js
+++ b/tests/adminEventosRoutes.test.js
@@ -4,18 +4,38 @@ const path = require('path');
 const express = require('express');
 const supertest = require('supertest');
 
-function setupRouter(atualizarMock) {
+function setupRouter(arg) {
+  const options = typeof arg === 'function' ? { atualizarMock: arg } : (arg || {});
+  const atualizarMock = options.atualizarMock || (async () => {});
   const adminAuthPath = path.resolve(__dirname, '../src/middleware/adminAuthMiddleware.js');
   require.cache[adminAuthPath] = { exports: (_req, _res, next) => next() };
   const sefazPath = path.resolve(__dirname, '../src/services/sefazService.js');
   require.cache[sefazPath] = { exports: { emitirGuiaSefaz: async () => {} } };
   const tokenPath = path.resolve(__dirname, '../src/utils/token.js');
   require.cache[tokenPath] = { exports: { gerarTokenDocumento: async () => {}, imprimirTokenEmPdf: async () => {} } };
-  const dbStub = { stub: true };
+  const dbStub = options.dbStub || { stub: true };
   const dbPath = path.resolve(__dirname, '../src/database/db.js');
   require.cache[dbPath] = { exports: dbStub };
   const servicePath = path.resolve(__dirname, '../src/services/eventoDarService.js');
   require.cache[servicePath] = { exports: { criarEventoComDars: async () => {}, atualizarEventoComDars: atualizarMock } };
+  const assinafyClientPath = path.resolve(__dirname, '../src/services/assinafyClient.js');
+  require.cache[assinafyClientPath] = { exports: { getDocumentStatus: async () => ({}) } };
+  const assinafyPath = path.resolve(__dirname, '../src/services/assinafyService.js');
+  const ensureSignerMock = options.ensureSignerMock || (async () => ({ id: 'signer-mock', email: 'mock@example.com' }));
+  const requestSignaturesMock = options.requestSignaturesMock || (async () => {});
+  require.cache[assinafyPath] = {
+    exports: {
+      uploadDocumentFromFile: async () => ({}),
+      ensureSigner: ensureSignerMock,
+      requestSignatures: requestSignaturesMock,
+      getDocument: async () => ({}),
+      pickBestArtifactUrl: () => null,
+      waitUntilPendingSignature: async () => {},
+      waitUntilReadyForAssignment: async () => {},
+      getSigningUrl: async () => null,
+      onlyDigits: (value = '') => String(value).replace(/\D/g, ''),
+    },
+  };
   delete require.cache[require.resolve('../src/api/adminEventosRoutes.js')];
   const routes = require('../src/api/adminEventosRoutes.js');
   const app = express();
@@ -78,4 +98,61 @@ test('PATCH /:id/status retorna 404 quando evento não existe', async () => {
   };
   const res = await supertest(app).patch('/2/status').send({ status: 'Pago' }).expect(404);
   assert.equal(res.body.error, 'Evento não encontrado.');
+});
+
+test('POST /:id/termo/reativar-assinatura usa e-mail atualizado do signatário', async () => {
+  const calls = [];
+  const ensureSignerMock = async (payload) => {
+    calls.push({ step: 'ensure', payload });
+    return { id: 'signer-77', email: payload.email, telephone: payload.phone };
+  };
+  const requestSignaturesMock = async (docId, signerIds, options) => {
+    calls.push({ step: 'request', docId, signerIds, options });
+  };
+  const dbStub = {
+    stub: true,
+    get: (sql, params, cb) => {
+      calls.push({ step: 'db:get', sql, params });
+      if (/FROM documentos/.test(sql)) {
+        return cb(null, { assinafy_id: 'doc-123' });
+      }
+      return cb(null, null);
+    },
+    run: (sql, params, cb) => {
+      calls.push({ step: 'db:run', sql, params });
+      cb.call({ lastID: 0, changes: 1 }, null);
+    },
+  };
+
+  const { app } = setupRouter({ atualizarMock: async () => {}, ensureSignerMock, requestSignaturesMock, dbStub });
+
+  const res = await supertest(app)
+    .post('/10/termo/reativar-assinatura')
+    .send({
+      signerName: 'Novo Contato',
+      signerEmail: 'novo@example.com',
+      signerCpf: '12345678900',
+      signerPhone: '11988887777',
+    })
+    .expect(200);
+
+  assert.deepEqual(res.body, { ok: true, message: 'Solicitação de assinatura reenviada com sucesso.' });
+
+  const ensureCallIndex = calls.findIndex((c) => c.step === 'ensure');
+  const requestCallIndex = calls.findIndex((c) => c.step === 'request');
+  assert.ok(ensureCallIndex >= 0);
+  assert.ok(requestCallIndex > ensureCallIndex);
+  assert.deepEqual(calls[ensureCallIndex].payload, {
+    full_name: 'Novo Contato',
+    email: 'novo@example.com',
+    government_id: '12345678900',
+    phone: '+5511988887777',
+  });
+  assert.deepEqual(calls[requestCallIndex], {
+    step: 'request',
+    docId: 'doc-123',
+    signerIds: ['signer-77'],
+    options: { message: undefined, expires_at: undefined },
+  });
+  assert.ok(calls.some((c) => c.step === 'db:run'));
 });


### PR DESCRIPTION
## Summary
- Atualiza o ensureSigner para sincronizar e-mail e telefone de signatários existentes e evitar sobrescrever com valores vazios
- Ajusta os testes do serviço Assinafy com novos cenários que validam a sincronização do e-mail
- Amplia o utilitário de testes das rotas de eventos para permitir mocks adicionais e cobre o reenvio de termo com contato atualizado

## Testing
- npm test *(falha: diversas suites dependem de infraestrutura externa/banco real, ver saída)*
- node --test tests/assinafyService.test.js
- node --test tests/adminEventosRoutes.test.js

------
https://chatgpt.com/codex/tasks/task_e_68caec1aaa708333b26dbfd752d8fdb9