### PR TITLE
Handle manual comprovante unique constraint

### DIFF
--- a/src/api/adminEventosRoutes.js
+++ b/src/api/adminEventosRoutes.js
@@ -884,7 +884,22 @@ router.post(
       }
 
       if (!tokenDoc) {
-        tokenDoc = await gerarTokenDocumento('DAR_COMPROVANTE_MANUAL', null, db);
+        existingDoc = await dbGet(
+          `SELECT id, token, caminho
+             FROM documentos
+            WHERE evento_id = ? AND tipo = ?
+         ORDER BY id DESC
+            LIMIT 1`,
+          [eventoId, 'DAR_COMPROVANTE_MANUAL'],
+          'evento/baixa-manual/documento-evento-atual'
+        ).catch(() => null);
+
+        if (existingDoc?.token) {
+          tokenDoc = existingDoc.token;
+        } else {
+          existingDoc = null;
+          tokenDoc = await gerarTokenDocumento('DAR_COMPROVANTE_MANUAL', null, db);
+        }
       }
 
       const previousPath = existingDoc?.caminho && String(existingDoc.caminho).trim() ? existingDoc.caminho : null;


### PR DESCRIPTION
## Summary
- reuse existing manual comprovante records for an evento before generating new tokens to avoid UNIQUE violations
- allow admin eventos test harness to stub role middleware and document token generation
- add regression test ensuring existing comprovante is reused when baixando manualmente

## Testing
- npm test -- tests/adminEventosRoutes.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e3d16320dc83338ff07b7a2356c9d0