### PR TITLE
Adjust assistant widget flex sizing

### DIFF
--- a/public/css/assistant-widget.css
+++ b/public/css/assistant-widget.css
@@ -71,11 +71,14 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  flex: 1;
+  min-height: 0;
 }
 
 .assistant-messages {
   flex: 1;
   overflow-y: auto;
+  min-height: 0;
   padding: 16px;
   background: #f5f7fa;
   display: flex;


### PR DESCRIPTION
## Summary
- add flex growth and min-height controls to the assistant body so it respects panel bounds
- allow the messages container to shrink while keeping scroll behavior by setting min-height to zero

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cc00eb0950833383475320217f2cc2