### PR TITLE
Normalize SEFAZ healthcheck receita code

### DIFF
--- a/src/services/sefazService.js
+++ b/src/services/sefazService.js
@@ -574,14 +574,14 @@ async function checkSefazHealth() {
     RECEITA_CODIGO_EVENTO_PF,
     RECEITA_CODIGO_EVENTO_PJ,
   ]
-    .map((cod) => onlyDigits(cod))
-    .filter((cod) => !!cod);
+    .map((cod) => normalizeCodigoReceita(cod))
+    .filter((cod) => Number.isFinite(cod) && cod > 0);
 
   if (!candidatos.length) {
     throw new Error('Nenhum código de receita configurado para health-check da SEFAZ.');
   }
 
-  const codigo = candidatos[0];
+  const codigo = Number(candidatos[0]);
   const { data } = await reqWithRetry(
     () => sefaz.get('/api/public/receita/consultar', { params: { codigo } }),
     'health-check'

--- a/tests/sefazServiceHealth.test.js
+++ b/tests/sefazServiceHealth.test.js
@@ -1,0 +1,86 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const servicePath = path.resolve(__dirname, '../src/services/sefazService.js');
+const Module = require('module');
+
+function withAxiosMock(onGet) {
+  const originalLoad = Module._load;
+  Module._load = function mockAxios(request, parent, isMain) {
+    if (request === 'axios') {
+      return {
+        create: (config) => ({
+          config,
+          interceptors: {
+            request: { use: () => {} },
+            response: { use: () => {} },
+          },
+          get: async (url, options) => onGet(url, options),
+          post: async () => ({ data: {} }),
+        }),
+      };
+    }
+    if (request === 'dotenv') {
+      return { config: () => ({}) };
+    }
+    return originalLoad(request, parent, isMain);
+  };
+
+  delete require.cache[servicePath];
+  const svc = require(servicePath);
+
+  return {
+    ...svc,
+    restore: () => {
+      delete require.cache[servicePath];
+      Module._load = originalLoad;
+    },
+  };
+}
+
+test('checkSefazHealth aceita código com dígito verificador', async () => {
+  const envKeys = [
+    'SEFAZ_APP_TOKEN',
+    'SEFAZ_HEALTHCHECK_RECEITA_CODIGO',
+    'RECEITA_CODIGO_PERMISSIONARIO',
+    'RECEITA_CODIGO_EVENTO',
+    'RECEITA_CODIGO_EVENTO_PF',
+    'RECEITA_CODIGO_EVENTO_PJ',
+  ];
+  const previousEnv = {};
+  for (const key of envKeys) {
+    previousEnv[key] = process.env[key];
+  }
+
+  process.env.SEFAZ_APP_TOKEN = 'token-saude';
+  process.env.SEFAZ_HEALTHCHECK_RECEITA_CODIGO = '20165-1';
+  process.env.RECEITA_CODIGO_PERMISSIONARIO = '';
+  process.env.RECEITA_CODIGO_EVENTO = '';
+  process.env.RECEITA_CODIGO_EVENTO_PF = '';
+  process.env.RECEITA_CODIGO_EVENTO_PJ = '';
+
+  const calls = [];
+  const { checkSefazHealth, restore } = withAxiosMock(async (url, options) => {
+    calls.push({ url, options });
+    return { data: { ok: true } };
+  });
+
+  try {
+    const result = await checkSefazHealth();
+    assert.equal(result, true);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, '/api/public/receita/consultar');
+    assert.equal(calls[0].options.params.codigo, 20165);
+    assert.equal(typeof calls[0].options.params.codigo, 'number');
+  } finally {
+    restore();
+    for (const key of envKeys) {
+      if (previousEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = previousEnv[key];
+      }
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- normalize SEFAZ health check receita candidates using the existing helper and drop invalid entries
- ensure the health check request passes the numeric receita code to the consulta endpoint
- add a focused unit test that covers codes with verification digits during the health check

## Testing
- node --test tests/sefazServiceHealth.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cbfd171dac8333a59084e639c76e5a