### PR TITLE
Ensure ui-kit is loaded on secondary portal pages

### DIFF
--- a/public/admin/advertencias.html
+++ b/public/admin/advertencias.html
@@ -89,6 +89,7 @@
   </div>
   <script src="/js/admin-sidebar.js"></script>
   <script src="/js/admin-guard.js"></script>
+  <script defer src="/js/ui-kit.js"></script>
   <script src="/js/termo-clausulas.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {

--- a/public/admin/salas.html
+++ b/public/admin/salas.html
@@ -202,6 +202,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>
     <script defer src="/js/mobile-adapter.js"></script>
+    <script defer src="/js/ui-kit.js"></script>
     <script defer src="/js/mobile-tweaks.js"></script>
     <script src="/js/admin-sidebar.js"></script>
     <script src="/js/admin-guard.js"></script>

--- a/public/advertencias.html
+++ b/public/advertencias.html
@@ -157,6 +157,7 @@
 
 
     <script src="/js/termo-clausulas.js"></script>
+    <script defer src="/js/ui-kit.js"></script>
     <script>
     const clausulas = window.TERMO_CLAUSULAS;
     const container = document.getElementById('clausulas-container');

--- a/public/consultar-email-cadastrado.html
+++ b/public/consultar-email-cadastrado.html
@@ -191,6 +191,7 @@
     </script>
 
     <script defer src="/js/mobile-adapter.js"></script>
+    <script defer src="/js/ui-kit.js"></script>
     <script defer src="/js/mobile-tweaks.js"></script>
 
 </body>

--- a/public/eventos/meus-eventos.html
+++ b/public/eventos/meus-eventos.html
@@ -139,6 +139,7 @@
 
   <!-- JS -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script defer src="/js/ui-kit.js"></script>
 
  <script>
     // helpers

--- a/public/eventos/termo.html
+++ b/public/eventos/termo.html
@@ -90,5 +90,6 @@
     preloadPdf();
     verificarStatus();
   </script>
+  <script defer src="/js/ui-kit.js"></script>
 </body>
 </html>

--- a/public/permissionarios/certidao.html
+++ b/public/permissionarios/certidao.html
@@ -264,5 +264,6 @@
       }
     });
   </script>
+  <script defer src="/js/ui-kit.js"></script>
 </body>
 </html>

--- a/public/termo-permisao.html
+++ b/public/termo-permisao.html
@@ -242,5 +242,6 @@
       <div class="linha">TESTEMUNHA – CPF {{testemunha2_cpf}}</div>
     </div>
   </main>
+  <script defer src="/js/ui-kit.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add the ui-kit loader to the advertências view and other secondary HTML screens so the assistant widget is available
- update admin and permissionário certificate pages to load ui-kit alongside existing scripts
- ensure event-related public pages also defer-load ui-kit for consistent chat availability

## Testing
- not run (HTML-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cbfb71bdc08333bb207bd0b316fed9