### PR TITLE
Exclude Yarn artifacts from assistant index

### DIFF
--- a/scripts/buildAssistantIndex.js
+++ b/scripts/buildAssistantIndex.js
@@ -16,6 +16,7 @@ const EXCLUDE_DIRS = new Set([
   '.github',
   '.idea',
   '.vscode',
+  '.yarn',
   'config/assistant',
   'sistemadepagamentocipt',
   'extrator-termos-drive',


### PR DESCRIPTION
## Summary
- add the .yarn directory to the assistant index exclusion list so Yarn-managed dependencies are skipped

## Testing
- npm run assistant:index *(fails: missing OPENAI_API_KEY configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc086ad8a48333a8e04fdb08f725bb