### PR TITLE
Padroniza horários em formato brasileiro

### DIFF
--- a/cron/gerarDarsMensais.js
+++ b/cron/gerarDarsMensais.js
@@ -19,6 +19,13 @@ const TEST_PERMISSIONARIO_ID = process.env.TEST_PERMISSIONARIO_ID
 // ================== Datas (AL, BR) ==================
 const { getLastBusinessDay } = require('../src/utils/businessDays');
 
+const formatTimestampBR = (date = new Date()) =>
+  date.toLocaleString('pt-BR', {
+    dateStyle: 'short',
+    timeStyle: 'medium',
+    hour12: false,
+  });
+
 // ================== Helpers DB ==================
 function dbAll(db, sql, params = []) {
   return new Promise((resolve, reject) => {
@@ -63,7 +70,7 @@ async function gerarDarsEEnviarNotificacoes() {
 
     const permissionarios = await dbAll(db, sql, params); // SEMPRE array
     console.log(
-      `[ROBÔ] ${new Date().toLocaleString('pt-BR')}: Iniciando rotina de geração de DARs...`
+      `[ROBÔ] ${formatTimestampBR()}: Iniciando rotina de geração de DARs...`
     );
     console.log(
       `[ROBÔ] ${permissionarios.length} permissionários. Competência ${String(mesReferencia).padStart(2, '0')}/${anoReferencia} - vencimento ${vencISO}`

--- a/gerarDarsMensais.js
+++ b/gerarDarsMensais.js
@@ -4,6 +4,13 @@ const { enviarEmailNovaDar } = require('../src/services/emailService');
 
 // --- Funções Auxiliares para Datas ---
 
+const formatTimestampBR = (date = new Date()) =>
+    date.toLocaleString('pt-BR', {
+        dateStyle: 'short',
+        timeStyle: 'medium',
+        hour12: false,
+    });
+
 // Função para verificar se um dia é útil (não é Sábado nem Domingo)
 function isDiaUtil(data) {
     const diaDaSemana = data.getDay(); // 0 = Domingo, 6 = Sábado
@@ -24,7 +31,7 @@ function getUltimoDiaUtil(ano, mes) {
 // --- Lógica Principal do Robô ---
 
 async function gerarDarsEEnviarNotificacoes() {
-    console.log(`[ROBÔ] ${new Date().toLocaleString('pt-BR')}: Iniciando rotina de geração de DARs...`);
+    console.log(`[ROBÔ] ${formatTimestampBR()}: Iniciando rotina de geração de DARs...`);
     const db = new sqlite3.Database('./sistemacipt.db');
 
     try {

--- a/public/admin/service-status.html
+++ b/public/admin/service-status.html
@@ -312,6 +312,12 @@
         const SNAPSHOT_STORAGE_KEY = 'adminServiceStatus:lastSnapshot';
         let hasRenderedOnce = false;
 
+        const dataHoraFormatter = new Intl.DateTimeFormat('pt-BR', {
+            dateStyle: 'short',
+            timeStyle: 'medium',
+            hour12: false
+        });
+
         const showAlert = (message, type = 'warning') => {
             statusAlert.textContent = message;
             statusAlert.className = `alert alert-${type} status-alert`;
@@ -325,11 +331,7 @@
 
         const updateLastUpdated = (date = new Date()) => {
             if (!lastUpdatedEl) return;
-            const formatter = new Intl.DateTimeFormat('pt-BR', {
-                dateStyle: 'short',
-                timeStyle: 'medium'
-            });
-            lastUpdatedEl.textContent = `Atualizado em ${formatter.format(date)}`;
+            lastUpdatedEl.textContent = `Atualizado em ${dataHoraFormatter.format(date)}`;
         };
 
         const showLoading = () => {
@@ -454,7 +456,10 @@
             if (timestamp) {
                 const ts = document.createElement('p');
                 ts.className = 'status-timestamp mb-0';
-                ts.textContent = `Última verificação: ${new Date(timestamp).toLocaleString('pt-BR')}`;
+                const dataVerificacao = new Date(timestamp);
+                ts.textContent = Number.isNaN(dataVerificacao.getTime())
+                    ? `Última verificação: ${timestamp}`
+                    : `Última verificação: ${dataHoraFormatter.format(dataVerificacao)}`;
                 body.appendChild(ts);
             }
 

--- a/public/js/admin-salas.js
+++ b/public/js/admin-salas.js
@@ -5,6 +5,8 @@ let modalNovaSala;
 let modalNovaReserva;
 let eventoSelecionado;
 
+const formatoHoraBR = { hour: '2-digit', minute: '2-digit', hour12: false };
+
 document.addEventListener('DOMContentLoaded', () => {
   const calendarEl = document.getElementById('calendar');
   if (calendarEl && window.FullCalendar) {
@@ -14,11 +16,8 @@ document.addEventListener('DOMContentLoaded', () => {
       editable: true,
       themeSystem: 'bootstrap5',
       displayEventEnd: true,
-      eventTimeFormat: {
-        hour: '2-digit',
-        minute: '2-digit',
-        hour12: false
-      },
+      eventTimeFormat: formatoHoraBR,
+      slotLabelFormat: formatoHoraBR,
       eventSources: [fetchReservas],
       eventClick: onEventClick,
       eventDrop: onEventChange,
@@ -56,9 +55,8 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 function formatRange(inicio, fim) {
-  const opcoes = { hour: '2-digit', minute: '2-digit', hour12: false };
-  const ini = new Date(inicio).toLocaleTimeString('pt-BR', opcoes);
-  const f = new Date(fim).toLocaleTimeString('pt-BR', opcoes);
+  const ini = new Date(inicio).toLocaleTimeString('pt-BR', formatoHoraBR);
+  const f = new Date(fim).toLocaleTimeString('pt-BR', formatoHoraBR);
   return `${ini} - ${f}`;
 }
 

--- a/public/js/salas.js
+++ b/public/js/salas.js
@@ -83,12 +83,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         return livres;
     }
 
+    const formatoHoraBR = { hour: '2-digit', minute: '2-digit', hour12: false };
+
     function formatarHora(dataHora) {
-        return new Date(dataHora).toLocaleTimeString('pt-BR', {
-            hour: '2-digit',
-            minute: '2-digit',
-            hour12: false
-        });
+        return new Date(dataHora).toLocaleTimeString('pt-BR', formatoHoraBR);
     }
 
     function formatarDataBR(dataStr) {
@@ -102,7 +100,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         locale: 'pt-br',
         themeSystem: 'bootstrap5',
         displayEventEnd: true,
-        eventTimeFormat: { hour: '2-digit', minute: '2-digit', hour12: false },
+        eventTimeFormat: formatoHoraBR,
+        slotLabelFormat: formatoHoraBR,
         dateClick: info => {
             calendar.changeView('timeGridDay', info.dateStr);
         },


### PR DESCRIPTION
## Summary
- ajusta calendários de reservas para exibir horários com formatação brasileira em 24 horas
- padroniza mensagens de log e cartões de status administrativos para usar data e hora brasileiras

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e51b62688c8333ba56c775d7110613