### PR TITLE
Fix documentos schema to allow versioned terms

### DIFF
--- a/src/api/adminTermoEventosRoutes.js
+++ b/src/api/adminTermoEventosRoutes.js
@@ -82,7 +82,11 @@ async function ensureDocumentosSchema() {
   await add('signed_at','TEXT');
   await add('signer','TEXT');
   await add('created_at','TEXT');
-  await dbRun(`CREATE UNIQUE INDEX IF NOT EXISTS ux_documentos_evento_tipo ON documentos(evento_id, tipo)`);
+  await add('versao','INTEGER DEFAULT 1');
+  await dbRun(`UPDATE documentos SET versao = 1 WHERE versao IS NULL`);
+  await dbRun(`DROP INDEX IF EXISTS ux_documentos_evento_tipo`);
+  await dbRun(`DROP INDEX IF EXISTS idx_documentos_evento_tipo`);
+  await dbRun(`CREATE UNIQUE INDEX IF NOT EXISTS ux_documentos_evento_tipo_versao ON documentos(evento_id, tipo, versao)`);
 }
 
 /* ========= Resolve caminho do timbrado ========= */

--- a/src/services/advertenciaPdfService.js
+++ b/src/services/advertenciaPdfService.js
@@ -62,11 +62,15 @@ async function ensureDocumentosSchema() {
   await add('signed_at', 'TEXT');
   await add('signer', 'TEXT');
   await add('created_at', 'TEXT');
+  await add('versao', 'INTEGER DEFAULT 1');
 
+  await dbRun(`UPDATE documentos SET versao = 1 WHERE versao IS NULL`, [], 'doc/set-versao-default');
+  await dbRun(`DROP INDEX IF EXISTS ux_documentos_evento_tipo`, [], 'doc/drop-ux');
+  await dbRun(`DROP INDEX IF EXISTS idx_documentos_evento_tipo`, [], 'doc/drop-idx');
   await dbRun(
-    `CREATE UNIQUE INDEX IF NOT EXISTS ux_documentos_evento_tipo ON documentos(evento_id, tipo)`,
+    `CREATE UNIQUE INDEX IF NOT EXISTS ux_documentos_evento_tipo_versao ON documentos(evento_id, tipo, versao)`,
     [],
-    'doc/index-ux'
+    'doc/index-ux-versao'
   );
 }
 


### PR DESCRIPTION
## Summary
- ensure admin termo route upgrades the documentos schema with versao defaults and the new unique index on evento/tipo/versao
- align advertência PDF service with the same schema adjustments
- update termo export service to enforce versao defaults and recreate the unique index

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5283383948333964ff73cfa5d83ee