### PR TITLE
Ajusta remarcação e versão de termos de eventos

### DIFF
--- a/public/admin/eventos-remarcacoes.html
+++ b/public/admin/eventos-remarcacoes.html
@@ -246,7 +246,7 @@
         const resp = await fetch(`/api/admin/eventos/${id}/remarcar`, {
           method:'PUT',
           headers:{'Content-Type':'application/json', ...AUTH_HEADERS},
-          body: JSON.stringify({ mode:'unilateral', nova_data: nova })
+          body: JSON.stringify({ modo:'unilateral', nova_data: nova })
         });
         if (!resp.ok) throw new Error('Falha');
         remarcarModal.hide();
@@ -276,7 +276,7 @@
           await fetch(`/api/admin/eventos/${id}/remarcar`, {
             method:'PUT',
             headers:{'Content-Type':'application/json', ...AUTH_HEADERS},
-            body: JSON.stringify({ mode:'aprovar' })
+            body: JSON.stringify({ modo:'aprovar' })
           });
           carregarRemarcacoes();
         }catch{
@@ -290,7 +290,7 @@
           await fetch(`/api/admin/eventos/${id}/remarcar`, {
             method:'PUT',
             headers:{'Content-Type':'application/json', ...AUTH_HEADERS},
-            body: JSON.stringify({ mode:'rejeitar' })
+            body: JSON.stringify({ modo:'rejeitar' })
           });
           carregarRemarcacoes();
         }catch{
@@ -306,7 +306,7 @@
           await fetch(`/api/admin/eventos/${id}/remarcar`, {
             method:'PUT',
             headers:{'Content-Type':'application/json', ...AUTH_HEADERS},
-            body: JSON.stringify({ mode:'unilateral', nova_data: nova })
+            body: JSON.stringify({ modo:'unilateral', nova_data: nova })
           });
           carregarRemarcacoes();
         }catch{

--- a/public/eventos/meus-eventos.html
+++ b/public/eventos/meus-eventos.html
@@ -180,32 +180,79 @@
           const btns = document.getElementById(`btns-${eventoId}`);
           if(!btns) return;
 
-          const estaAssinado = meta.status === 'assinado';
-          const foiEnviado = meta.assinafy_id && meta.status !== 'nao_enviado';
+          const docs = Array.isArray(meta.documentos) ? meta.documentos : [];
+          const docAtual = docs[0] || null;
+          const statusAtual = (docAtual?.status || meta.status || '').toLowerCase();
+          const estaAssinado = statusAtual === 'assinado';
+          const foiEnviado = !!docAtual?.assinafy_id && !estaAssinado;
 
-          // Constrói a URL de download de forma segura
-          const urlDownloadSegura = meta.assinafy_id
-            ? `/api/documentos/assinafy/${meta.assinafy_id}/download-signed`
-            : meta.signed_pdf_public_url;
+          const buildDownloadUrl = (doc) => {
+            if (!doc) return null;
+            if (doc.signed_pdf_public_url) return doc.signed_pdf_public_url;
+            if ((doc.status || '').toLowerCase() === 'assinado' && doc.assinafy_id) {
+              return `/api/documentos/assinafy/${doc.assinafy_id}/download-signed`;
+            }
+            if (doc.download_url) return doc.download_url;
+            const versao = doc.versao || 1;
+            return `${TERMO_ENDPOINT(eventoId)}?versao=${versao}`;
+          };
 
-          let botoesTermoHtml = `
-            <button class="btn btn-sm btn-outline-secondary" data-baixar-termo="${eventoId}">
-              <i class="bi bi-filetype-pdf"></i> Baixar Termo Original
-            </button>
-          `;
+          const formatStatusLabel = (doc, atual) => {
+            const versao = doc.versao || 1;
+            const statusTxt = (doc.status || '').toLowerCase();
+            let label = `Versão ${versao}`;
+            if (atual) label += ' • atual';
+            if (statusTxt === 'assinado') label += ' (assinado)';
+            else if (statusTxt === 'pendente_assinatura' || statusTxt === 'enviado') label += ' (pendente)';
+            return label;
+          };
 
-          if (estaAssinado) {
+          let botoesTermoHtml = '';
+          if (docs.length > 1 && docAtual) {
+            const classePrincipal = estaAssinado ? 'btn-success' : 'btn-outline-secondary';
+            const rotuloPrincipal = estaAssinado ? 'Baixar Termo Assinado' : 'Baixar Termo Atual';
+            const hrefPrincipal = buildDownloadUrl(docAtual);
             botoesTermoHtml += `
-              <a class="btn btn-sm btn-success" href="${urlDownloadSegura}" target="_blank" rel="noopener">
-                <i class="bi bi-download"></i> Baixar Termo Assinado
+              <div class="btn-group">
+                <a class="btn btn-sm ${classePrincipal}" href="${hrefPrincipal}" target="_blank" rel="noopener">
+                  <i class="bi bi-filetype-pdf"></i> ${rotuloPrincipal}
+                </a>
+                <button type="button" class="btn btn-sm ${classePrincipal} dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+                  <span class="visually-hidden">Alternar lista de termos</span>
+                </button>
+                <ul class="dropdown-menu dropdown-menu-end">
+                  ${docs.map((doc) => {
+                    const href = buildDownloadUrl(doc);
+                    const ativo = doc.id === docAtual.id;
+                    const rotulo = formatStatusLabel(doc, ativo);
+                    const attrs = href ? `href="${href}" target="_blank" rel="noopener"` : 'href="#"';
+                    const disabled = href ? '' : ' disabled';
+                    return `<li><a class="dropdown-item${ativo ? ' active' : ''}${disabled}" ${attrs}>${rotulo}</a></li>`;
+                  }).join('')}
+                </ul>
+              </div>`;
+          } else if (docAtual) {
+            const classePrincipal = estaAssinado ? 'btn-success' : 'btn-outline-secondary';
+            const rotuloPrincipal = estaAssinado ? 'Baixar Termo Assinado' : 'Baixar Termo Atual';
+            const hrefPrincipal = buildDownloadUrl(docAtual);
+            botoesTermoHtml += `
+              <a class="btn btn-sm ${classePrincipal}" href="${hrefPrincipal}" target="_blank" rel="noopener">
+                <i class="bi bi-filetype-pdf"></i> ${rotuloPrincipal}
               </a>`;
-          } else if (foiEnviado) {
+          } else {
+            botoesTermoHtml += `
+              <button class="btn btn-sm btn-outline-secondary" data-baixar-termo="${eventoId}">
+                <i class="bi bi-filetype-pdf"></i> Baixar Termo
+              </button>`;
+          }
+
+          if (foiEnviado) {
             botoesTermoHtml += `
               <button class="btn btn-sm btn-primary" data-assinar-termo="${eventoId}">
                 <i class="bi bi-pen"></i> Assinar Termo
               </button>`;
           }
-          
+
           btns.innerHTML = botoesTermoHtml;
         }catch(e){ 
           console.warn('Falha ao atualizar UI do evento:', e); 

--- a/src/services/advertenciaPdfService.js
+++ b/src/services/advertenciaPdfService.js
@@ -141,9 +141,9 @@ async function gerarAdvertenciaPdfEIndexar({ advertenciaId = null, evento = {}, 
   const createdAt = new Date().toISOString();
   const publicUrl = `/documentos/${fileName}`;
   await dbRun(
-    `INSERT INTO documentos (tipo, token, evento_id, permissionario_id, pdf_url, pdf_public_url, status, created_at)
-     VALUES ('advertencia', ?, ?, ?, ?, ?, 'gerado', ?)
-     ON CONFLICT(evento_id, tipo) DO UPDATE SET
+    `INSERT INTO documentos (tipo, token, evento_id, permissionario_id, pdf_url, pdf_public_url, status, created_at, versao)
+     VALUES ('advertencia', ?, ?, ?, ?, ?, 'gerado', ?, 1)
+     ON CONFLICT(evento_id, tipo, versao) DO UPDATE SET
        token = excluded.token,
        pdf_url = excluded.pdf_url,
        pdf_public_url = excluded.pdf_public_url,


### PR DESCRIPTION
## Summary
- Corrige o envio do parâmetro `modo` nas telas administrativas de remarcação para concluir as solicitações de remarcação
- Gera nova versão do termo sempre que dados relevantes do evento forem alterados e persiste múltiplas versões de documentos
- Atualiza APIs e o portal do cliente para listar e baixar todas as versões do termo, com dropdown de seleção e suporte a versão no backend

## Testing
- `npm test` *(falha: dependência "express" ausente no ambiente de testes)*

------
https://chatgpt.com/codex/tasks/task_e_68e5205f4c3083338e9013af90a78699