### PR TITLE
Ajusta payload de geração de DAR

### DIFF
--- a/public/admin/permissionarios.html
+++ b/public/admin/permissionarios.html
@@ -457,17 +457,16 @@
             };
 
             if (tipo === 'Mensalidade') {
-                const competencia = mensalidadeCompetencia?.value || '';
-                const [ano, mes] = competencia.split('-');
-                payload.anoReferencia = ano ? Number(ano) : null;
-                payload.mesReferencia = mes ? Number(mes) : null;
-                payload.valor = selectedPermissionario && Number(selectedPermissionario.valor_aluguel)
-                    ? Number(selectedPermissionario.valor_aluguel)
-                    : null;
+                const competencia = mensalidadeCompetencia?.value?.trim() || '';
+                if (competencia) {
+                    payload.competencia = competencia;
+                }
+                const aluguelBase = Number(selectedPermissionario?.valor_aluguel);
+                payload.valor = Number.isFinite(aluguelBase) ? aluguelBase : null;
             } else {
                 payload.valor = advertenciaValor?.value ? Number(advertenciaValor.value) : null;
                 payload.dataPagamento = advertenciaDataPagamento?.value || null;
-                payload.descricao = advertenciaDescricao?.value?.trim() || '';
+                payload.fatos = advertenciaDescricao?.value?.trim() || '';
             }
 
             try {


### PR DESCRIPTION
## Summary
- envia competência diretamente como string no payload de mensalidades
- mantém envio do valor cadastrado do permissionário quando disponível
- renomeia o campo de descrição de advertência para fatos mantendo a data de pagamento

## Testing
- npm test *(fails: diversas rotas dependem de infraestrutura externa e variáveis SEFAZ ausentes no ambiente de testes)*

------
https://chatgpt.com/codex/tasks/task_e_68caf279ee8083338332f7348f271268