### PR TITLE
Render assistant markdown responses

### DIFF
--- a/public/css/assistant-widget.css
+++ b/public/css/assistant-widget.css
@@ -93,7 +93,30 @@
   line-height: 1.45;
   font-size: 0.92rem;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
-  white-space: pre-line;
+  white-space: normal;
+}
+
+.assistant-message p {
+  margin: 0 0 0.6em;
+}
+
+.assistant-message p:last-child {
+  margin-bottom: 0;
+}
+
+.assistant-message ul,
+.assistant-message ol {
+  margin: 0.25em 0 0.6em 1.25em;
+  padding: 0;
+}
+
+.assistant-message ul:last-child,
+.assistant-message ol:last-child {
+  margin-bottom: 0;
+}
+
+.assistant-message li {
+  margin: 0.2em 0;
 }
 
 .assistant-message.user {


### PR DESCRIPTION
## Summary
- add a markdown-to-HTML renderer for assistant replies so bold text and lists survive sanitization
- update the widget styling to support paragraphs and list formatting
- extend the assistant widget test to cover strong text and ordered list rendering

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc0ddcaa64833396b459b2af3d3087