### PR TITLE
Load dotenv for assistant index script

### DIFF
--- a/scripts/buildAssistantIndex.js
+++ b/scripts/buildAssistantIndex.js
@@ -4,6 +4,8 @@
 const fs = require('fs/promises');
 const path = require('path');
 
+require('dotenv').config({ path: path.resolve(__dirname, '../.env') });
+
 const { vectorStorePath, openAiEmbeddingModel, repoRoot } = require('../src/services/assistant/assistantConfig');
 const { getClient, isConfigured } = require('../src/services/assistant/openaiClient');
 


### PR DESCRIPTION
## Summary
- load the dotenv configuration in `scripts/buildAssistantIndex.js` so that environment variables in `.env` are available before use

## Testing
- npm run assistant:index -- --dry-run *(interrupted after verifying configuration to avoid network calls)*

------
https://chatgpt.com/codex/tasks/task_e_68caf76543408333a3e0919c6196bd2e