### PR TITLE
Fix admin DAR reissue status constraint failure

### DIFF
--- a/src/api/adminDarsRoutes.js
+++ b/src/api/adminDarsRoutes.js
@@ -938,7 +938,11 @@ await dbRunAsync(
   `UPDATE dars
       SET numero_documento = ?,
           pdf_url          = ?,
-          status           = CASE WHEN COALESCE(status,'') IN ('','Pendente','Vencido','Vencida') THEN 'Reemitido' ELSE status END,
+          status           = CASE
+                                WHEN status = 'Pago Parcialmente' THEN 'Parcialmente Pago'
+                                WHEN COALESCE(status,'') IN ('','Pendente','Vencido','Vencida') THEN 'Reemitido'
+                                ELSE status
+                              END,
           data_emissao     = COALESCE(data_emissao, date('now')),
           emitido_por_id   = COALESCE(emitido_por_id, ?),
           valor            = ?,


### PR DESCRIPTION
## Summary
- normalize legacy DAR statuses when reissuing so SQLite CHECK constraints accept the update

## Testing
- npm test *(fails: many suites depend on unavailable fixtures in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3d181c1a883339c08a7dab095e9f0