### PR TITLE
Ajusta cálculo de atraso de DAR no dia do vencimento

### DIFF
--- a/tests/cobrancaService.test.js
+++ b/tests/cobrancaService.test.js
@@ -1,0 +1,43 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const axios = require('axios');
+
+const { calcularEncargosAtraso } = require('../src/services/cobrancaService');
+
+test('não calcula atraso quando o vencimento é hoje antes das 15h', async (t) => {
+  const dar = {
+    valor: 1000,
+    data_vencimento: '2025-09-30'
+  };
+
+  const referencia = new Date('2025-09-30T14:00:00-03:00');
+
+  const mockSelic = t.mock.method(axios, 'get', async () => {
+    throw new Error('API SELIC não deve ser chamada quando não há atraso');
+  });
+
+  const resultado = await calcularEncargosAtraso(dar, referencia);
+
+  assert.equal(resultado.diasAtraso, 0);
+  assert.equal(resultado.valorAtualizado, dar.valor);
+  assert.equal(resultado.novaDataVencimento, dar.data_vencimento);
+  assert.equal(mockSelic.mock.callCount(), 0);
+});
+
+test('ajusta vencimento para o próximo dia útil após as 15h', async (t) => {
+  const dar = {
+    valor: 1000,
+    data_vencimento: '2025-09-30'
+  };
+
+  const referencia = new Date('2025-09-30T16:00:00-03:00');
+
+  const mockSelic = t.mock.method(axios, 'get', async () => ({ data: { valor: 12.5 } }));
+
+  const resultado = await calcularEncargosAtraso(dar, referencia);
+
+  assert.equal(mockSelic.mock.callCount(), 1);
+  assert.equal(resultado.diasAtraso, 1);
+  assert.equal(resultado.novaDataVencimento, '2025-10-01');
+  assert(resultado.valorAtualizado > dar.valor);
+});


### PR DESCRIPTION
## Summary
- normaliza o cálculo de dias de atraso considerando o fuso horário de Maceió e permitindo injetar uma data de referência
- evita que DARs com vencimento no dia sejam tratadas como vencidas e mantém o vencimento original nesses casos
- adiciona testes unitários para cobrir cenários antes e depois das 15h com verificação do uso da API da SELIC

## Testing
- node --test tests/cobrancaService.test.js
- npm test *(falha: diversos testes exigem dependências externas como SEFAZ_APP_TOKEN e banco configurado)*

------
https://chatgpt.com/codex/tasks/task_e_68dc260485cc8333b5d133945adb947e