### PR TITLE
Initialize assistant widget immediately when DOM ready

### DIFF
--- a/public/js/assistant-widget.js
+++ b/public/js/assistant-widget.js
@@ -344,5 +344,9 @@
     createPanel();
   }
 
-  document.addEventListener('DOMContentLoaded', init);
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
 })();


### PR DESCRIPTION
## Summary
- initialize the assistant widget immediately when the document is already interactive or complete
- keep the DOMContentLoaded listener for cases where the DOM is still loading

## Testing
- `npm test` *(fails: numerous integration tests require full database schema, configured environment variables, and external SMTP/service integrations that are unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68caf4f895d883339226954fce444685