### PR TITLE
Add modal to generate DAR sem juros

### DIFF
--- a/public/admin/dars.html
+++ b/public/admin/dars.html
@@ -38,8 +38,12 @@
   <div class="wrapper">
     <div id="sidebar-container"></div>
     <div class="main-content">
-      <header class="topbar">
-        <div id="userInfo" class="text-end">
+      <header class="topbar d-flex flex-wrap align-items-center gap-3 justify-content-between">
+        <button type="button" class="btn btn-warning fw-semibold shadow-sm" data-bs-toggle="modal" data-bs-target="#gerarDarSemJurosModal">
+          <i class="bi bi-lightning-charge-fill me-1"></i>
+          Gerar DAR sem juros
+        </button>
+        <div id="userInfo" class="text-end ms-auto">
           <strong id="adminName">Carregando...</strong>
         </div>
       </header>
@@ -97,6 +101,53 @@
     </div>
   </div>
 
+  <div class="modal fade" id="gerarDarSemJurosModal" tabindex="-1" aria-labelledby="gerarDarSemJurosModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-lg">
+      <form class="modal-content" id="gerarDarSemJurosForm" novalidate>
+        <div class="modal-header">
+          <h5 class="modal-title" id="gerarDarSemJurosModalLabel">Gerar DAR sem juros</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+        </div>
+        <div class="modal-body">
+          <div class="mb-3">
+            <label for="semJurosPermissionarioSearch" class="form-label">Buscar permissionário</label>
+            <input type="search" id="semJurosPermissionarioSearch" class="form-control" placeholder="Digite o nome, CNPJ ou inscrição" autocomplete="off">
+          </div>
+          <div class="mb-3">
+            <label for="semJurosPermissionario" class="form-label">Permissionário</label>
+            <select id="semJurosPermissionario" class="form-select" required>
+              <option value="" selected disabled>Carregando permissionários...</option>
+            </select>
+            <div class="invalid-feedback">Selecione um permissionário válido.</div>
+          </div>
+          <div class="row g-3">
+            <div class="col-md-6">
+              <label for="semJurosCompetencia" class="form-label">Competência</label>
+              <input type="month" id="semJurosCompetencia" class="form-control" required>
+              <div class="invalid-feedback">Informe a competência no formato ano/mês.</div>
+            </div>
+            <div class="col-md-6">
+              <label for="semJurosValor" class="form-label">Valor (R$)</label>
+              <input type="number" id="semJurosValor" class="form-control" min="0" step="0.01" required>
+              <div class="invalid-feedback">Informe um valor válido para o DAR.</div>
+            </div>
+          </div>
+          <div class="form-check form-switch mt-4">
+            <input class="form-check-input" type="checkbox" role="switch" id="semJurosCheckbox" checked>
+            <label class="form-check-label" for="semJurosCheckbox">Sem juros (vencimento hoje)</label>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
+          <button type="submit" class="btn btn-primary">
+            <i class="bi bi-file-earmark-plus me-1"></i>
+            Gerar DAR
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   <script src="/js/admin-sidebar.js"></script>
   <script src="/js/admin-guard.js"></script>
@@ -133,6 +184,16 @@
       const filterButton  = document.getElementById('filterButton');
       const tableBody     = document.getElementById('dars-table-body');
       const paginationNav = document.getElementById('paginationNav');
+      const gerarDarSemJurosModalEl = document.getElementById('gerarDarSemJurosModal');
+      const gerarDarSemJurosForm = document.getElementById('gerarDarSemJurosForm');
+      const semJurosPermissionarioSelect = document.getElementById('semJurosPermissionario');
+      const semJurosPermissionarioSearch = document.getElementById('semJurosPermissionarioSearch');
+      const semJurosCompetenciaInput = document.getElementById('semJurosCompetencia');
+      const semJurosValorInput = document.getElementById('semJurosValor');
+      const semJurosCheckbox = document.getElementById('semJurosCheckbox');
+
+      let semJurosPermissionariosCache = [];
+      const semJurosPermissionariosMap = new Map();
 
       // combos
       const meses = ["Janeiro","Fevereiro","Março","Abril","Maio","Junho","Julho","Agosto","Setembro","Outubro","Novembro","Dezembro"];
@@ -213,6 +274,219 @@
       }
 
       filterButton.addEventListener('click', ()=> fetchDars(1));
+
+      function getSemJurosModalInstance(){
+        if (!gerarDarSemJurosModalEl) return null;
+        try {
+          return bootstrap.Modal.getOrCreateInstance(gerarDarSemJurosModalEl);
+        } catch (error) {
+          console.error('Bootstrap Modal error:', error);
+          return null;
+        }
+      }
+
+      function formatMonthValue(date = new Date()){
+        const year = date.getFullYear();
+        const month = String(date.getMonth()+1).padStart(2,'0');
+        return `${year}-${month}`;
+      }
+
+      function renderSemJurosPermissionarios(lista){
+        if (!semJurosPermissionarioSelect) return;
+        const valorAtual = semJurosPermissionarioSelect.value;
+        semJurosPermissionarioSelect.innerHTML = '';
+
+        const placeholder = document.createElement('option');
+        placeholder.value = '';
+        placeholder.disabled = true;
+        placeholder.textContent = lista.length ? 'Selecione um permissionário' : 'Nenhum permissionário encontrado';
+        semJurosPermissionarioSelect.appendChild(placeholder);
+
+        const ordenados = lista.slice().sort((a,b)=>{
+          return String(a.nome_empresa||'').localeCompare(String(b.nome_empresa||''),'pt-BR',{ sensitivity:'base' });
+        });
+
+        ordenados.forEach(p=>{
+          const option = document.createElement('option');
+          option.value = String(p.id);
+          const nome = p.nome_empresa ? p.nome_empresa : 'Sem nome';
+          const cnpj = p.cnpj ? ` • ${formatarCNPJ(p.cnpj)}` : '';
+          option.textContent = `${nome}${cnpj}`;
+          semJurosPermissionarioSelect.appendChild(option);
+        });
+
+        if (valorAtual && ordenados.some(p=>String(p.id)===valorAtual)) {
+          semJurosPermissionarioSelect.value = valorAtual;
+          placeholder.selected = false;
+        } else {
+          semJurosPermissionarioSelect.value = '';
+          placeholder.selected = true;
+        }
+      }
+
+      function atualizarValorSemJuros(){
+        if (!semJurosValorInput || !semJurosPermissionarioSelect) return;
+        const selecionado = semJurosPermissionarioSelect.value;
+        const dados = semJurosPermissionariosMap.get(selecionado);
+        if (!dados){
+          semJurosValorInput.value = '';
+          return;
+        }
+        const valorAluguel = Number(dados.valor_aluguel);
+        if (Number.isFinite(valorAluguel) && valorAluguel > 0) {
+          semJurosValorInput.value = valorAluguel.toFixed(2);
+        } else {
+          semJurosValorInput.value = '';
+        }
+      }
+
+      function filtrarSemJurosPermissionarios(termo){
+        if (!semJurosPermissionarioSelect) return;
+        const normalizado = String(termo||'').trim().toLowerCase();
+        if (!normalizado){
+          renderSemJurosPermissionarios(semJurosPermissionariosCache);
+          atualizarValorSemJuros();
+          return;
+        }
+        const somenteDigitos = normalizado.replace(/\D/g,'');
+        const filtrados = semJurosPermissionariosCache.filter(p=>{
+          const nome = String(p.nome_empresa||'').toLowerCase();
+          const cnpj = String(p.cnpj||'');
+          const cnpjDigits = cnpj.replace(/\D/g,'');
+          return (
+            nome.includes(normalizado) ||
+            (somenteDigitos && cnpjDigits.includes(somenteDigitos))
+          );
+        });
+        renderSemJurosPermissionarios(filtrados);
+        atualizarValorSemJuros();
+      }
+
+      async function carregarSemJurosPermissionarios(forceReload=false){
+        if (!semJurosPermissionarioSelect) return;
+        if (semJurosPermissionariosCache.length && !forceReload){
+          renderSemJurosPermissionarios(semJurosPermissionariosCache);
+          atualizarValorSemJuros();
+          return;
+        }
+        try{
+          semJurosPermissionarioSelect.disabled = true;
+          semJurosPermissionarioSelect.innerHTML = '<option value="" disabled selected>Carregando permissionários...</option>';
+          const response = await fetch(`/api/admin/permissionarios?page=1&limit=500`, {
+            headers:{ Authorization:`Bearer ${token}` }
+          });
+          if (!response.ok) throw new Error('Não foi possível carregar os permissionários.');
+          const data = await response.json();
+          semJurosPermissionariosCache = Array.isArray(data.permissionarios) ? data.permissionarios : [];
+          semJurosPermissionariosMap.clear();
+          semJurosPermissionariosCache.forEach(p=>{
+            semJurosPermissionariosMap.set(String(p.id), p);
+          });
+          renderSemJurosPermissionarios(semJurosPermissionariosCache);
+          atualizarValorSemJuros();
+        }catch(error){
+          console.error('Erro ao carregar permissionários (sem juros):', error);
+          AppUI.toast(error.message || 'Falha ao carregar a lista de permissionários.', 'error');
+          semJurosPermissionarioSelect.innerHTML = '<option value="" disabled selected>Erro ao carregar permissionários</option>';
+        }finally{
+          semJurosPermissionarioSelect.disabled = false;
+        }
+      }
+
+      async function enviarDarSemJuros(event){
+        event.preventDefault();
+        if (!gerarDarSemJurosForm) return;
+
+        gerarDarSemJurosForm.classList.add('was-validated');
+
+        if (!semJurosPermissionarioSelect || !semJurosPermissionarioSelect.value){
+          AppUI.toast('Selecione um permissionário para continuar.', 'warn');
+          semJurosPermissionarioSelect?.focus();
+          return;
+        }
+        if (!semJurosCompetenciaInput || !semJurosCompetenciaInput.value){
+          AppUI.toast('Informe a competência desejada.', 'warn');
+          semJurosCompetenciaInput?.focus();
+          return;
+        }
+        const valorBruto = semJurosValorInput?.value ?? '';
+        const valorNormalizado = Number(String(valorBruto).replace(',', '.'));
+        if (!Number.isFinite(valorNormalizado) || !(valorNormalizado > 0)){
+          AppUI.toast('Informe um valor válido para o DAR.', 'warn');
+          semJurosValorInput?.focus();
+          return;
+        }
+
+        const payload = {
+          permissionarioId: Number(semJurosPermissionarioSelect.value),
+          tipo: 'Mensalidade',
+          competencia: semJurosCompetenciaInput.value,
+          valor: valorNormalizado,
+          semJuros: true
+        };
+
+        try{
+          AppUI.loading.show();
+          const response = await fetch('/api/admin/dars', {
+            method:'POST',
+            headers:{
+              'Content-Type':'application/json',
+              Authorization:`Bearer ${token}`
+            },
+            body: JSON.stringify(payload)
+          });
+          const resultado = await response.json().catch(()=>({}));
+          if (!response.ok){
+            throw new Error(resultado.error || 'Não foi possível gerar o DAR.');
+          }
+          AppUI.toast(resultado.message || 'DAR gerada com sucesso!', 'success');
+          gerarDarSemJurosForm.reset();
+          gerarDarSemJurosForm.classList.remove('was-validated');
+          if (semJurosCheckbox) semJurosCheckbox.checked = true;
+          if (semJurosCompetenciaInput) semJurosCompetenciaInput.value = formatMonthValue();
+          atualizarValorSemJuros();
+          const modalInstance = getSemJurosModalInstance();
+          modalInstance?.hide();
+          fetchDars();
+        }catch(error){
+          console.error('Erro ao gerar DAR sem juros:', error);
+          AppUI.toast(error.message || 'Falha ao gerar o DAR.', 'error');
+        }finally{
+          AppUI.loading.hide();
+        }
+      }
+
+      if (semJurosPermissionarioSelect){
+        semJurosPermissionarioSelect.addEventListener('change', ()=>{
+          atualizarValorSemJuros();
+        });
+      }
+
+      if (semJurosPermissionarioSearch){
+        semJurosPermissionarioSearch.addEventListener('input', (event)=>{
+          filtrarSemJurosPermissionarios(event.target.value);
+        });
+      }
+
+      if (gerarDarSemJurosForm){
+        gerarDarSemJurosForm.addEventListener('submit', enviarDarSemJuros);
+      }
+
+      if (gerarDarSemJurosModalEl){
+        gerarDarSemJurosModalEl.addEventListener('shown.bs.modal', ()=>{
+          if (semJurosCheckbox) semJurosCheckbox.checked = true;
+          if (semJurosCompetenciaInput) semJurosCompetenciaInput.value = formatMonthValue();
+          if (semJurosPermissionarioSearch) semJurosPermissionarioSearch.value = '';
+          carregarSemJurosPermissionarios();
+          semJurosPermissionarioSelect?.focus();
+        });
+        gerarDarSemJurosModalEl.addEventListener('hidden.bs.modal', ()=>{
+          gerarDarSemJurosForm?.classList.remove('was-validated');
+          if (semJurosCheckbox) semJurosCheckbox.checked = true;
+          if (semJurosCompetenciaInput) semJurosCompetenciaInput.value = formatMonthValue();
+          if (semJurosPermissionarioSearch) semJurosPermissionarioSearch.value = '';
+        });
+      }
 
       paginationNav.addEventListener('click', (e)=>{
         if (e.target.tagName==='A' && !e.target.parentElement.classList.contains('disabled')){


### PR DESCRIPTION
## Summary
- add a highlighted call-to-action in the DARs header to abrir o fluxo de geração sem juros
- incluir modal com formulário de competência, valor ajustável e indicação de geração sem juros
- implementar carregamento, filtro e envio do formulário para gerar DARs sem juros e atualizar a listagem

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd1f93143c8333bc46e78a54b0feb5