### PR TITLE
Add sem juros handling for admin DARs

### DIFF
--- a/src/migrations/20250927100000-add-sem-juros-to-dars.js
+++ b/src/migrations/20250927100000-add-sem-juros-to-dars.js
@@ -1,0 +1,30 @@
+"use strict";
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const table = await queryInterface.describeTable("dars");
+    if (!table.sem_juros) {
+      await queryInterface.addColumn("dars", "sem_juros", {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        defaultValue: 0,
+      });
+      await queryInterface.sequelize.query(`
+        UPDATE dars
+           SET sem_juros = 0
+         WHERE sem_juros IS NULL;
+      `);
+      console.log("[MIGRATE] dars.sem_juros criado com default 0.");
+    } else {
+      console.log("[MIGRATE] dars.sem_juros já existe — pulando.");
+    }
+  },
+
+  async down(queryInterface) {
+    const table = await queryInterface.describeTable("dars");
+    if (table.sem_juros) {
+      await queryInterface.removeColumn("dars", "sem_juros");
+      console.log("[MIGRATE][down] dars.sem_juros removido.");
+    }
+  },
+};

--- a/tests/adminDarsComprovante.test.js
+++ b/tests/adminDarsComprovante.test.js
@@ -30,7 +30,8 @@ test('comprovante persiste data de pagamento encontrada', async () => {
     pdf_url TEXT,
     codigo_barras TEXT,
     linha_digitavel TEXT,
-    comprovante_token TEXT
+    comprovante_token TEXT,
+    sem_juros INTEGER DEFAULT 0
   )`);
   await run(`CREATE TABLE documentos (id INTEGER PRIMARY KEY AUTOINCREMENT, token TEXT, caminho TEXT, permissionario_id INTEGER, created_at TEXT)`);
   await run(`INSERT INTO permissionarios (id, nome_empresa, cnpj) VALUES (1, 'Perm', '12345678000199')`);
@@ -145,7 +146,8 @@ test('comprovante busca pagamentos anteriores ao vencimento', async () => {
     pdf_url TEXT,
     codigo_barras TEXT,
     linha_digitavel TEXT,
-    comprovante_token TEXT
+    comprovante_token TEXT,
+    sem_juros INTEGER DEFAULT 0
   )`);
   await run(`CREATE TABLE documentos (id INTEGER PRIMARY KEY AUTOINCREMENT, token TEXT, caminho TEXT, permissionario_id INTEGER, created_at TEXT)`);
   await run(`INSERT INTO permissionarios (id, nome_empresa, cnpj) VALUES (1, 'Perm', '12345678000199')`);
@@ -260,7 +262,8 @@ test('comprovante reutiliza PDF existente quando token e arquivo presentes', asy
     pdf_url TEXT,
     codigo_barras TEXT,
     linha_digitavel TEXT,
-    comprovante_token TEXT
+    comprovante_token TEXT,
+    sem_juros INTEGER DEFAULT 0
   )`);
   await run(`CREATE TABLE documentos (id INTEGER PRIMARY KEY AUTOINCREMENT, token TEXT, caminho TEXT, permissionario_id INTEGER, created_at TEXT)`);
   await run(`INSERT INTO permissionarios (id, nome_empresa, cnpj) VALUES (1, 'Perm', '12345678000199')`);

--- a/tests/adminDarsReemitir.test.js
+++ b/tests/adminDarsReemitir.test.js
@@ -16,7 +16,7 @@ test('reemitir DAR vencido atualiza valor e vencimento', async () => {
   const get = (sql, params=[]) => new Promise((res, rej) => db.get(sql, params, (err, row) => err ? rej(err) : res(row)));
 
   await run(`CREATE TABLE permissionarios (id INTEGER PRIMARY KEY, nome_empresa TEXT, cnpj TEXT, cpf TEXT, tipo TEXT)`);
-  await run(`CREATE TABLE dars (id INTEGER PRIMARY KEY, permissionario_id INTEGER, data_vencimento TEXT, mes_referencia INTEGER, ano_referencia INTEGER, valor REAL, status TEXT, numero_documento TEXT, pdf_url TEXT, codigo_barras TEXT, link_pdf TEXT, data_emissao TEXT, emitido_por_id INTEGER)`);
+  await run(`CREATE TABLE dars (id INTEGER PRIMARY KEY, permissionario_id INTEGER, data_vencimento TEXT, mes_referencia INTEGER, ano_referencia INTEGER, valor REAL, status TEXT, numero_documento TEXT, pdf_url TEXT, codigo_barras TEXT, link_pdf TEXT, data_emissao TEXT, emitido_por_id INTEGER, sem_juros INTEGER DEFAULT 0)`);
   await run(`INSERT INTO permissionarios (id, nome_empresa, cnpj) VALUES (1, 'Perm', '12345678000199')`);
   await run(`INSERT INTO dars (id, permissionario_id, data_vencimento, mes_referencia, ano_referencia, valor, status) VALUES (99, 1, '2024-01-01', 1, 2024, 100, 'Vencido')`);
 

--- a/tests/adminDashboardStatsFilter.test.js
+++ b/tests/adminDashboardStatsFilter.test.js
@@ -12,7 +12,7 @@ test('dashboard-stats respects tipo filter', async () => {
   const run = (sql, params=[]) => new Promise((res, rej) => db.run(sql, params, err => err ? rej(err) : res()));
 
   await run(`CREATE TABLE permissionarios (id INTEGER PRIMARY KEY, nome_empresa TEXT, tipo TEXT);`);
-  await run(`CREATE TABLE dars (id INTEGER PRIMARY KEY, permissionario_id INTEGER, tipo_permissionario TEXT, valor REAL, data_vencimento TEXT, status TEXT, mes_referencia INTEGER, ano_referencia INTEGER);`);
+  await run(`CREATE TABLE dars (id INTEGER PRIMARY KEY, permissionario_id INTEGER, tipo_permissionario TEXT, valor REAL, data_vencimento TEXT, status TEXT, mes_referencia INTEGER, ano_referencia INTEGER, sem_juros INTEGER DEFAULT 0);`);
 
   await run(`INSERT INTO permissionarios (id, nome_empresa, tipo, valor_aluguel) VALUES (1, 'Perm A', 'Normal', 100);`);
   await run(`INSERT INTO dars (id, permissionario_id, tipo_permissionario, valor, data_vencimento, status, mes_referencia, ano_referencia) VALUES (1, 1, 'Permissionario', 100, '2030-01-01', 'Pendente', 1, 2030);`);

--- a/tests/adminRelatorioDars.test.js
+++ b/tests/adminRelatorioDars.test.js
@@ -29,7 +29,7 @@ test('relatorio de dars inclui guias emitidas mesmo sem emitido_por_id ou permis
   await run(`CREATE TABLE permissionarios (id INTEGER PRIMARY KEY, nome_empresa TEXT, cnpj TEXT, tipo TEXT, valor_aluguel REAL)`);
   await run(`CREATE TABLE dars (id INTEGER PRIMARY KEY, permissionario_id INTEGER, data_vencimento TEXT, mes_referencia INTEGER,
  ano_referencia INTEGER, valor REAL, status TEXT, numero_documento TEXT, pdf_url TEXT, linha_digitavel TEXT, data_emissao TEXT,
- emitido_por_id INTEGER)`);
+ emitido_por_id INTEGER, sem_juros INTEGER DEFAULT 0)`);
   await run(`CREATE TABLE documentos (id INTEGER PRIMARY KEY, tipo TEXT, caminho TEXT, token TEXT)`);
   await run(`CREATE TABLE DARs_Eventos (id_dar INTEGER, id_evento INTEGER)`);
   await run(`CREATE TABLE Eventos (id INTEGER PRIMARY KEY, id_cliente INTEGER)`);
@@ -86,7 +86,7 @@ test('retorna 204 quando nao existem dars emitidas', async () => {
 
   await run(`CREATE TABLE dars (id INTEGER PRIMARY KEY, permissionario_id INTEGER, data_vencimento TEXT, mes_referencia INTEGER,
  ano_referencia INTEGER, valor REAL, status TEXT, numero_documento TEXT, pdf_url TEXT, linha_digitavel TEXT, data_emissao TEXT,
- emitido_por_id INTEGER)`);
+ emitido_por_id INTEGER, sem_juros INTEGER DEFAULT 0)`);
   await run(`CREATE TABLE documentos (id INTEGER PRIMARY KEY, tipo TEXT, caminho TEXT, token TEXT)`);
   await run(`CREATE TABLE DARs_Eventos (id_dar INTEGER, id_evento INTEGER)`);
   await run(`CREATE TABLE Eventos (id INTEGER PRIMARY KEY, id_cliente INTEGER)`);

--- a/tests/adminRelatorioDevedores.test.js
+++ b/tests/adminRelatorioDevedores.test.js
@@ -26,7 +26,7 @@ test('relatorio devedores gera PDF contendo permissionario', async () => {
   const run = (sql, params = []) => new Promise((res, rej) => db.run(sql, params, err => err ? rej(err) : res()));
 
   await run(`CREATE TABLE permissionarios (id INTEGER PRIMARY KEY, nome_empresa TEXT, cnpj TEXT, tipo TEXT, valor_aluguel REAL)`);
-  await run(`CREATE TABLE dars (id INTEGER PRIMARY KEY, permissionario_id INTEGER, data_vencimento TEXT, valor REAL, status TEXT)`);
+  await run(`CREATE TABLE dars (id INTEGER PRIMARY KEY, permissionario_id INTEGER, data_vencimento TEXT, valor REAL, status TEXT, sem_juros INTEGER DEFAULT 0)`);
   await run(`CREATE TABLE documentos (id INTEGER PRIMARY KEY, tipo TEXT, caminho TEXT, token TEXT)`);
 
   await run(`INSERT INTO permissionarios (id, nome_empresa, cnpj, tipo, valor_aluguel) VALUES (1, 'Perm', '12345678000199', 'Normal', 100)`);

--- a/tests/adminRelatorioEventosDars.test.js
+++ b/tests/adminRelatorioEventosDars.test.js
@@ -26,7 +26,7 @@ test('relatorio de dars de eventos filtra por data', async () => {
   const run = (sql, params = []) => new Promise((res, rej) => db.run(sql, params, err => err ? rej(err) : res()));
 
   await run(
-    `CREATE TABLE dars (id INTEGER PRIMARY KEY, status TEXT, numero_documento TEXT, data_vencimento TEXT, valor REAL);`
+    `CREATE TABLE dars (id INTEGER PRIMARY KEY, status TEXT, numero_documento TEXT, data_vencimento TEXT, valor REAL, sem_juros INTEGER DEFAULT 0);`
   );
   await run(`CREATE TABLE DARs_Eventos (id_dar INTEGER, id_evento INTEGER);`);
   await run(`CREATE TABLE Eventos (id INTEGER PRIMARY KEY, nome_evento TEXT, id_cliente INTEGER);`);

--- a/tests/advertenciaDarService.test.js
+++ b/tests/advertenciaDarService.test.js
@@ -45,7 +45,8 @@ test('emitirDarAdvertencia cria dar e vincula à advertencia', async () => {
     pdf_url TEXT,
     linha_digitavel TEXT,
     codigo_barras TEXT,
-    data_emissao TEXT
+    data_emissao TEXT,
+    sem_juros INTEGER DEFAULT 0
   );`);
   await run(db, `CREATE TABLE Advertencias (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/tests/clientDashboardStatsEmitidoReemitido.test.js
+++ b/tests/clientDashboardStatsEmitidoReemitido.test.js
@@ -12,7 +12,7 @@ test('client dashboard-stats counts Emitido/Reemitido correctly', async () => {
   const run = (sql, params=[]) => new Promise((res, rej) => db.run(sql, params, err => err ? rej(err) : res()));
 
   await run('CREATE TABLE Eventos (id INTEGER PRIMARY KEY, id_cliente INTEGER);');
-  await run('CREATE TABLE dars (id INTEGER PRIMARY KEY, valor REAL, data_vencimento TEXT, status TEXT);');
+  await run('CREATE TABLE dars (id INTEGER PRIMARY KEY, valor REAL, data_vencimento TEXT, status TEXT, sem_juros INTEGER DEFAULT 0);');
   await run('CREATE TABLE DARs_Eventos (id INTEGER PRIMARY KEY, id_dar INTEGER, id_evento INTEGER);');
 
   await run('INSERT INTO Eventos (id, id_cliente) VALUES (1, 1);');

--- a/tests/darsRoutesEmitir.test.js
+++ b/tests/darsRoutesEmitir.test.js
@@ -18,7 +18,7 @@ test('codigo_barras atualizado a partir da linha digitavel', async () => {
   const get = (sql, params = []) => new Promise((res, rej) => db.get(sql, params, (err, row) => err ? rej(err) : res(row)));
 
   await run(`CREATE TABLE permissionarios (id INTEGER PRIMARY KEY, nome_empresa TEXT, cnpj TEXT, numero_documento TEXT, telefone_cobranca TEXT, tipo TEXT)`);
-  await run(`CREATE TABLE dars (id INTEGER PRIMARY KEY, permissionario_id INTEGER, data_vencimento TEXT, mes_referencia INTEGER, ano_referencia INTEGER, valor REAL, status TEXT, numero_documento TEXT, pdf_url TEXT, linha_digitavel TEXT, codigo_barras TEXT, link_pdf TEXT, data_emissao TEXT DEFAULT CURRENT_TIMESTAMP)`);
+  await run(`CREATE TABLE dars (id INTEGER PRIMARY KEY, permissionario_id INTEGER, data_vencimento TEXT, mes_referencia INTEGER, ano_referencia INTEGER, valor REAL, status TEXT, numero_documento TEXT, pdf_url TEXT, linha_digitavel TEXT, codigo_barras TEXT, link_pdf TEXT, data_emissao TEXT DEFAULT CURRENT_TIMESTAMP, sem_juros INTEGER DEFAULT 0)`);
   await run(`INSERT INTO permissionarios (id, nome_empresa, cnpj) VALUES (1, 'Perm', '12345678000199')`);
   await run(`INSERT INTO dars (id, permissionario_id, data_vencimento, mes_referencia, ano_referencia, valor, status) VALUES (10, 1, '2025-12-31', 12, 2025, 100, 'Novo')`);
 

--- a/tests/darsRoutesEmitirVencido.test.js
+++ b/tests/darsRoutesEmitirVencido.test.js
@@ -16,7 +16,7 @@ const setupDb = async (dbPath, status = 'Vencido') => {
   const run = (sql, params = []) => new Promise((res, rej) => db.run(sql, params, err => err ? rej(err) : res()));
   const get = (sql, params = []) => new Promise((res, rej) => db.get(sql, params, (err, row) => err ? rej(err) : res(row)));
   await run(`CREATE TABLE permissionarios (id INTEGER PRIMARY KEY, nome_empresa TEXT, cnpj TEXT, numero_documento TEXT, telefone_cobranca TEXT, tipo TEXT)`);
-  await run(`CREATE TABLE dars (id INTEGER PRIMARY KEY, permissionario_id INTEGER, data_vencimento TEXT, mes_referencia INTEGER, ano_referencia INTEGER, valor REAL, status TEXT, numero_documento TEXT, pdf_url TEXT, linha_digitavel TEXT, codigo_barras TEXT, link_pdf TEXT, data_emissao TEXT DEFAULT CURRENT_TIMESTAMP)`);
+  await run(`CREATE TABLE dars (id INTEGER PRIMARY KEY, permissionario_id INTEGER, data_vencimento TEXT, mes_referencia INTEGER, ano_referencia INTEGER, valor REAL, status TEXT, numero_documento TEXT, pdf_url TEXT, linha_digitavel TEXT, codigo_barras TEXT, link_pdf TEXT, data_emissao TEXT DEFAULT CURRENT_TIMESTAMP, sem_juros INTEGER DEFAULT 0)`);
   await run(`INSERT INTO permissionarios (id, nome_empresa, cnpj) VALUES (1, 'Perm', '12345678000199')`);
   await run(
     `INSERT INTO dars (id, permissionario_id, data_vencimento, mes_referencia, ano_referencia, valor, status) VALUES (20, 1, '2024-01-01', 1, 2024, 100, ?)`,

--- a/tests/darsRoutesPreviewVencido.test.js
+++ b/tests/darsRoutesPreviewVencido.test.js
@@ -12,7 +12,7 @@ const setupDb = async (dbPath) => {
   const db = require('../src/database/db');
   const run = (sql, params = []) => new Promise((res, rej) => db.run(sql, params, err => err ? rej(err) : res()));
   await run(`CREATE TABLE permissionarios (id INTEGER PRIMARY KEY, nome_empresa TEXT, cnpj TEXT, numero_documento TEXT, telefone_cobranca TEXT, tipo TEXT)`);
-  await run(`CREATE TABLE dars (id INTEGER PRIMARY KEY, permissionario_id INTEGER, data_vencimento TEXT, mes_referencia INTEGER, ano_referencia INTEGER, valor REAL, status TEXT, numero_documento TEXT, pdf_url TEXT, linha_digitavel TEXT, codigo_barras TEXT, link_pdf TEXT, data_emissao TEXT DEFAULT CURRENT_TIMESTAMP)`);
+  await run(`CREATE TABLE dars (id INTEGER PRIMARY KEY, permissionario_id INTEGER, data_vencimento TEXT, mes_referencia INTEGER, ano_referencia INTEGER, valor REAL, status TEXT, numero_documento TEXT, pdf_url TEXT, linha_digitavel TEXT, codigo_barras TEXT, link_pdf TEXT, data_emissao TEXT DEFAULT CURRENT_TIMESTAMP, sem_juros INTEGER DEFAULT 0)`);
   await run(`INSERT INTO permissionarios (id, nome_empresa, cnpj) VALUES (1, 'Perm', '12345678000199')`);
   await run(`INSERT INTO dars (id, permissionario_id, data_vencimento, mes_referencia, ano_referencia, valor, status) VALUES (30, 1, '2024-01-01', 1, 2024, 200, 'Vencido')`);
 };

--- a/tests/darsRoutesReemitir.test.js
+++ b/tests/darsRoutesReemitir.test.js
@@ -16,7 +16,7 @@ test('reemitir DAR vencido atualiza valor e vencimento', async () => {
   const get = (sql, params = []) => new Promise((res, rej) => db.get(sql, params, (err, row) => err ? rej(err) : res(row)));
 
   await run(`CREATE TABLE permissionarios (id INTEGER PRIMARY KEY, nome_empresa TEXT, cnpj TEXT, numero_documento TEXT, telefone_cobranca TEXT, tipo TEXT)`);
-  await run(`CREATE TABLE dars (id INTEGER PRIMARY KEY, permissionario_id INTEGER, data_vencimento TEXT, mes_referencia INTEGER, ano_referencia INTEGER, valor REAL, status TEXT, numero_documento TEXT, pdf_url TEXT, linha_digitavel TEXT, codigo_barras TEXT, link_pdf TEXT, data_emissao TEXT)`);
+  await run(`CREATE TABLE dars (id INTEGER PRIMARY KEY, permissionario_id INTEGER, data_vencimento TEXT, mes_referencia INTEGER, ano_referencia INTEGER, valor REAL, status TEXT, numero_documento TEXT, pdf_url TEXT, linha_digitavel TEXT, codigo_barras TEXT, link_pdf TEXT, data_emissao TEXT, sem_juros INTEGER DEFAULT 0)`);
   await run(`INSERT INTO permissionarios (id, nome_empresa, cnpj) VALUES (1, 'Perm', '12345678000199')`);
   await run(`INSERT INTO dars (id, permissionario_id, data_vencimento, mes_referencia, ano_referencia, valor, status, data_emissao) VALUES (10,1,'2024-01-01',1,2024,100,'Vencido','2000-01-01')`);
 

--- a/tests/eventoDarService.test.js
+++ b/tests/eventoDarService.test.js
@@ -81,7 +81,8 @@ async function setupSchema(db) {
     pdf_url TEXT,
     linha_digitavel TEXT,
     codigo_barras TEXT,
-    data_emissao TEXT DEFAULT CURRENT_TIMESTAMP
+    data_emissao TEXT DEFAULT CURRENT_TIMESTAMP,
+    sem_juros INTEGER DEFAULT 0
   );`);
   await run(db, `CREATE TABLE DARs_Eventos (
     id_evento INTEGER,

--- a/tests/isentoFilterBilling.test.js
+++ b/tests/isentoFilterBilling.test.js
@@ -10,7 +10,7 @@ test('dashboard and pagamentos ignore isentos ou valor zero', async () => {
   const run = (sql, params=[]) => new Promise((res, rej) => db.run(sql, params, err => err?rej(err):res()));
 
   await run(`CREATE TABLE permissionarios (id INTEGER PRIMARY KEY, nome_empresa TEXT, cnpj TEXT, tipo TEXT, valor_aluguel REAL);`);
-  await run(`CREATE TABLE dars (id INTEGER PRIMARY KEY, permissionario_id INTEGER, tipo_permissionario TEXT, valor REAL, data_vencimento TEXT, status TEXT, mes_referencia INTEGER, ano_referencia INTEGER);`);
+  await run(`CREATE TABLE dars (id INTEGER PRIMARY KEY, permissionario_id INTEGER, tipo_permissionario TEXT, valor REAL, data_vencimento TEXT, status TEXT, mes_referencia INTEGER, ano_referencia INTEGER, sem_juros INTEGER DEFAULT 0);`);
 
   await run(`INSERT INTO permissionarios (id,nome_empresa,cnpj,tipo,valor_aluguel) VALUES (1,'Normal','1','Normal',100);`);
   await run(`INSERT INTO permissionarios (id,nome_empresa,cnpj,tipo,valor_aluguel) VALUES (2,'Isento','2','Isento',100);`);

--- a/tests/migrationFixDarsEventosForeignKey.test.js
+++ b/tests/migrationFixDarsEventosForeignKey.test.js
@@ -72,7 +72,8 @@ test('migration keeps DARs_Eventos triggers and emitir route works', async () =>
       link_pdf TEXT,
       emitido_por_id INTEGER,
       data_emissao TEXT,
-      advertencia_fatos TEXT
+      advertencia_fatos TEXT,
+      sem_juros INTEGER DEFAULT 0
     );`
   );
 

--- a/tests/permissionariosCertidao.test.js
+++ b/tests/permissionariosCertidao.test.js
@@ -18,7 +18,7 @@ async function setup(dataVencimento) {
     new Promise((resolve, reject) => db.run(sql, params, err => err ? reject(err) : resolve()));
 
   await run(`CREATE TABLE permissionarios (id INTEGER PRIMARY KEY, nome_empresa TEXT, cnpj TEXT, email TEXT, tipo TEXT);`);
-  await run(`CREATE TABLE dars (id INTEGER PRIMARY KEY, permissionario_id INTEGER, data_vencimento TEXT, status TEXT);`);
+  await run(`CREATE TABLE dars (id INTEGER PRIMARY KEY, permissionario_id INTEGER, data_vencimento TEXT, status TEXT, sem_juros INTEGER DEFAULT 0);`);
   await run(`CREATE TABLE documentos (id INTEGER PRIMARY KEY, tipo TEXT, caminho TEXT, token TEXT);`);
 
   await run(`INSERT INTO permissionarios (id, nome_empresa, cnpj, email) VALUES (1, 'Perm', '12345678000199', 'perm@example.com');`);

--- a/tests/userDashboardStatsEmitidoReemitido.test.js
+++ b/tests/userDashboardStatsEmitidoReemitido.test.js
@@ -12,7 +12,7 @@ test('dashboard-stats includes Emitido/Reemitido', async () => {
   const run = (sql, params=[]) => new Promise((res, rej) => db.run(sql, params, err => err ? rej(err) : res()));
 
   await run(`CREATE TABLE permissionarios (id INTEGER PRIMARY KEY, nome_empresa TEXT);`);
-  await run(`CREATE TABLE dars (id INTEGER PRIMARY KEY, permissionario_id INTEGER, data_vencimento TEXT, valor REAL, status TEXT);`);
+  await run(`CREATE TABLE dars (id INTEGER PRIMARY KEY, permissionario_id INTEGER, data_vencimento TEXT, valor REAL, status TEXT, sem_juros INTEGER DEFAULT 0);`);
   await run(`INSERT INTO permissionarios (id, nome_empresa) VALUES (1, 'Perm');`);
 
   const today = new Date();


### PR DESCRIPTION
## Summary
- add a migration that introduces the sem_juros flag to the dars table
- allow admin DAR creation to persist the sem juros flag and set the due date to today when requested
- skip surcharge calculations when emitting no-interest DARs and expand the admin DAR test suite accordingly

## Testing
- node --test tests/adminDarsRoutesCreate.test.js --test-name-pattern "respeita sem juros"

------
https://chatgpt.com/codex/tasks/task_e_68dd1d1c36248333bc6460e9f7ba4556